### PR TITLE
Compare can be implemented for custom TypedValues

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -47,7 +47,6 @@ use starlark::environment::Environment;
 use starlark::eval::eval_lexer;
 use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
-use starlark::values::TypedValue;
 use std::sync::{Arc, Mutex};
 
 fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -18,7 +18,6 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Emitter};
 use environment::Environment;
 use std::sync::{Arc, Mutex};
-use values::*;
 
 /// Evaluate a string content, mutate the environment accordingly  and print
 /// the value of the last statement (if not `None`) or the error diagnostic.

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -350,7 +350,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for TransformedExpr<T> {
         match self {
             &TransformedExpr::Tuple(ref v, ..) => {
                 let r = eval_vector!(v, context);
-                Ok(tuple::Tuple::new(r.as_slice()))
+                Ok(Value::new(tuple::Tuple::new(r.as_slice())))
             }
             &TransformedExpr::List(ref v, ..) => {
                 let r = eval_vector!(v, context);
@@ -412,7 +412,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstExpr {
         match self.node {
             Expr::Tuple(ref v) => {
                 let r = eval_vector!(v, context);
-                Ok(tuple::Tuple::new(r.as_slice()))
+                Ok(Value::new(tuple::Tuple::new(r.as_slice())))
             }
             Expr::Dot(ref e, ref s) => {
                 let left = e.eval(context)?;

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -18,7 +18,6 @@ use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use environment;
 use eval;
 use std::sync;
-use values::TypedValue;
 
 /// Execute a starlark snippet with an empty environment.
 pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -263,14 +263,14 @@ starlark_module! {global =>
     /// ```
     dict.setdefault(this, #key, #default = None) {
         key.get_hash()?; // Ensure the key is hashable
-        let cloned_this = this.clone();
+        let cloned_default = default.clone_for_container_value(&this);
         dict::Dictionary::mutate(
             &mut this,
             &|x: &mut LinkedHashMap<Value, Value>| -> ValueResult {
                 if let Some(r) = x.get(&key) {
                     return Ok(r.clone())
                 }
-                x.insert(key.clone(), default.clone_for_container(&cloned_this)?);
+                x.insert(key.clone(), cloned_default.clone()?);
                 Ok(default.clone())
             }
         )

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -52,9 +52,9 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     list.append(this, #el) {
-        let cloned_this = this.clone();
+        let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &|x| {
-            x.push(el.clone_for_container(&cloned_this)?);
+            x.push(el.clone()?);
             ok!(None)
         })
     }
@@ -109,9 +109,9 @@ starlark_module! {global =>
     /// ```
     list.extend(this, #other) {
         let this_cloned = this.clone();
+        let other_cloned: Result<Vec<_>, _>  = other.into_iter()?.map(|v| v.clone_for_container_value(&this_cloned)).collect();
         list::List::mutate(&this, &|x| {
-            let other : Result<Vec<_>, _> = other.into_iter()?.map(|v| v.clone_for_container(&this_cloned)).collect();
-            x.extend(other?);
+            x.extend(other_cloned.clone()?);
             ok!(None)
         })
     }
@@ -186,9 +186,9 @@ starlark_module! {global =>
     /// ```
     list.insert(this, #index, #el) {
         convert_indices!(this, index);
-        let cloned_this = this.clone();
-        list::List::mutate(&this, &|x| {
-            x.insert(index, el.clone_for_container(&cloned_this)?);
+        let el = el.clone_for_container_value(&this);
+        list::List::mutate(&this, &move |x| {
+            x.insert(index, el.clone()?);
             ok!(None)
         })
     }

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -739,7 +739,7 @@ starlark_module! {global_functions =>
                 idx += step;
             }
         }
-        Ok(tuple::Tuple::new(r.as_slice()))
+        Ok(Value::new(tuple::Tuple::new(r.as_slice())))
     }
 
     /// [repr](
@@ -971,7 +971,6 @@ pub mod tests {
     use codemap_diagnostic::Diagnostic;
     use eval::simple::eval;
     use std::sync;
-    use values::TypedValue;
 
     pub fn starlark_default_fail(snippet: &str) -> Result<bool, Diagnostic> {
         let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -37,8 +37,7 @@ impl Dictionary {
         if v.get_type() != "dict" {
             Err(ValueError::IncorrectParameterType)
         } else {
-            let mut v = v.clone();
-            v.downcast_apply(|x: &mut Dictionary| -> ValueResult { f(&x.content) })
+            v.downcast_apply(|x: &Dictionary| -> ValueResult { f(&x.content) })
         }
     }
 
@@ -50,7 +49,7 @@ impl Dictionary {
             Err(ValueError::IncorrectParameterType)
         } else {
             let mut v = v.clone();
-            v.downcast_apply(|x: &mut Dictionary| -> ValueResult {
+            v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
                 x.mutability.test()?;
                 f(&mut x.content)
             })

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -126,7 +126,7 @@ impl TypedValue for Dictionary {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "dict" {
             let mut v1: Vec<Value> = self.into_iter()?.collect();
             let mut v2: Vec<Value> = other.into_iter()?.collect();

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -252,7 +252,7 @@ impl TypedValue for Function {
     }
     not_supported!(get_hash);
 
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "function" {
             Ok(self.to_repr().cmp(&other.to_repr()))
         } else {
@@ -375,8 +375,8 @@ impl TypedValue for WrappedMethod {
     fn to_bool(&self) -> bool {
         true
     }
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
-        self.method.compare(other, recursion)
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
+        self.method.compare_underlying(other, recursion)
     }
 
     fn call(

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -49,7 +49,7 @@ impl List {
             Err(ValueError::IncorrectParameterType)
         } else {
             let mut v = v.clone();
-            v.downcast_apply(|x: &mut List| -> ValueResult {
+            v.downcast_apply_mut(|x: &mut List| -> ValueResult {
                 x.mutability.test()?;
                 f(&mut x.content)
             })

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -107,7 +107,7 @@ impl TypedValue for List {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "list" {
             let mut iter1 = self.into_iter()?;
             let mut iter2 = other.into_iter()?;

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1098,7 +1098,11 @@ impl Value {
         self.compare_underlying(other.0.borrow().deref(), recursion)
     }
 
-    pub fn compare_underlying(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
+    pub fn compare_underlying(
+        &self,
+        other: &TypedValue,
+        recursion: u32,
+    ) -> Result<Ordering, ValueError> {
         let borrowed = self.0.borrow();
         if recursion > MAX_RECURSION {
             return Err(ValueError::TooManyRecursionLevel);
@@ -1613,8 +1617,8 @@ impl TypedValue {
 impl Value {
     /// A convenient wrapper around any_apply to actually operate on the underlying type
     pub fn downcast_apply<T: Any, F, Return>(&self, f: F) -> Return
-        where
-            F: Fn(&T) -> Return,
+    where
+        F: Fn(&T) -> Return,
     {
         self.any_apply(&move |x| f(x.downcast_ref().unwrap()))
     }
@@ -1813,16 +1817,22 @@ mod tests {
             fn get_type(&self) -> &'static str {
                 "WrappedNumber"
             }
-            fn to_bool(&self) -> bool { false }
+            fn to_bool(&self) -> bool {
+                false
+            }
             fn get_hash(&self) -> Result<u64, ValueError> {
                 Ok(self.0)
             }
-            fn compare<'a>(&'a self, other: &TypedValue, _recursion: u32) -> Result<std::cmp::Ordering, ValueError> {
+            fn compare<'a>(
+                &'a self,
+                other: &TypedValue,
+                _recursion: u32,
+            ) -> Result<std::cmp::Ordering, ValueError> {
                 match other.get_type() {
                     "WrappedNumber" => {
                         let other = other.as_any().downcast_ref::<Self>().unwrap();
                         Ok(std::cmp::Ord::cmp(self, other))
-                    },
+                    }
                     _ => default_compare(self, other),
                 }
             }
@@ -1836,7 +1846,7 @@ mod tests {
         let two = Value::new(WrappedNumber(2));
         let not_wrapped_number: Value = 1.into();
 
-        use ::std::cmp::Ordering::*;
+        use std::cmp::Ordering::*;
 
         assert_eq!(one.compare(&one, 0), Ok(Equal));
         assert_eq!(one.compare(&another_one, 0), Ok(Equal));

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1045,12 +1045,12 @@ macro_rules! define_iterable_mutability {
 }
 
 impl Value {
-    pub fn any_apply(&self, f: &Fn(&Any) -> ValueResult) -> ValueResult {
+    pub fn any_apply<Return>(&self, f: &Fn(&Any) -> Return) -> Return {
         let borrowed = self.0.borrow();
         f(borrowed.as_any())
     }
 
-    pub fn any_apply_mut(&mut self, f: &Fn(&mut Any) -> ValueResult) -> ValueResult {
+    pub fn any_apply_mut<Return>(&mut self, f: &Fn(&mut Any) -> Return) -> Return {
         let mut borrowed = self.0.borrow_mut();
         f(borrowed.as_any_mut())
     }
@@ -1607,17 +1607,17 @@ impl TypedValue {
 
 impl Value {
     /// A convenient wrapper around any_apply to actually operate on the underlying type
-    pub fn downcast_apply<T: Any, F>(&self, f: F) -> ValueResult
+    pub fn downcast_apply<T: Any, F, Return>(&self, f: F) -> Return
         where
-            F: Fn(&T) -> ValueResult,
+            F: Fn(&T) -> Return,
     {
         self.any_apply(&move |x| f(x.downcast_ref().unwrap()))
     }
 
     /// A convenient wrapper around any_apply_mut to actually operate on the underlying type
-    pub fn downcast_apply_mut<T: Any, F>(&mut self, f: F) -> ValueResult
+    pub fn downcast_apply_mut<T: Any, F, Return>(&mut self, f: F) -> Return
     where
-        F: Fn(&mut T) -> ValueResult,
+        F: Fn(&mut T) -> Return,
     {
         self.any_apply_mut(&move |x| f(x.downcast_mut().unwrap()))
     }

--- a/starlark/src/values/string.rs
+++ b/starlark/src/values/string.rs
@@ -49,7 +49,7 @@ impl TypedValue for String {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "string" {
             Ok(self.cmp(&other.to_str()))
         } else {

--- a/starlark/src/values/string.rs
+++ b/starlark/src/values/string.rs
@@ -325,7 +325,6 @@ impl TypedValue for String {
 #[cfg(test)]
 mod tests {
     use super::super::Value;
-    use super::*;
     use std::collections::HashMap;
 
     #[test]

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -56,14 +56,14 @@ pub fn slice_vector(start: i64, stop: i64, stride: i64, content: &Vec<Value>) ->
 }
 
 impl Tuple {
-    pub fn new(values: &[Value]) -> Value {
+    pub fn new(values: &[Value]) -> Tuple {
         let mut result = Tuple {
             content: Vec::new(),
         };
         for x in values.iter() {
             result.content.push(x.clone());
         }
-        Value::new(result)
+        result
     }
 }
 
@@ -354,12 +354,12 @@ impl TypedValue for Tuple {
     ) -> ValueResult {
         let (start, stop, stride) =
             Value::convert_slice_indices(self.length()?, start, stop, stride)?;
-        Ok(Tuple::new(&slice_vector(
+        Ok(Value::new(Tuple::new(&slice_vector(
             start,
             stop,
             stride,
             &self.content,
-        )))
+        ))))
     }
 
     fn into_iter<'a>(&'a self) -> Result<Box<Iterator<Item = Value> + 'a>, ValueError> {

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -300,7 +300,7 @@ impl TypedValue for Tuple {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "tuple" {
             let mut iter1 = self.into_iter()?;
             let mut iter2 = other.into_iter()?;


### PR DESCRIPTION
Before this PR, `compare` could only be implemented on a `TypedValue` if the `TypedValue` trait happened to expose its underlying representation in a useful way. e.g. `string` could implement `compare` using the `to_str` function.

For custom types implemented outside of this crate, this means that `compare` cannot be meaningfully implemented (other than maybe by parsing out the `to_str` implementation, or similar).

This series of commits (which are useful to review separately) makes it possible to actually implement `compare` for custom types, and adds a test showing that this works.