### PR TITLE
[refactor] Introduce a dialect domain concept.

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -46,6 +46,7 @@ use linefeed::{Interface, ReadResult};
 use starlark::environment::Environment;
 use starlark::eval::eval_lexer;
 use starlark::eval::simple::SimpleFileLoader;
+use starlark::syntax::dialect::Dialect;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
 use std::sync::{Arc, Mutex};
 
@@ -54,14 +55,14 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     filename: &str,
     content: &str,
     lexer: T2,
-    build: bool,
+    dialect: Dialect,
     env: &mut Environment,
 ) {
     match eval_lexer(
         &map,
         filename,
         content,
-        build,
+        dialect,
         lexer,
         env,
         SimpleFileLoader::new(&map.clone()),
@@ -83,8 +84,8 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
 /// # Parameters:
 ///
 /// * global_environment: the parent enviroment for the loop.
-/// * build_file: set to true to run in BUILD mode, false to run in full Starlark,
-pub fn repl(global_environment: &Environment, build_file: bool) {
+/// * dialect: Starlark language dialect.
+pub fn repl(global_environment: &Environment, dialect: Dialect) {
     let map = Arc::new(Mutex::new(codemap::CodeMap::new()));
     let reader = Interface::new("Starlark").unwrap();
     let mut env = global_environment.child("repl");
@@ -116,7 +117,7 @@ pub fn repl(global_environment: &Environment, build_file: bool) {
                 &format!("<{}>", n),
                 &content,
                 lexer,
-                build_file,
+                dialect,
                 &mut env,
             )
         }

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -21,6 +21,7 @@ extern crate starlark_repl;
 use getopts::Options;
 use starlark::eval::interactive::eval_file;
 use starlark::stdlib::global_environment;
+use starlark::syntax::dialect::Dialect;
 use starlark_repl::repl;
 use std::env;
 
@@ -70,12 +71,17 @@ fn main() {
                 let opt_repl = matches.opt_present("r");
                 let global = global_environment();
                 global.freeze();
+                let dialect = if build_file {
+                    Dialect::Build
+                } else {
+                    Dialect::Bzl
+                };
                 for i in matches.free.into_iter() {
-                    eval_file(&i, build_file, &mut global.child(&i));
+                    eval_file(&i, dialect, &mut global.child(&i));
                 }
                 if opt_repl {
                     println!("Welcome to Starlark REPL, press Ctrl+D to exit.");
-                    repl(&global, build_file);
+                    repl(&global, dialect);
                 }
             }
         }

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -18,6 +18,7 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Emitter};
 use environment::Environment;
 use std::sync::{Arc, Mutex};
+use syntax::dialect::Dialect;
 
 /// Evaluate a string content, mutate the environment accordingly  and print
 /// the value of the last statement (if not `None`) or the error diagnostic.
@@ -29,13 +30,11 @@ use std::sync::{Arc, Mutex};
 ///
 /// * path: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
-///   More information about the difference can be found in [the eval module's
-///   documentation](../index.html#build_file).
+/// * dialect: starlark language dialect
 /// * env: the environment to mutate during the evaluation
-pub fn eval(path: &str, content: &str, build: bool, env: &mut Environment) {
+pub fn eval(path: &str, content: &str, dialect: Dialect, env: &mut Environment) {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    match super::simple::eval(&map, path, content, build, env) {
+    match super::simple::eval(&map, path, content, dialect, env) {
         Ok(v) => {
             if v.get_type() != "NoneType" {
                 println!("{}", v.to_repr())
@@ -54,13 +53,11 @@ pub fn eval(path: &str, content: &str, build: bool, env: &mut Environment) {
 /// # Arguments
 ///
 /// * path: the file to parse and evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
-///   More information about the difference can be found in [the eval module's
-///   documentation](../index.html#build_file).
+/// * dialect: Starlark language dialect
 /// * env: the environment to mutate during the evaluation
-pub fn eval_file(path: &str, build: bool, env: &mut Environment) {
+pub fn eval_file(path: &str, dialect: Dialect, env: &mut Environment) {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    match super::simple::eval_file(&map, path, build, env) {
+    match super::simple::eval_file(&map, path, dialect, env) {
         Ok(v) => {
             if v.get_type() != "NoneType" {
                 println!("{}", v.to_repr())

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -27,6 +27,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use syntax::ast::*;
+use syntax::dialect::Dialect;
 use syntax::errors::SyntaxError;
 use syntax::lexer::{LexerIntoIter, LexerItem};
 use syntax::parser::{parse, parse_file, parse_lexer};
@@ -840,9 +841,7 @@ pub fn eval_def(
 /// * map: the codemap object used for diagnostics
 /// * filename: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate, for diagnostics
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file.
-///   More information about the difference can be found in [this module's
-///   documentation](index.html#build_file).
+/// * dialect: starlark syntax dialect
 /// * lexer: the custom lexer to use
 /// * env: the environment to mutate during the evaluation
 /// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
@@ -854,13 +853,13 @@ pub fn eval_lexer<
     map: &Arc<Mutex<CodeMap>>,
     filename: &str,
     content: &str,
-    build: bool,
+    dialect: Dialect,
     lexer: T2,
     env: &mut Environment,
     file_loader: T3,
 ) -> Result<Value, Diagnostic> {
     let mut context = EvaluationContext::new(env.clone(), file_loader, map.clone());
-    match parse_lexer(map, filename, content, build, lexer)?.eval(&mut context) {
+    match parse_lexer(map, filename, content, dialect, lexer)?.eval(&mut context) {
         Ok(v) => Ok(v),
         Err(p) => Err(p.into()),
     }
@@ -882,7 +881,7 @@ pub fn eval<T: FileLoader + 'static>(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
     content: &str,
-    build: bool,
+    build: Dialect,
     env: &mut Environment,
     file_loader: T,
 ) -> Result<Value, Diagnostic> {
@@ -907,7 +906,7 @@ pub fn eval<T: FileLoader + 'static>(
 pub fn eval_file<T: FileLoader + 'static>(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
-    build: bool,
+    build: Dialect,
     env: &mut Environment,
     file_loader: T,
 ) -> Result<Value, Diagnostic> {

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! Define simpler version of the evaluation function
+use super::Dialect;
 use super::{EvalException, FileLoader};
 use codemap::CodeMap;
 use codemap_diagnostic::Diagnostic;
@@ -60,7 +61,8 @@ impl FileLoader for SimpleFileLoader {
             Some(ref e) => e.child(path),
             None => Environment::new(path),
         };
-        if let Err(d) = super::eval_file(&self.codemap, path, false, &mut env, self.clone()) {
+        if let Err(d) = super::eval_file(&self.codemap, path, Dialect::Bzl, &mut env, self.clone())
+        {
             return Err(EvalException::DiagnosedError(d));
         }
         env.freeze();
@@ -82,16 +84,16 @@ impl FileLoader for SimpleFileLoader {
 /// * map: the codemap object used for diagnostics
 /// * path: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate
-/// * build: set to true if you want to evaluate a BUILD file or false to evaluate a .bzl file
+/// * dialect: Starlark language dialect
 /// * env: the environment to mutate during the evaluation
 pub fn eval(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
     content: &str,
-    build: bool,
+    dialect: Dialect,
     env: &mut Environment,
 ) -> Result<Value, Diagnostic> {
-    super::eval(map, path, content, build, env, SimpleFileLoader::new(map))
+    super::eval(map, path, content, dialect, env, SimpleFileLoader::new(map))
 }
 
 /// Evaluate a file, mutate the environment accordingly and return the evaluated value.
@@ -108,7 +110,7 @@ pub fn eval(
 pub fn eval_file(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
-    build: bool,
+    build: Dialect,
     env: &mut Environment,
 ) -> Result<Value, Diagnostic> {
     super::eval_file(map, path, build, env, SimpleFileLoader::new(map))

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -18,12 +18,13 @@ use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use environment;
 use eval;
 use std::sync;
+use syntax::dialect::Dialect;
 
 /// Execute a starlark snippet with an empty environment.
 pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     let mut env = environment::Environment::new("test");
-    match eval::simple::eval(&map, "<test>", snippet, false, &mut env) {
+    match eval::simple::eval(&map, "<test>", snippet, Dialect::Bzl, &mut env) {
         Ok(v) => Ok(v.to_bool()),
         Err(d) => {
             Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[d.clone()]);
@@ -36,7 +37,7 @@ pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
 pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     let mut env = environment::Environment::new("test");
-    Ok(eval::simple::eval(&map, "<test>", snippet, false, &mut env)?.to_bool())
+    Ok(eval::simple::eval(&map, "<test>", snippet, Dialect::Bzl, &mut env)?.to_bool())
 }
 
 /// A simple macro to execute a Starlark snippet and fails if the last statement is false.

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -22,6 +22,7 @@ use std::error::Error;
 use std::sync;
 
 use environment::Environment;
+use syntax::dialect::Dialect;
 use values::dict::Dictionary;
 use values::*;
 
@@ -954,7 +955,7 @@ pub fn global_environment() -> Environment {
 pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     let mut env = global_environment().freeze().child("test");
-    match eval(&map, "<test>", snippet, false, &mut env) {
+    match eval(&map, "<test>", snippet, Dialect::Bzl, &mut env) {
         Ok(v) => Ok(v.to_bool()),
         Err(d) => {
             Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[d.clone()]);
@@ -967,6 +968,7 @@ pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
 pub mod tests {
     use super::global_environment;
     use super::starlark_default;
+    use super::Dialect;
     use codemap::CodeMap;
     use codemap_diagnostic::Diagnostic;
     use eval::simple::eval;
@@ -975,7 +977,7 @@ pub mod tests {
     pub fn starlark_default_fail(snippet: &str) -> Result<bool, Diagnostic> {
         let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
         let mut env = global_environment().freeze().child("test");
-        match eval(&map, "<test>", snippet, false, &mut env) {
+        match eval(&map, "<test>", snippet, Dialect::Bzl, &mut env) {
             Ok(v) => Ok(v.to_bool()),
             Err(d) => Err(d),
         }

--- a/starlark/src/syntax/dialect.rs
+++ b/starlark/src/syntax/dialect.rs
@@ -12,29 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The syntax module that handle lexing and parsing
-
-#[doc(hidden)]
-pub mod errors;
-
-#[cfg(test)]
-#[macro_use]
-mod testutil;
-
-#[doc(hidden)]
-pub mod ast;
-pub mod dialect;
-#[doc(hidden)]
-pub mod lexer;
-mod grammar {
-    include!(concat!(env!("OUT_DIR"), "/syntax/grammar.rs"));
-    #[cfg(test)]
-    mod tests {
-        include!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/src/syntax/grammar.tests.rs"
-        ));
-    }
+/// Starlark language dialect.
+#[derive(Copy, Debug, Clone)]
+pub enum Dialect {
+    // Build file dialect which is used to interpret Bazel's BUILD files
+    Build,
+    // Full Starlark language that is available in Bazel's .bzl files
+    Bzl,
 }
-#[doc(hidden)]
-pub mod parser;

--- a/starlark/src/syntax/grammar.tests.rs
+++ b/starlark/src/syntax/grammar.tests.rs
@@ -15,6 +15,7 @@
 use super::StarlarkParser;
 use std::sync::{Arc, Mutex};
 use syntax::ast::Statement;
+use syntax::dialect::Dialect;
 use syntax::parser::parse_file;
 use syntax::errors::SyntaxError;
 use codemap;
@@ -204,7 +205,7 @@ fn smoke_test() {
         let path_entry = p.unwrap().path();
         let path = path_entry.to_str().unwrap();
         if path.ends_with(".bzl") {
-            if let Result::Err(err) = parse_file(&map, path, false) {
+            if let Result::Err(err) = parse_file(&map, path, Dialect::Bzl) {
                 diagnostics.push(err);
             }
         }

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -92,7 +92,7 @@ def assert_(cond, msg="assertion failed"):
   if not cond:
     fail(msg)
 "#,
-        false,
+        starlark::syntax::dialect::Dialect::Bzl,
         &mut prelude,
     )
     .unwrap();
@@ -108,7 +108,7 @@ def assert_(cond, msg="assertion failed"):
             &map,
             &format!("{}<{}>", path, offset),
             &content,
-            false,
+            starlark::syntax::dialect::Dialect::Bzl,
             &mut prelude.child(&path),
         ) {
             Err(p) => {


### PR DESCRIPTION
Language dialect is an important domain concept that should
be explicitly called out in code. It makes it much easier to
document it and makes code using it easier to follow, since
instead of `true` and `false` we use `Dialect::Build` or `Dialect::Bzl`.
This can also come very handy in case some useful methods should
be available for it.