### PR TITLE
Add print function to the REPL.

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -39,6 +39,7 @@
 extern crate codemap;
 extern crate codemap_diagnostic;
 extern crate linefeed;
+#[macro_use]
 extern crate starlark;
 
 use codemap_diagnostic::{ColorConfig, Emitter};
@@ -49,6 +50,7 @@ use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
 use std::sync::{Arc, Mutex};
+use starlark::values::Value;
 
 fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: Arc<Mutex<codemap::CodeMap>>,
@@ -73,6 +75,19 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             }
         }
         Err(p) => Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[p]),
+    }
+}
+
+starlark_module! {print_function =>
+    /// print: print an object string representation to stderr.
+    ///
+    /// Examples:
+    /// ```python
+    /// print("some message")  # Will print "some message" to stderr
+    /// ```
+    print(msg) {
+        eprintln!("{}", msg.to_str());
+        Ok(Value::new(None))
     }
 }
 

--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -49,8 +49,8 @@ use starlark::eval::eval_lexer;
 use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
-use std::sync::{Arc, Mutex};
 use starlark::values::Value;
+use std::sync::{Arc, Mutex};
 
 fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: Arc<Mutex<codemap::CodeMap>>,

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -22,7 +22,7 @@ use getopts::Options;
 use starlark::eval::interactive::eval_file;
 use starlark::stdlib::global_environment;
 use starlark::syntax::dialect::Dialect;
-use starlark_repl::repl;
+use starlark_repl::{repl, print_function};
 use std::env;
 
 macro_rules! print_usage {
@@ -69,7 +69,7 @@ fn main() {
             } else {
                 let build_file = matches.opt_present("b");
                 let opt_repl = matches.opt_present("r");
-                let global = global_environment();
+                let global = print_function(global_environment());
                 global.freeze();
                 let dialect = if build_file {
                     Dialect::Build

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -22,7 +22,7 @@ use getopts::Options;
 use starlark::eval::interactive::eval_file;
 use starlark::stdlib::global_environment;
 use starlark::syntax::dialect::Dialect;
-use starlark_repl::{repl, print_function};
+use starlark_repl::{print_function, repl};
 use std::env;
 
 macro_rules! print_usage {


### PR DESCRIPTION
print() is in the specification but the specification is leaving to the
application the decision on how it should be print (which make sense),
hence it make no sense to have the implementation of that function
in the library but the REPL should still have it.

Fixes #32.