### PR TITLE
Add a longer explanation about the BUILD file dialect

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+unstable_features = true
 edition = "2018"

--- a/src/eval/interactive.rs
+++ b/src/eval/interactive.rs
@@ -30,7 +30,9 @@ use values::*;
 ///
 /// * path: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
+///   More information about the difference can be found in [the eval module's
+///   documentation](../index.html#build_file).
 /// * env: the environment to mutate during the evaluation
 pub fn eval(path: &str, content: &str, build: bool, env: &mut Environment) {
     let map = Arc::new(Mutex::new(CodeMap::new()));
@@ -53,7 +55,9 @@ pub fn eval(path: &str, content: &str, build: bool, env: &mut Environment) {
 /// # Arguments
 ///
 /// * path: the file to parse and evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
+///   More information about the difference can be found in [the eval module's
+///   documentation](../index.html#build_file).
 /// * env: the environment to mutate during the evaluation
 pub fn eval_file(path: &str, build: bool, env: &mut Environment) {
     let map = Arc::new(Mutex::new(CodeMap::new()));

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Evaluation environment, provide converters from Ast* element to value
+//! Evaluation environment, provide converters from Ast* element to value.
+//!
+//! # <a name="build_file"></a>Starlark and BUILD dialect
+//! 
+//! All evaluation function can evaluate the full Starlark language (i.e. Bazel's
+//! .bzl files) or the BUILD file dialect (i.e. used to interpret Bazel's BUILD file).
+//! The BUILD dialect does not allow `def` statements.
 use codemap::{CodeMap, Span, Spanned};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use environment::Environment;
@@ -826,7 +832,9 @@ pub fn eval_def(
 /// * map: the codemap object used for diagnostics
 /// * filename: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate, for diagnostics
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
+///   More information about the difference can be found in [this module's
+///   documentation](index.html#build_file).
 /// * lexer: the custom lexer to use
 /// * env: the environment to mutate during the evaluation
 /// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
@@ -853,7 +861,9 @@ fn eval_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>, T3: FileLoa
 /// * map: the codemap object used for diagnostics
 /// * path: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
+///   More information about the difference can be found in [this module's
+///   documentation](index.html#build_file).
 /// * env: the environment to mutate during the evaluation
 /// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
 pub fn eval<T: FileLoader + 'static>(
@@ -877,7 +887,9 @@ pub fn eval<T: FileLoader + 'static>(
 ///
 /// * map: the codemap object used for diagnostics
 /// * path: the file to parse and evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
+///   More information about the difference can be found in [this module's
+///   documentation](index.html#build_file).
 /// * env: the environment to mutate during the evaluation
 /// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
 pub fn eval_file<T: FileLoader + 'static>(

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -15,7 +15,7 @@
 //! Evaluation environment, provide converters from Ast* element to value.
 //!
 //! # <a name="build_file"></a>Starlark and BUILD dialect
-//! 
+//!
 //! All evaluation function can evaluate the full Starlark language (i.e. Bazel's
 //! .bzl files) or the BUILD file dialect (i.e. used to interpret Bazel's BUILD file).
 //! The BUILD dialect does not allow `def` statements.
@@ -34,7 +34,7 @@ use values::function::FunctionParameter;
 use values::*;
 
 macro_rules! eval_vector {
-    ($v: expr, $ctx: expr) => {{
+    ($v:expr, $ctx:expr) => {{
         let mut r = Vec::new();
         for s in $v.iter() {
             r.push(s.eval($ctx)?)
@@ -78,13 +78,13 @@ pub enum EvalException {
 type EvalResult = Result<Value, EvalException>;
 
 macro_rules! t {
-    ($v: expr, span $el: expr) => {{
+    ($v:expr,span $el:expr) => {{
         match $v {
             Err(e) => Err(EvalException::DiagnosedError(e.to_diagnostic($el))),
             Ok(v) => Ok(v),
         }
     }};
-    ($v: expr, $el: expr) => {{
+    ($v:expr, $el:expr) => {{
         match $v {
             Err(e) => Err(EvalException::DiagnosedError(e.to_diagnostic($el.span))),
             Ok(v) => Ok(v),
@@ -459,7 +459,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstExpr {
                         ),
                     ));
                     t!(
-                        e.eval(context)?.call(
+                        e.eval(context,)?.call(
                             &new_stack,
                             context.env.clone(),
                             npos,

--- a/src/eval/testutil.rs
+++ b/src/eval/testutil.rs
@@ -42,23 +42,23 @@ pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
 
 /// A simple macro to execute a Starlark snippet and fails if the last statement is false.
 macro_rules! starlark_ok_fn {
-    ($fn: path, $t:expr) => {
+    ($fn:path, $t:expr) => {
         assert!($fn($t).unwrap());
     };
-    ($fn: path, $t1:expr, $t2:expr) => {
+    ($fn:path, $t1:expr, $t2:expr) => {
         assert!($fn(&format!("{}{}", $t1, $t2)).unwrap());
     };
 }
 
 /// Test that the execution of a starlark code raise an error
 macro_rules! starlark_fail_fn {
-    ($fn: path, $t:expr) => {
+    ($fn:path, $t:expr) => {
         assert!($fn($t).is_err());
     };
-    ($fn: path, $t:expr, $c:expr) => {
+    ($fn:path, $t:expr, $c:expr) => {
         assert_eq!($c, $fn($t).err().unwrap().code.unwrap());
     };
-    ($fn: path, $t1:expr, $t2: expr, $c:expr) => {
+    ($fn:path, $t1:expr, $t2:expr, $c:expr) => {
         assert_eq!(
             $c,
             $fn(&format!("{}{}", $t1, $t2)).err().unwrap().code.unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,11 @@ fn main() {
     opts.optflag(
         "b",
         "build_file",
-        "Parse the build file format instead of full Starlark.",
+        concat!(
+            "Parse the build file format instead of full Starlark. See https://docs.rs/starlark/",
+            env!("CARGO_PKG_VERSION"),
+            "/starlark/eval/index.html#build_file"
+        ),
     );
     opts.optflag("h", "help", "Show the usage of this program.");
     opts.optflag("r", "repl", "Run a REPL after files have been parsed.");

--- a/src/stdlib/macros.rs
+++ b/src/stdlib/macros.rs
@@ -375,7 +375,7 @@ macro_rules! starlark_module {
 /// * $label is a a short description of the error to be put next to the code.
 #[macro_export]
 macro_rules! starlark_err {
-    ($code:expr, $message: expr, $label: expr) => {
+    ($code:expr, $message:expr, $label:expr) => {
         return Err(RuntimeError {
             code: $code,
             message: $message,
@@ -426,7 +426,7 @@ macro_rules! check_type {
 /// * $end: the variable denoting the end index (optional)
 #[macro_export]
 macro_rules! convert_indices {
-    ($this: ident, $start: ident, $end: ident) => {
+    ($this:ident, $start:ident, $end:ident) => {
         let len = $this.length()?;
         let $end = if $end.get_type() == "NoneType" {
             len
@@ -459,7 +459,7 @@ macro_rules! convert_indices {
             }
         };
     };
-    ($this: ident, $start: ident) => {
+    ($this:ident, $start:ident) => {
         let len = $this.length()?;
         let $start = if $start.get_type() == "NoneType" {
             0

--- a/src/stdlib/string.rs
+++ b/src/stdlib/string.rs
@@ -1450,17 +1450,15 @@ mod tests {
             .unwrap(),
             "x"
         );
-        assert!(
-            format_capture(
-                "{1",
-                &mut it,
-                &mut captured_by_index,
-                &mut captured_by_order,
-                &args,
-                &kwargs,
-            )
-            .is_err()
-        );
+        assert!(format_capture(
+            "{1",
+            &mut it,
+            &mut captured_by_index,
+            &mut captured_by_order,
+            &args,
+            &kwargs,
+        )
+        .is_err());
         captured_by_order = false;
         it = args.into_iter().unwrap();
         assert_eq!(
@@ -1475,17 +1473,15 @@ mod tests {
             .unwrap(),
             "2"
         );
-        assert!(
-            format_capture(
-                "{",
-                &mut it,
-                &mut captured_by_index,
-                &mut captured_by_order,
-                &args,
-                &kwargs,
-            )
-            .is_err()
-        );
+        assert!(format_capture(
+            "{",
+            &mut it,
+            &mut captured_by_index,
+            &mut captured_by_order,
+            &args,
+            &kwargs,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -43,14 +43,14 @@ pub trait ToAst<T> {
 }
 
 macro_rules! to_ast_trait {
-    ($t1: ty, $t2: ty, $t3: ident) => {
+    ($t1:ty, $t2:ty, $t3:ident) => {
         impl ToAst<$t2> for $t1 {
             fn to_ast(self, span: Span) -> $t2 {
                 $t3::new(Spanned { span, node: self })
             }
         }
     };
-    ($t1: ty, $t2: ty) => {
+    ($t1:ty, $t2:ty) => {
         impl ToAst<$t2> for $t1 {
             fn to_ast(self, span: Span) -> $t2 {
                 Spanned { span, node: self }
@@ -247,7 +247,7 @@ pub enum Statement {
 to_ast_trait!(Statement, AstStatement, Box);
 
 macro_rules! test_param_name {
-    ($argset:ident, $n: ident, $arg: ident) => {{
+    ($argset:ident, $n:ident, $arg:ident) => {{
         if $argset.contains(&$n.node) {
             return Err(lalrpop_util::ParseError::User {
                 error: lexer::LexerError::WrappedError {

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -222,7 +222,8 @@ pub trait LexerIntoIter<T: Iterator<Item = LexerItem>>:
 }
 impl<T1: Iterator<Item = LexerItem>, T2: IntoIterator<Item = LexerItem, IntoIter = T1>>
     LexerIntoIter<T1> for T2
-{}
+{
+}
 
 /// An iterator over a string slice that convert it to a list of token, i.e. the lexer.
 #[derive(Debug)]

--- a/src/syntax/testutil.rs
+++ b/src/syntax/testutil.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 macro_rules! assert_diagnostics {
-    ($e: expr, $m: expr) => {
+    ($e:expr, $m:expr) => {
         if !$e.is_empty() {
             let nb_errors = $e.len();
             let locked = $m.lock();

--- a/src/values/list.rs
+++ b/src/values/list.rs
@@ -88,7 +88,7 @@ impl TypedValue for List {
     fn to_str(&self) -> String {
         format!(
             "[{}]",
-            self.content.iter().map(|x| x.to_repr()).enumerate().fold(
+            self.content.iter().map(|x| x.to_repr(),).enumerate().fold(
                 "".to_string(),
                 |accum, s| if s.0 == 0 {
                     accum + &s.1

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -338,11 +338,7 @@ impl PartialEq for ValueError {
             (
                 &ValueError::OperationNotSupported { op: ref x, .. },
                 &ValueError::OperationNotSupported { op: ref y, .. },
-            )
-                if x == y =>
-            {
-                true
-            }
+            ) if x == y => true,
             (&ValueError::IndexOutOfBound(x), &ValueError::IndexOutOfBound(y)) if x == y => true,
             _ => false,
         }
@@ -1591,10 +1587,10 @@ impl<'a> From<&'a str> for Value {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! int_op {
-    ($v1:tt . $op:ident ( $v2:expr ) ) => {
+    ($v1:tt. $op:ident($v2:expr)) => {
         $v1.$op(Value::new($v2)).unwrap().to_int().unwrap()
     };
-    ($v1:tt . $op:ident ( ) ) => {
+    ($v1:tt. $op:ident()) => {
         $v1.$op().unwrap().to_int().unwrap()
     };
 }

--- a/src/values/string.rs
+++ b/src/values/string.rs
@@ -396,26 +396,20 @@ mod tests {
     #[test]
     fn test_string_is_in() {
         // "a" in "abc" == True
-        assert!(
-            Value::from("abc")
-                .is_in(&Value::from("a"))
-                .unwrap()
-                .to_bool()
-        );
+        assert!(Value::from("abc")
+            .is_in(&Value::from("a"))
+            .unwrap()
+            .to_bool());
         // "b" in "abc" == True
-        assert!(
-            Value::from("abc")
-                .is_in(&Value::from("b"))
-                .unwrap()
-                .to_bool()
-        );
+        assert!(Value::from("abc")
+            .is_in(&Value::from("b"))
+            .unwrap()
+            .to_bool());
         // "z" in "abc" == False
-        assert!(
-            !Value::from("abc")
-                .is_in(&Value::from("z"))
-                .unwrap()
-                .to_bool()
-        );
+        assert!(!Value::from("abc")
+            .is_in(&Value::from("z"))
+            .unwrap()
+            .to_bool());
     }
 
     #[test]

--- a/src/values/tuple.rs
+++ b/src/values/tuple.rs
@@ -269,7 +269,7 @@ impl TypedValue for Tuple {
     fn to_str(&self) -> String {
         format!(
             "({}{})",
-            self.content.iter().map(|x| x.to_repr()).enumerate().fold(
+            self.content.iter().map(|x| x.to_repr(),).enumerate().fold(
                 "".to_string(),
                 |accum, s| if s.0 == 0 {
                     accum + &s.1


### PR DESCRIPTION
This dialect is activated when using the `build_file` option of the `eval`
functions or the `--build_file` command line argument of the REPL.

Fixes #18.

/cc @luser: can you take a look and tell me if the explanation are good now?