### PR TITLE
Disallow mutation of iterable during iteration

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -725,7 +725,10 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                     match st.eval(context) {
                         Err(EvalException::Break(..)) => break,
                         Err(EvalException::Continue(..)) => (),
-                        Err(x) => { result = Err(x); break },
+                        Err(x) => {
+                            result = Err(x);
+                            break;
+                        }
                         _ => (),
                     }
                 }

--- a/src/values/tuple.rs
+++ b/src/values/tuple.rs
@@ -429,6 +429,7 @@ impl TypedValue for Tuple {
         }
     }
 
+    not_supported!(freeze_for_iteration);
     not_supported!(set_indexable);
     not_supported!(attr, function);
     not_supported!(plus, minus, sub, div, pipe, percent, floor_div);

--- a/tests/go-testcases/dict.sky
+++ b/tests/go-testcases/dict.sky
@@ -136,28 +136,28 @@ x16 = kwargs(**x15)
 assert_eq(x16, x15)
 x15["two"] = 2 # mutate
 assert_(x16 != x15)
-
+---
 # iterator invalidation
 def iterator1():
   dict = {1:1, 2:1}
   for k in dict:
     dict[2*k] = dict[k]
-iterator1()
-
+iterator1()   ### Cannot mutate an iterable while iterating
+---
 def iterator2():
   dict = {1:1, 2:1}
   for k in dict:
     dict.pop(k)
-iterator2()
-
+iterator2()   ### Cannot mutate an iterable while iterating
+---
 def f(d):
   d[3] = 3
 
 def iterator3():
   dict = {1:1, 2:1}
   _ = [f(dict) for x in dict]
-iterator3()
-
+iterator3()   ### Cannot mutate an iterable while iterating
+---
 # This assignment is not a modification-during-iteration:
 # the sequence x should be completely iterated before
 # the assignment occurs.

--- a/tests/go-testcases/list.sky
+++ b/tests/go-testcases/list.sky
@@ -221,10 +221,12 @@ def iterator1():
   for x in list:
     list[x] = 2 * x
   return list
-# This is allowed in the go implementation but following the specification
+# Updating elements of a list while iterating is allowed in the go
+# implementation but following the specification
 # (https://github.com/bazelbuild/starlark/blob/815aed90b552fa70adca4dc18d73082fae83b538/design.md#no-mutation-during-iteration)
-# they are not deep content so we do not allow them.
-assert_eq(iterator1(), [0, 2, 4])   ### Cannot mutate an iterable while iterating
+# a immutable list element like a number does not match the definition of
+# "deep content" so it is disallowed in our implementation.
+iterator1()   ### Cannot mutate an iterable while iterating
 ---
 def iterator2():
   list = [0, 1, 2]

--- a/tests/go-testcases/list.sky
+++ b/tests/go-testcases/list.sky
@@ -214,36 +214,39 @@ assert_eq(bananas[4::-2], list("nnb".split_codepoints()))
 assert_eq(bananas[99::-2], list("snnb".split_codepoints()))
 assert_eq(bananas[100::-2], list("snnb".split_codepoints()))
 # TODO(adonovan): many more tests
-
+---
 # iterator invalidation
 def iterator1():
   list = [0, 1, 2]
   for x in list:
     list[x] = 2 * x
   return list
-assert_eq(iterator1(), [0, 2, 4]) # element updates are allowed
-
+# This is allowed in the go implementation but following the specification
+# (https://github.com/bazelbuild/starlark/blob/815aed90b552fa70adca4dc18d73082fae83b538/design.md#no-mutation-during-iteration)
+# they are not deep content so we do not allow them.
+assert_eq(iterator1(), [0, 2, 4])   ### Cannot mutate an iterable while iterating
+---
 def iterator2():
   list = [0, 1, 2]
   for x in list:
     list.remove(x)
-iterator2()
-
+iterator2()   ### Cannot mutate an iterable while iterating
+---
 def iterator3():
   list = [0, 1, 2]
   for x in list:
     list.append(3)
-iterator3()
-
+iterator3()   ### Cannot mutate an iterable while iterating
+---
 def iterator4():
   list = [0, 1, 2]
   for x in list:
     list.extend([3, 4])
-iterator4()
-
+iterator4()   ### Cannot mutate an iterable while iterating
+---
 def fff(x):
   x.append(4)
 def iterator5():
   list = [1, 2, 3]
   _ = [fff(list) for x in list]
-iterator5()
+iterator5()   ### Cannot mutate an iterable while iterating

--- a/tests/rust-testcases/mutation_during_iteration.sky
+++ b/tests/rust-testcases/mutation_during_iteration.sky
@@ -1,0 +1,24 @@
+# Test for disallowing mutation during iteration.
+# https://github.com/bazelbuild/starlark/blob/815aed90b552fa70adca4dc18d73082fae83b538/design.md#no-mutation-during-iteration
+a = [1, 2, 3]
+def fun():
+  for x in a:
+    a.append(1)
+
+fun()  ### Cannot mutate an iterable while iterating
+---
+def increment_values(dict):
+  for k in dict:
+    dict[k] += 1
+
+dict = {"one": 1, "two": 2}
+increment_values(dict)   ### Cannot mutate an iterable while iterating
+---
+# modifying deep content is allowed
+def modify_deep_content():
+  list = [[0], [1], [2]]
+  for x in list:
+    list[x[0]][0] = 2 * x[0]
+  return list
+assert_eq(modify_deep_content(), [[0], [2], [4]])
+---


### PR DESCRIPTION
This is not allowed in the official Starlark spec so cut. Contrary
to the Go implementation, this one does not allow to assign a new
value to a list as this is not seen as a modification of a deep element.

https://github.com/bazelbuild/starlark/blob/815aed90b552fa70adca4dc18d73082fae83b538/design.md#no-mutation-during-iteration

Fixes #3.

/cc @adonovan

Also /cc @luser and @stuhood if one of you want to review. I would also be glad to welcome one of you to join as maintainers if you are interested (so the code can actually be correctly reviewed now).