### PR TITLE
Add support for set collections, behind a feature

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,6 +7,7 @@ case "$1" in
   build)
     cargo build --all
     cargo test --all
+    (cd starlark && cargo test --all --features=linked_hash_set)
     ;;
   doc)
     cargo doc --all

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ https://github.com/google/skylark/blob/a0e5de7e63b47e716cca7226662a4c95d47bf873/
 and the Python 3 documentation when things were unclear.
 
 This interpreter does not support most of the go extensions (e.g. bitwise
-operator or floating point). It does not include the `set()` type either ([the
-official Starlark specification](https://github.com/bazelbuild/starlark/blob/master/spec.md)
-does not have them either). It uses signed 64-bit integers.
+operator or floating point). It optionally includes a `set` type (by enabling the `linked_hash_set` feature),
+as an extension which is not specified in [the
+official Starlark specification](https://github.com/bazelbuild/starlark/blob/master/spec.md), but note that this
+is just an insertion-order-preserving set, and does not have optimisations for nesting as can be found in the
+starlark Java implemnetation's [depset](https://docs.bazel.build/versions/master/skylark/lib/depset.html) implementation.
+It uses signed 64-bit integers.
 
 ## Usage
 

--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -36,5 +36,5 @@ tempfile = ">=3, <3.0.5"
 name = "starlark-repl"
 
 [features]
-default =["linked_hash_set"]
+default = ["linked_hash_set"]
 linked_hash_set = ["starlark/linked_hash_set"]

--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -34,3 +34,6 @@ tempfile = ">=3, <3.0.5"
 
 [[bin]]
 name = "starlark-repl"
+
+[features]
+linked_hash_set = ["starlark/linked_hash_set"]

--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -36,4 +36,5 @@ tempfile = ">=3, <3.0.5"
 name = "starlark-repl"
 
 [features]
+default =["linked_hash_set"]
 linked_hash_set = ["starlark/linked_hash_set"]

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -26,6 +26,7 @@ codemap = "0.1.1"
 codemap-diagnostic = "0.1"
 lalrpop-util = "0.16.0"
 linked-hash-map = "0.5.1"
+linked_hash_set = { version = "0.1.3", optional = true }
 
 [lib]
 

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -214,6 +214,7 @@ impl Environment {
         self.env.borrow_mut().set_constructor = SetConstructor(Some(constructor));
     }
 
+    #[doc(hidden)]
     pub fn make_set(&self, values: Vec<Value>) -> ValueResult {
         match self.env.borrow().set_constructor.0 {
             Some(ref ctor) => ctor(values),

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -94,7 +94,8 @@ struct EnvironmentContent {
     variables: HashMap<String, Value>,
     /// List of static values of an object per type
     type_objs: HashMap<String, HashMap<String, Value>>,
-
+    /// Optional function which can be used to construct set literals (i.e. `{foo, bar}`).
+    /// If not set, attempts to use set literals will raise an error.
     set_constructor: SetConstructor,
 }
 
@@ -198,6 +199,17 @@ impl Environment {
         self.env.borrow().get_parent()
     }
 
+    /// Set the function which will be used to instantiate set literals encountered when evaluating
+    /// in this `Environment`. Set literals are {}s with one or more elements between, separated by
+    /// commas, e.g. `{1, 2, "three"}`.
+    ///
+    /// If this function is not called on the `Environment`, its parent's set constructor will be
+    /// used when set literals are encountered. If neither this `Environment`, nor any of its
+    /// transitive parents, have a set constructor defined, attempts to evaluate set literals will
+    /// raise and error.
+    ///
+    /// The `Value` returned by this function is expected to be a one-dimensional collection
+    /// containing no duplicates.
     pub fn with_set_constructor(&self, constructor: Box<Fn(Vec<Value>) -> ValueResult>) {
         self.env.borrow_mut().set_constructor = SetConstructor(Some(constructor));
     }

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::eval::testutil;
+use crate::eval::testutil::starlark_no_diagnostic;
 use crate::eval::RECURSION_ERROR_CODE;
+use crate::values::NOT_SUPPORTED_ERROR_CODE;
 
 #[test]
 fn arithmetic_test() {
@@ -91,4 +93,35 @@ def rec6(): rec2()
     starlark_fail!("def f(a, **kwargs, b=1): pass");
     starlark_fail!("def f(a, b=1, **kwargs, c=1): pass");
     starlark_fail!("def f(a, **kwargs, *args): pass");
+}
+
+#[cfg(not(feature = "linked_hash_set"))]
+#[test]
+fn sets() {
+    let err = starlark_no_diagnostic(&mut crate::stdlib::global_environment(), "s = {1, 2, 3}")
+        .unwrap_err();
+    assert_eq!(
+        err.message,
+        "Type `set` is not supported. Perhaps you need to enable some crate feature?".to_string()
+    );
+    assert_eq!(err.level, codemap_diagnostic::Level::Error);
+    assert_eq!(err.code, Some(NOT_SUPPORTED_ERROR_CODE.to_string()));
+}
+
+#[cfg(feature = "linked_hash_set")]
+#[test]
+fn sets() {
+    fn starlark_ok_with_global_env(snippet: &str) {
+        assert!(starlark_no_diagnostic(&mut crate::stdlib::global_environment(), snippet).unwrap());
+    }
+
+    starlark_ok_with_global_env(
+        "s1 = {1, 2, 3, 1} ; s2 = set([1, 2, 3]) ; len(s1) == 3 and s1 == s2",
+    );
+    starlark_ok_with_global_env("list(set([1, 2, 3, 1])) == [1, 2, 3]");
+    starlark_ok_with_global_env("list(set()) == []");
+    starlark_ok_with_global_env("not set()");
+
+    let parent_env = crate::stdlib::global_environment();
+    assert!(starlark_no_diagnostic(&mut parent_env.child("child"), "len({1, 2}) == 2").unwrap());
 }

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -15,7 +15,6 @@
 use crate::eval::testutil;
 use crate::eval::testutil::starlark_no_diagnostic;
 use crate::eval::RECURSION_ERROR_CODE;
-use crate::values::NOT_SUPPORTED_ERROR_CODE;
 
 #[test]
 fn arithmetic_test() {
@@ -105,7 +104,7 @@ fn sets() {
         "Type `set` is not supported. Perhaps you need to enable some crate feature?".to_string()
     );
     assert_eq!(err.level, codemap_diagnostic::Level::Error);
-    assert_eq!(err.code, Some(NOT_SUPPORTED_ERROR_CODE.to_string()));
+    assert_eq!(err.code, Some(crate::values::NOT_SUPPORTED_ERROR_CODE.to_string()));
 }
 
 #[cfg(feature = "linked_hash_set")]

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -104,7 +104,10 @@ fn sets() {
         "Type `set` is not supported. Perhaps you need to enable some crate feature?".to_string()
     );
     assert_eq!(err.level, codemap_diagnostic::Level::Error);
-    assert_eq!(err.code, Some(crate::values::NOT_SUPPORTED_ERROR_CODE.to_string()));
+    assert_eq!(
+        err.code,
+        Some(crate::values::NOT_SUPPORTED_ERROR_CODE.to_string())
+    );
 }
 
 #[cfg(feature = "linked_hash_set")]

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -35,9 +35,16 @@ pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
 
 /// Execute a starlark snippet with an empty environment.
 pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
+    starlark_no_diagnostic(&mut environment::Environment::new("test"), snippet)
+}
+
+/// Execute a starlark snippet with the passed environment.
+pub fn starlark_no_diagnostic(
+    env: &mut environment::Environment,
+    snippet: &str,
+) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    let mut env = environment::Environment::new("test");
-    Ok(eval::simple::eval(&map, "<test>", snippet, Dialect::Bzl, &mut env)?.to_bool())
+    Ok(eval::simple::eval(&map, "<test>", snippet, Dialect::Bzl, env)?.to_bool())
 }
 
 /// A simple macro to execute a Starlark snippet and fails if the last statement is false.

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -73,8 +73,11 @@
 pub mod environment;
 #[doc(hidden)]
 pub mod syntax;
+#[macro_use]
 pub mod values;
 #[macro_use]
 pub mod eval;
 #[macro_use]
 pub mod stdlib;
+#[cfg(feature = "linked_hash_set")]
+pub mod linked_hash_set;

--- a/starlark/src/linked_hash_set/mod.rs
+++ b/starlark/src/linked_hash_set/mod.rs
@@ -1,0 +1,2 @@
+pub mod stdlib;
+pub mod value;

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -114,6 +114,7 @@ starlark_module! {global =>
     /// # and
     /// y == set([1, 2, 3, 5])
     /// # )"#).unwrap());
+    /// ```
     set.copy(this) {
         let ret = Set::empty();
         for el in this.iter()? {
@@ -148,6 +149,7 @@ starlark_module! {global =>
     /// # and
     /// z == set([2, 3])
     /// # )"#).unwrap());
+    /// ```
     set.difference(this, *others) {
         let ret = Set::empty();
         for el in this.iter()? {
@@ -181,6 +183,7 @@ starlark_module! {global =>
     /// x.difference_update([2, 3])
     /// x == set([4])
     /// "#).unwrap());
+    /// ```
     set.difference_update(this, #other) {
         let previous_length = this.length()? as usize;
         Set::mutate(&this, &|x| {
@@ -251,6 +254,7 @@ starlark_module! {global =>
     /// # and
     /// z == set([2, 3])
     /// # )"#).unwrap());
+    /// ```
     set.intersection(this, *others) {
         let ret = Set::empty();
         for el in this.iter()? {
@@ -285,6 +289,7 @@ starlark_module! {global =>
     /// x.intersection_update([2, 3])
     /// x == set([2])
     /// "#).unwrap());
+    /// ```
     set.intersection_update(this, #other) {
         let previous_length = this.length()? as usize;
         Set::mutate(&this, &|x| {
@@ -321,6 +326,7 @@ starlark_module! {global =>
     /// # and
     /// x.isdisjoint(set([1, 5])) == False
     /// # )"#).unwrap());
+    /// ```
     set.isdisjoint(this, #other) {
         ok!(Set::compare(&this, &other, &|s1, s2| Ok(s1.intersection(s2).next().is_none()))?)
     }
@@ -344,6 +350,7 @@ starlark_module! {global =>
     /// # and
     /// x.issubset(set([1, 2, 3, 4, 5])) == True
     /// # )"#).unwrap());
+    /// ```
     set.issubset(this, #other) {
         ok!(Set::compare(&this, &other, &|this, other| Ok(this.is_subset(other)))?)
     }
@@ -367,6 +374,7 @@ starlark_module! {global =>
     /// # and
     /// x.issuperset(set([1, 2, 3, 4, 5])) == False
     /// # )"#).unwrap());
+    /// ```
     set.issuperset(this, #other) {
         ok!(Set::compare(&this, &other, &|this, other| Ok(other.is_subset(this)))?)
     }
@@ -445,7 +453,6 @@ starlark_module! {global =>
     ///
     /// A subsequent call to `x.remove(2)` would yield an error because the element won't be
     /// found.
-    /// ```
     set.remove(this, #needle) {
         let did_remove = Set::mutate(&this, &|x| {
             ok!(x.remove(&ValueWrapper::new(needle.clone())?))
@@ -481,6 +488,7 @@ starlark_module! {global =>
     /// # and
     /// x.symmetric_difference(z) == set([1, 2, 3, 4, 5])
     /// # )"#).unwrap());
+    /// ```
     set.symmetric_difference(this, #other) {
         Set::compare(&this, &other, &|s1, s2| Ok(Set::from(s1.symmetric_difference(s2).collect()).unwrap()))
     }
@@ -518,6 +526,7 @@ starlark_module! {global =>
     /// # and
     /// z == set([5])
     /// # )"#).unwrap());
+    /// ```
     set.symmetric_difference_update(this, #other) {
         let symmetric_difference = Set::compare(&this, &other, &|s1, s2| Ok(Set::from(s1.symmetric_difference(s2).collect()).unwrap()))?;
         Set::mutate(&this, &|s| {
@@ -554,6 +563,7 @@ starlark_module! {global =>
     /// # and
     /// z == [5, 6]
     /// # )"#).unwrap());
+    /// ```
     set.union(this, *others) {
         let ret = Set::empty();
         for el in this.iter()? {

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -1,0 +1,599 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Methods for the `set` type.
+
+use crate::values::*;
+
+use crate::linked_hash_set::value::{Set, ValueWrapper};
+
+// Errors -- UF = User Failure -- Failure that should be expected by the user (e.g. from a fail()).
+pub const SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE: &str = "UF30";
+
+macro_rules! ok {
+    ($e:expr) => {
+        return Ok(Value::from($e));
+    };
+}
+
+starlark_module! {global =>
+    /// set: construct a set.
+    ///
+    /// `set(x)` returns a new set containing the elements of the
+    /// iterable sequence x.
+    ///
+    /// With no argument, `set()` returns a new empty set.
+    set(#a = None) {
+        let mut s = Set::empty();
+        if a.get_type() != "NoneType" {
+            for x in a.iter()? {
+                Set::insert_if_absent(&mut s, x)?;
+            }
+        }
+        ok!(s)
+    }
+
+    /// set.add: append an element to a set.
+    ///
+    /// `S.add(x)` adds `x` to the set S, and returns `None`.
+    ///
+    /// `add` fails if the set is frozen or has active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set()
+    /// # (
+    /// x.add(1) == None
+    /// # and
+    /// x.add(2) == None
+    /// # and
+    /// x.add(3) == None
+    /// # and
+    /// x.add(1) == None
+    /// # and
+    /// x == set([1, 2, 3])
+    /// # )"#).unwrap());
+    /// ```
+    set.add(this, #el) {
+        Set::insert_if_absent(&this, el)?;
+        ok!(None)
+    }
+
+    /// set.clear: clear a set
+    ///
+    /// `S.clear()` removes all the elements of the set S and returns `None`.
+    ///
+    /// It fails if the set is frozen or if there are active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3])
+    /// # (
+    /// x.clear() == None
+    /// # and
+    /// x == set()
+    /// # )"#).unwrap());
+    /// ```
+    set.clear(this) {
+        Set::mutate(&this, &|x| {
+            x.clear();
+            ok!(None)
+        })
+    }
+
+    /// set.copy: return a set containing all of the elements of this set, in the same order.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3])
+    /// y = x.copy()
+    /// x.add(4)
+    /// y.add(5)
+    /// # (
+    /// x == set([1, 2, 3, 4])
+    /// # and
+    /// y == set([1, 2, 3, 5])
+    /// # )"#).unwrap());
+    set.copy(this) {
+        let ret = Set::empty();
+        for el in this.iter()? {
+            Set::insert_if_absent(&ret, el)?;
+        }
+        ok!(ret)
+    }
+
+    /// set.difference: return a set containing all of the elements of this set, without any
+    /// elements present in any of the passed sets.
+    ///
+    /// `S.difference(x, y)` returns `S - x - y`.
+    ///
+    /// `difference` fails if its argument(s) are not iterable.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// y = [1]
+    /// z = set([2, 3])
+    /// (
+    /// x.difference(y, z) == set([4])
+    /// # and
+    /// x.difference() == x
+    /// # and
+    /// x == set([1, 2, 3, 4])
+    /// # and
+    /// y == [1]
+    /// # and
+    /// z == set([2, 3])
+    /// # )"#).unwrap());
+    set.difference(this, *others) {
+        let ret = Set::empty();
+        for el in this.iter()? {
+            let mut is_in_any_other = false;
+            for other in others.iter()? {
+                if other.is_in(&el)?.to_bool() {
+                    is_in_any_other = true;
+                    break;
+                }
+            }
+            if !is_in_any_other {
+                Set::insert_if_absent(&ret, el)?;
+            }
+        }
+        ok!(ret)
+    }
+
+    /// set.difference_update: remove all elements of another iterable from this set.
+    ///
+    /// `S.difference_update(x)` removes all values in x from S.
+    ///
+    /// `difference_update` fails if its argument is not iterable.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// x.difference_update(set([1]))
+    /// x.difference_update([2, 3])
+    /// x == set([4])
+    /// "#).unwrap());
+    set.difference_update(this, #other) {
+        let previous_length = this.length()? as usize;
+        Set::mutate(&this, &|x| {
+            let mut values = Vec::with_capacity(previous_length);
+            for el in x.iter() {
+                if !other.is_in(&el.into())?.to_bool() {
+                    values.push(el.clone());
+                }
+            }
+            x.clear();
+            for value in values.into_iter() {
+                x.insert(value);
+            }
+            ok!(None)
+        })
+    }
+
+    /// set.discard: remove a value from a set if it is present.
+    ///
+    /// `S.discard(x)` removes the the value `x` from the set S if it is present, and returns `None`.
+    ///
+    /// `discard` fails if the set is frozen, or has active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3])
+    /// # (
+    /// x.discard(2) == None
+    /// # and
+    /// x.discard(4) == None
+    /// # and
+    /// x == set([1, 3])
+    /// # )"#).unwrap());
+    /// ```
+    set.discard(this, #needle) {
+        Set::mutate(&this, &|x| {
+            x.remove(&ValueWrapper::new(needle.clone())?);
+            ok!(None)
+        })
+    }
+
+    /// set.intersection: return a set containing all of the elements of this set which are also
+    /// present in all of the passed iterables.
+    ///
+    /// `intersection` fails if its argument(s) are not iterable.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// y = [1, 2]
+    /// z = set([2, 3])
+    /// (
+    /// x.intersection(y, z) == set([2])
+    /// # and
+    /// x.intersection() == x
+    /// # and
+    /// x.intersection().clear() == None
+    /// # and
+    /// x == set([1, 2, 3, 4])
+    /// # and
+    /// y == [1, 2]
+    /// # and
+    /// z == set([2, 3])
+    /// # )"#).unwrap());
+    set.intersection(this, *others) {
+        let ret = Set::empty();
+        for el in this.iter()? {
+            let mut is_in_every_other = true;
+            for other in others.iter()? {
+                if !other.is_in(&el)?.to_bool() {
+                    is_in_every_other = false;
+                    break;
+                }
+            }
+            if is_in_every_other {
+                Set::insert_if_absent(&ret, el)?;
+            }
+        }
+        ok!(ret)
+    }
+
+    /// set.intersection_update: remove all elements from this set which are not in the other
+    /// iterable.
+    ///
+    /// `S.intersection_update(x)` removes all values not in x from S.
+    ///
+    /// `intersection_update` fails if its argument is not iterable.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// x.intersection_update(set([1, 2]))
+    /// x.intersection_update([2, 3])
+    /// x == set([2])
+    /// "#).unwrap());
+    set.intersection_update(this, #other) {
+        let previous_length = this.length()? as usize;
+        Set::mutate(&this, &|x| {
+            let mut values = Vec::with_capacity(previous_length);
+            for el in x.iter() {
+                if other.is_in(&el.into())?.to_bool() {
+                    values.push(el.clone());
+                }
+            }
+            x.clear();
+            for value in values.into_iter() {
+                x.insert(value);
+            }
+            ok!(None)
+        })
+    }
+
+    /// set.isdisjoint: return whether a set has no intersection with another set.
+    ///
+    /// `isdisjoint` fails if its argument is not a set.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// (
+    /// x.isdisjoint(set()) == True
+    /// # and
+    /// x.isdisjoint(set([5])) == True
+    /// # and
+    /// x.isdisjoint(set([1])) == False
+    /// # and
+    /// x.isdisjoint(set([1, 5])) == False
+    /// # )"#).unwrap());
+    set.isdisjoint(this, #other) {
+        ok!(Set::compare(&this, &other, &|s1, s2| Ok(s1.intersection(s2).next().is_none()))?)
+    }
+
+    /// set.issubset: return whether another set contains this set.
+    ///
+    /// `issubset` fails if its argument is not a set.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// (
+    /// x.issubset(set()) == False
+    /// # and
+    /// x.issubset(set([1, 2, 3])) == False
+    /// # and
+    /// x.issubset(set([4, 3, 2, 1])) == True
+    /// # and
+    /// x.issubset(set([1, 2, 3, 4, 5])) == True
+    /// # )"#).unwrap());
+    set.issubset(this, #other) {
+        ok!(Set::compare(&this, &other, &|this, other| Ok(this.is_subset(other)))?)
+    }
+
+    /// set.issubset: return whether this set contains another set.
+    ///
+    /// `issuperset` fails if its argument is not a set.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// (
+    /// x.issuperset(set()) == True
+    /// # and
+    /// x.issuperset(set([1, 2, 3])) == True
+    /// # and
+    /// x.issuperset(set([4, 3, 2, 1])) == True
+    /// # and
+    /// x.issuperset(set([1, 2, 3, 4, 5])) == False
+    /// # )"#).unwrap());
+    set.issuperset(this, #other) {
+        ok!(Set::compare(&this, &other, &|this, other| Ok(other.is_subset(this)))?)
+    }
+
+    /// set.pop: removes and returns the last element of a set.
+    ///
+    /// `S.pop([index])` removes and returns the last element of the set S, or,
+    /// if the optional index is provided, at that index.
+    ///
+    /// `pop` fails if the index is negative or not less than the length of
+    /// the set, of if the set is frozen or has active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// # (
+    /// x.pop(1) == 2
+    /// # and
+    /// x.pop() == 4
+    /// # and
+    /// x.pop(0) == 1
+    /// # and
+    /// x == set([3])
+    /// # )"#).unwrap());
+    /// ```
+    set.pop(this, #index = None) {
+        let length = this.length()?;
+        let index = if index.get_type() == "NoneType" {
+            length - 1
+        } else {
+            index.to_int()?
+        };
+        if index < 0 || index >= length {
+            return Err(ValueError::IndexOutOfBound(index));
+        }
+        let index = index as usize;
+        Set::mutate(&this, &|x| {
+            let ret = if index == (length - 1) as usize {
+                x.pop_back()
+            } else if index == 0 {
+                x.pop_front()
+            } else {
+                let ret = x.iter().nth(index).cloned();
+                let values: Vec<_> = x.iter().take(index).chain(x.iter().skip(index + 1)).cloned().collect();
+                x.clear();
+                for value in values.into_iter() {
+                    x.insert(value);
+                }
+                ret
+            };
+            Ok(ret.unwrap().into())
+        })
+    }
+
+    /// set.remove: remove a value from a set
+    ///
+    /// `S.remove(x)` removes the the value `x` from the set S, and returns `None`.
+    ///
+    /// `remove` fails if the set does not contain `x`, is frozen, or has active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3])
+    /// # (
+    /// x.remove(2) == None
+    /// # and
+    /// x == set([1, 3])
+    /// # )"#).unwrap());
+    /// ```
+    ///
+    /// A subsequent call to `x.remove(2)` would yield an error because the element won't be
+    /// found.
+    /// ```
+    set.remove(this, #needle) {
+        let did_remove = Set::mutate(&this, &|x| {
+            ok!(x.remove(&ValueWrapper::new(needle.clone())?))
+        });
+        if did_remove?.to_bool() {
+            ok!(None)
+        } else {
+            starlark_err!(
+                SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE,
+                format!("Element '{}' not found in '{}'", needle, this),
+                "not found".to_owned()
+            )
+        }
+    }
+
+    /// set.symmetric_difference: return a set containing the elements present in exactly one of
+    /// this and another set.
+    ///
+    /// `symmetric_difference` fails if its argument is not a set.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3, 4])
+    /// y = set([0, 1, 2])
+    /// z = set([5])
+    /// (
+    /// x.symmetric_difference(y) == set([3, 4, 0])
+    /// # and
+    /// y.symmetric_difference(x) == set([0, 3, 4])
+    /// # and
+    /// x.symmetric_difference(z) == set([1, 2, 3, 4, 5])
+    /// # )"#).unwrap());
+    set.symmetric_difference(this, #other) {
+        Set::compare(&this, &other, &|s1, s2| Ok(Set::new(s1.symmetric_difference(s2).into_iter().collect()).unwrap()))
+    }
+
+    /// set.symmetric_difference_update: update this set to contain the symmetric difference of
+    /// this and another set.
+    ///
+    /// `symmetric_difference_update` fails if its argument is not a set.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x1 = set([1, 2, 3, 4])
+    /// x2 = set([1, 2, 3, 4])
+    /// y = set([0, 1, 2])
+    /// z = set([5])
+    /// (
+    /// x1.symmetric_difference_update(y) == None
+    /// # and
+    /// x1 == set([3, 4, 0])
+    /// # and
+    /// y == set([0, 1, 2])
+    /// # and
+    /// y.symmetric_difference_update(x2) == None
+    /// # and
+    /// y == set([0, 3, 4])
+    /// # and
+    /// x2 == set([1, 2, 3, 4])
+    /// # and
+    /// x2.symmetric_difference_update(z) == None
+    /// # and
+    /// x2 == set([1, 2, 3, 4, 5])
+    /// # and
+    /// z == set([5])
+    /// # )"#).unwrap());
+    set.symmetric_difference_update(this, #other) {
+        let symmetric_difference = Set::compare(&this, &other, &|s1, s2| Ok(Set::new(s1.symmetric_difference(s2).collect()).unwrap()))?;
+        Set::mutate(&this, &|s| {
+            s.clear();
+            for item in symmetric_difference.iter()? {
+                s.insert(ValueWrapper::new(item)?);
+            }
+            ok!(None)
+        })
+    }
+
+    /// set.union: return a set containing all of the elements of this set, then all of the extra
+    /// elements of the other iterables.
+    ///
+    /// `S.union(x, y)` returns a set of the union of `S` and `x` and `y`
+    /// (which must be iterables)'s elements.
+    ///
+    /// `union` fails if its arguments are not iterable.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set([1, 2, 3])
+    /// y = set([2, 4, 5])
+    /// z = [5, 6]
+    /// (
+    /// x.union(y, z) == set([1, 2, 3, 4, 5, 6])
+    /// # and
+    /// x == set([1, 2, 3])
+    /// # and
+    /// y == set([2, 4, 5])
+    /// # and
+    /// z == [5, 6]
+    /// # )"#).unwrap());
+    set.union(this, *others) {
+        let ret = Set::empty();
+        for el in this.iter()? {
+            Set::insert_if_absent(&ret, el)?;
+        }
+        for other in others.iter()? {
+            for el in other.iter()? {
+                Set::insert_if_absent(&ret, el)?;
+            }
+        }
+        ok!(ret)
+    }
+
+    /// set.update: update a set to also contain another iterable's content.
+    ///
+    /// `S.update(x)` adds the elements of `x`, which must be iterable, to
+    /// the set S, and returns `None`.
+    ///
+    /// `update` fails if `x` is not iterable, or if the set S is frozen or has active iterators.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default(r#"
+    /// x = set()
+    /// # (
+    /// x.update([1, 2, 3], set(["foo"])) == None
+    /// # and
+    /// x.update(["bar"]) == None
+    /// # and
+    /// x == set([1, 2, 3, "foo", "bar"])
+    /// # )"#).unwrap());
+    /// ```
+    set.update(this, *others) {
+        for other in others.iter()? {
+            for el in other.iter()? {
+                Set::insert_if_absent(&this, el)?;
+            }
+        }
+        ok!(None)
+    }
+}

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -182,7 +182,7 @@ starlark_module! {global =>
     /// x.difference_update(set([1]))
     /// x.difference_update([2, 3])
     /// x == set([4])
-    /// "#).unwrap());
+    /// # "#).unwrap());
     /// ```
     set.difference_update(this, #other) {
         let previous_length = this.length()? as usize;
@@ -288,7 +288,7 @@ starlark_module! {global =>
     /// x.intersection_update(set([1, 2]))
     /// x.intersection_update([2, 3])
     /// x == set([2])
-    /// "#).unwrap());
+    /// # "#).unwrap());
     /// ```
     set.intersection_update(this, #other) {
         let previous_length = this.length()? as usize;

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -35,10 +35,10 @@ starlark_module! {global =>
     ///
     /// With no argument, `set()` returns a new empty set.
     set(#a = None) {
-        let mut s = Set::empty();
+        let s = Set::empty();
         if a.get_type() != "NoneType" {
             for x in a.iter()? {
-                Set::insert_if_absent(&mut s, x)?;
+                Set::insert_if_absent(&s, x)?;
             }
         }
         ok!(s)
@@ -482,7 +482,7 @@ starlark_module! {global =>
     /// x.symmetric_difference(z) == set([1, 2, 3, 4, 5])
     /// # )"#).unwrap());
     set.symmetric_difference(this, #other) {
-        Set::compare(&this, &other, &|s1, s2| Ok(Set::new(s1.symmetric_difference(s2).into_iter().collect()).unwrap()))
+        Set::compare(&this, &other, &|s1, s2| Ok(Set::from(s1.symmetric_difference(s2).collect()).unwrap()))
     }
 
     /// set.symmetric_difference_update: update this set to contain the symmetric difference of
@@ -519,7 +519,7 @@ starlark_module! {global =>
     /// z == set([5])
     /// # )"#).unwrap());
     set.symmetric_difference_update(this, #other) {
-        let symmetric_difference = Set::compare(&this, &other, &|s1, s2| Ok(Set::new(s1.symmetric_difference(s2).collect()).unwrap()))?;
+        let symmetric_difference = Set::compare(&this, &other, &|s1, s2| Ok(Set::from(s1.symmetric_difference(s2).collect()).unwrap()))?;
         Set::mutate(&this, &|s| {
             s.clear();
             for item in symmetric_difference.iter()? {

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -154,8 +154,10 @@ impl TypedValue for Set {
             {
                 return Ok(Ordering::Equal);
             }
-            // Consistent: Yes.
-            // Useful: No.
+            // Comparing based on hash value isn't particularly meaningful to users, who may expect
+            // sets to compare based on, say, their size, or comparing their elements.
+            // We do this because it's guaranteed to provide a consistent ordering for any pair of
+            // sets. We should consider better defining the sort order of sets if users complain.
             let l = self.get_hash().unwrap();
             let r = other.get_hash().unwrap();
             if l <= r {

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -39,7 +39,7 @@ impl Set {
         Value::new(Set::default())
     }
 
-    pub fn new<V: Into<Value>>(values: Vec<V>) -> Result<Value, ValueError> {
+    pub fn from<V: Into<Value>>(values: Vec<V>) -> Result<Value, ValueError> {
         let mut result = Self::default();
         for v in values.into_iter() {
             result
@@ -174,8 +174,7 @@ impl TypedValue for Set {
         Ok(self
             .content
             .iter()
-            .skip(to_skip)
-            .next()
+            .nth(to_skip)
             .unwrap()
             .value
             .clone())
@@ -186,9 +185,9 @@ impl TypedValue for Set {
     }
 
     fn is_in(&self, other: &Value) -> ValueResult {
-        return Ok(Value::new(
+        Ok(Value::new(
             self.content.contains(&ValueWrapper::new(other.clone())?),
-        ));
+        ))
     }
 
     fn is_descendant(&self, other: &TypedValue) -> bool {
@@ -317,28 +316,28 @@ mod tests {
 
     #[test]
     fn test_to_str() {
-        assert_eq!("{1, 2, 3}", Set::new(vec![1, 2, 3]).unwrap().to_str());
+        assert_eq!("{1, 2, 3}", Set::from(vec![1, 2, 3]).unwrap().to_str());
         assert_eq!(
             "{1, {2, 3}}",
-            Set::new(vec![Value::from(1), Set::new(vec![2, 3]).unwrap()])
+            Set::from(vec![Value::from(1), Set::from(vec![2, 3]).unwrap()])
                 .unwrap()
                 .to_str()
         );
-        assert_eq!("{1}", Set::new(vec![1]).unwrap().to_str());
-        assert_eq!("{}", Set::new(Vec::<i64>::new()).unwrap().to_str());
+        assert_eq!("{1}", Set::from(vec![1]).unwrap().to_str());
+        assert_eq!("{}", Set::from(Vec::<i64>::new()).unwrap().to_str());
     }
 
     #[test]
     fn equality_ignores_order() {
         assert_eq!(
-            Set::new(vec![1, 2, 3]).unwrap(),
-            Set::new(vec![3, 2, 1]).unwrap(),
+            Set::from(vec![1, 2, 3]).unwrap(),
+            Set::from(vec![3, 2, 1]).unwrap(),
         );
     }
 
     #[test]
     fn test_value_alias() {
-        let v1 = Set::new(vec![1, 2]).unwrap();
+        let v1 = Set::from(vec![1, 2]).unwrap();
         let v2 = v1.clone();
         Set::insert_if_absent(&v2, Value::from(3)).unwrap();
         assert_eq!(v2.to_str(), "{1, 2, 3}");
@@ -347,9 +346,9 @@ mod tests {
 
     #[test]
     fn test_is_descendant() {
-        let v1 = Set::new(vec![1, 2, 3]).unwrap();
-        let v2 = Set::new(vec![Value::new(1), Value::new(2), v1.clone()]).unwrap();
-        let v3 = Set::new(vec![Value::new(1), Value::new(2), v2.clone()]).unwrap();
+        let v1 = Set::from(vec![1, 2, 3]).unwrap();
+        let v2 = Set::from(vec![Value::new(1), Value::new(2), v1.clone()]).unwrap();
+        let v3 = Set::from(vec![Value::new(1), Value::new(2), v2.clone()]).unwrap();
         assert!(v3.is_descendant_value(&v2));
         assert!(v3.is_descendant_value(&v1));
         assert!(v3.is_descendant_value(&v3));

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -171,13 +171,7 @@ impl TypedValue for Set {
     fn at(&self, index: Value) -> ValueResult {
         let i = index.convert_index(self.length()?)? as usize;
         let to_skip = if i == 0 { 0 } else { i - 1 };
-        Ok(self
-            .content
-            .iter()
-            .nth(to_skip)
-            .unwrap()
-            .value
-            .clone())
+        Ok(self.content.iter().nth(to_skip).unwrap().value.clone())
     }
 
     fn length(&self) -> Result<i64, ValueError> {

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -1,0 +1,365 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define the set type of Starlark
+use crate::values::*;
+use linked_hash_set::LinkedHashSet;
+use std::borrow::BorrowMut;
+use std::cmp::{Eq, Ordering, PartialEq};
+use std::hash::{Hash, Hasher};
+use std::num::Wrapping;
+
+pub struct Set {
+    mutability: IterableMutability,
+    content: LinkedHashSet<ValueWrapper>,
+}
+
+impl Default for Set {
+    fn default() -> Self {
+        Set {
+            mutability: IterableMutability::Mutable,
+            content: LinkedHashSet::new(),
+        }
+    }
+}
+
+impl Set {
+    pub fn empty() -> Value {
+        Value::new(Set::default())
+    }
+
+    pub fn new<V: Into<Value>>(values: Vec<V>) -> Result<Value, ValueError> {
+        let mut result = Self::default();
+        for v in values.into_iter() {
+            result
+                .content
+                .insert_if_absent(ValueWrapper::new(v.into())?);
+        }
+        Ok(Value::new(result))
+    }
+
+    pub fn insert_if_absent(set: &Value, v: Value) -> Result<Value, ValueError> {
+        let v = v.clone_for_container_value(set)?;
+        Self::mutate(set, &|hashset| {
+            hashset.insert_if_absent(ValueWrapper::new(v.clone())?);
+            Ok(Value::from(None))
+        })
+    }
+
+    pub fn mutate(
+        v: &Value,
+        f: &Fn(&mut LinkedHashSet<ValueWrapper>) -> ValueResult,
+    ) -> ValueResult {
+        if v.get_type() != "set" {
+            Err(ValueError::IncorrectParameterType)
+        } else {
+            let mut v = v.clone();
+            v.downcast_apply_mut(|x: &mut Set| -> ValueResult {
+                x.mutability.test()?;
+                f(&mut x.content)
+            })
+        }
+    }
+
+    pub fn compare<Return>(
+        v1: &Value,
+        v2: &Value,
+        f: &Fn(
+            &LinkedHashSet<ValueWrapper>,
+            &LinkedHashSet<ValueWrapper>,
+        ) -> Result<Return, ValueError>,
+    ) -> Result<Return, ValueError> {
+        if v1.get_type() != "set" || v2.get_type() != "set" {
+            Err(ValueError::IncorrectParameterType)
+        } else {
+            v1.downcast_apply(|v1: &Set| v2.downcast_apply(|v2: &Set| f(&v1.content, &v2.content)))
+        }
+    }
+}
+
+impl TypedValue for Set {
+    any!();
+
+    define_iterable_mutability!(mutability);
+
+    fn freeze(&mut self) {
+        self.mutability.freeze();
+        let mut new = LinkedHashSet::with_capacity(self.content.len());
+        while !self.content.is_empty() {
+            let mut value = self.content.pop_front().unwrap();
+            value.value.borrow_mut().freeze();
+            new.insert(value);
+        }
+        self.content = new;
+    }
+
+    /// Returns a string representation for the set
+    ///
+    /// # Examples:
+    /// ```
+    /// # use starlark::values::*;
+    /// # use starlark::values::list::List;
+    /// assert_eq!("[1, 2, 3]", Value::from(vec![1, 2, 3]).to_str());
+    /// assert_eq!("[1, [2, 3]]",
+    ///            Value::from(vec![Value::from(1), Value::from(vec![2, 3])]).to_str());
+    /// assert_eq!("[1]", Value::from(vec![1]).to_str());
+    /// assert_eq!("[]", Value::from(Vec::<i64>::new()).to_str());
+    /// ```
+    fn to_str(&self) -> String {
+        format!(
+            "{{{}}}",
+            self.content
+                .iter()
+                .map(|x| x.value.to_repr(),)
+                .enumerate()
+                .fold("".to_string(), |accum, s| if s.0 == 0 {
+                    accum + &s.1
+                } else {
+                    accum + ", " + &s.1
+                },)
+        )
+    }
+
+    fn to_repr(&self) -> String {
+        self.to_str()
+    }
+
+    not_supported!(to_int);
+    fn get_type(&self) -> &'static str {
+        "set"
+    }
+    fn to_bool(&self) -> bool {
+        !self.content.is_empty()
+    }
+
+    fn compare(&self, other: &TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
+        if other.get_type() == "set" {
+            let other = other.as_any().downcast_ref::<Self>().unwrap();
+            if self
+                .content
+                .symmetric_difference(&other.content)
+                .next()
+                .is_none()
+            {
+                return Ok(Ordering::Equal);
+            }
+            // Consistent: Yes.
+            // Useful: No.
+            let l = self.get_hash().unwrap();
+            let r = other.get_hash().unwrap();
+            if l <= r {
+                Ok(Ordering::Less)
+            } else {
+                Ok(Ordering::Greater)
+            }
+        } else {
+            default_compare(self, other)
+        }
+    }
+
+    fn at(&self, index: Value) -> ValueResult {
+        let i = index.convert_index(self.length()?)? as usize;
+        let to_skip = if i == 0 { 0 } else { i - 1 };
+        Ok(self
+            .content
+            .iter()
+            .skip(to_skip)
+            .next()
+            .unwrap()
+            .value
+            .clone())
+    }
+
+    fn length(&self) -> Result<i64, ValueError> {
+        Ok(self.content.len() as i64)
+    }
+
+    fn is_in(&self, other: &Value) -> ValueResult {
+        return Ok(Value::new(
+            self.content.contains(&ValueWrapper::new(other.clone())?),
+        ));
+    }
+
+    fn is_descendant(&self, other: &TypedValue) -> bool {
+        self.content
+            .iter()
+            .any(|x| x.value.same_as(other) || x.value.is_descendant(other))
+    }
+
+    fn slice(
+        &self,
+        start: Option<Value>,
+        stop: Option<Value>,
+        stride: Option<Value>,
+    ) -> ValueResult {
+        let (start, stop, stride) =
+            Value::convert_slice_indices(self.length()?, start, stop, stride)?;
+        Ok(Value::from(tuple::slice_vector(
+            start,
+            stop,
+            stride,
+            self.content.iter().map(|v| &v.value),
+        )))
+    }
+
+    fn iter<'a>(&'a self) -> Result<Box<Iterator<Item = Value> + 'a>, ValueError> {
+        Ok(Box::new(self.content.iter().map(|x| x.value.clone())))
+    }
+
+    /// Concatenate `other` to the current value.
+    ///
+    /// `other` has to be a set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use starlark::values::*;
+    /// # use starlark::values::list::List;
+    /// # assert!(
+    /// // {1, 2, 3} + {2, 3, 4} == {1, 2, 3, 4}
+    /// Value::from(vec![1,2,3]).add(Value::from(vec![2,3])).unwrap()
+    ///     == Value::from(vec![1, 2, 3, 2, 3])
+    /// # );
+    /// ```
+    fn add(&self, other: Value) -> ValueResult {
+        if other.get_type() == "set" {
+            let mut result = Set {
+                mutability: IterableMutability::Mutable,
+                content: LinkedHashSet::new(),
+            };
+            for x in self.content.iter() {
+                result.content.insert(x.clone());
+            }
+            for x in other.iter()? {
+                result
+                    .content
+                    .insert_if_absent(ValueWrapper::new(x.clone())?);
+            }
+            Ok(Value::new(result))
+        } else {
+            Err(ValueError::IncorrectParameterType)
+        }
+    }
+
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        Ok(self
+            .content
+            .iter()
+            .map(|v| v.precomputed_hash)
+            .map(Wrapping)
+            .fold(Wrapping(0_u64), |acc, v| acc + v)
+            .0)
+    }
+
+    not_supported!(mul, set_at);
+    not_supported!(attr, function);
+    not_supported!(plus, minus, sub, div, pipe, percent, floor_div);
+}
+
+#[derive(Clone)]
+pub struct ValueWrapper {
+    pub value: Value,
+    // Precompute the hash to verify that the value is hashable. Eagerly error if it's not, so that
+    // the caller who wants to use the ValueWrapper knows it can't be done.
+    precomputed_hash: u64,
+}
+
+impl ValueWrapper {
+    pub fn new(value: Value) -> Result<ValueWrapper, ValueError> {
+        let precomputed_hash = value.get_hash()?;
+        Ok(ValueWrapper {
+            value,
+            precomputed_hash,
+        })
+    }
+}
+
+impl Into<Value> for &ValueWrapper {
+    fn into(self) -> Value {
+        self.clone().value
+    }
+}
+
+impl PartialEq for ValueWrapper {
+    fn eq(&self, other: &ValueWrapper) -> bool {
+        self.value.compare(&other.value, 0) == Ok(Ordering::Equal)
+    }
+}
+
+impl Eq for ValueWrapper {}
+
+impl Hash for ValueWrapper {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        h.write_u64(self.precomputed_hash);
+    }
+}
+
+impl Into<Value> for ValueWrapper {
+    fn into(self) -> Value {
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_str() {
+        assert_eq!("{1, 2, 3}", Set::new(vec![1, 2, 3]).unwrap().to_str());
+        assert_eq!(
+            "{1, {2, 3}}",
+            Set::new(vec![Value::from(1), Set::new(vec![2, 3]).unwrap()])
+                .unwrap()
+                .to_str()
+        );
+        assert_eq!("{1}", Set::new(vec![1]).unwrap().to_str());
+        assert_eq!("{}", Set::new(Vec::<i64>::new()).unwrap().to_str());
+    }
+
+    #[test]
+    fn equality_ignores_order() {
+        assert_eq!(
+            Set::new(vec![1, 2, 3]).unwrap(),
+            Set::new(vec![3, 2, 1]).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_value_alias() {
+        let v1 = Set::new(vec![1, 2]).unwrap();
+        let v2 = v1.clone();
+        Set::insert_if_absent(&v2, Value::from(3)).unwrap();
+        assert_eq!(v2.to_str(), "{1, 2, 3}");
+        assert_eq!(v1.to_str(), "{1, 2, 3}");
+    }
+
+    #[test]
+    fn test_is_descendant() {
+        let v1 = Set::new(vec![1, 2, 3]).unwrap();
+        let v2 = Set::new(vec![Value::new(1), Value::new(2), v1.clone()]).unwrap();
+        let v3 = Set::new(vec![Value::new(1), Value::new(2), v2.clone()]).unwrap();
+        assert!(v3.is_descendant_value(&v2));
+        assert!(v3.is_descendant_value(&v1));
+        assert!(v3.is_descendant_value(&v3));
+
+        assert!(v2.is_descendant_value(&v1));
+        assert!(v2.is_descendant_value(&v2));
+        assert!(!v2.is_descendant_value(&v3));
+
+        assert!(v1.is_descendant_value(&v1));
+        assert!(!v1.is_descendant_value(&v2));
+        assert!(!v1.is_descendant_value(&v3));
+    }
+}

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -939,11 +939,22 @@ starlark_module! {global_functions =>
 /// For example `stdlib::global_environment().freeze().child("test")` create a child environment
 /// of this global environment that have been frozen.
 pub fn global_environment() -> Environment {
-    let env = Environment::new("global");
+    let env = add_set(Environment::new("global"));
     env.set("None", Value::new(None)).unwrap();
     env.set("True", Value::new(true)).unwrap();
     env.set("False", Value::new(false)).unwrap();
     dict::global(list::global(string::global(global_functions(env))))
+}
+
+#[cfg(feature = "linked_hash_set")]
+fn add_set(env: Environment) -> Environment {
+    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::new));
+    crate::linked_hash_set::stdlib::global(env)
+}
+
+#[cfg(not(feature = "linked_hash_set"))]
+fn add_set(env: Environment) -> Environment {
+    env
 }
 
 /// Execute a starlark snippet with the default environment for test and return the truth value

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -948,7 +948,7 @@ pub fn global_environment() -> Environment {
 
 #[cfg(feature = "linked_hash_set")]
 fn add_set(env: Environment) -> Environment {
-    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::new));
+    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
     crate::linked_hash_set::stdlib::global(env)
 }
 

--- a/starlark/src/syntax/ast.rs
+++ b/starlark/src/syntax/ast.rs
@@ -106,8 +106,10 @@ pub enum Expr {
     Op(BinOp, AstExpr, AstExpr),
     If(AstExpr, AstExpr, AstExpr), // Order: condition, v1, v2 <=> v1 if condition else v2
     List(Vec<AstExpr>),
+    Set(Vec<AstExpr>),
     Dict(Vec<(AstExpr, AstExpr)>),
     ListComprehension(AstExpr, Vec<AstClause>),
+    SetComprehension(AstExpr, Vec<AstClause>),
     DictComprehension((AstExpr, AstExpr), Vec<AstClause>),
 }
 to_ast_trait!(Expr, AstExpr, Box);
@@ -479,6 +481,11 @@ impl Display for Expr {
                 comma_separated_fmt(f, v, |x, f| x.node.fmt(f), false)?;
                 f.write_str("]")
             }
+            Expr::Set(ref v) => {
+                f.write_str("{")?;
+                comma_separated_fmt(f, v, |x, f| x.node.fmt(f), false)?;
+                f.write_str("}")
+            }
             Expr::Dict(ref v) => {
                 f.write_str("{")?;
                 comma_separated_fmt(f, v, |x, f| write!(f, "{}: {}", x.0.node, x.1.node), false)?;
@@ -488,6 +495,11 @@ impl Display for Expr {
                 write!(f, "[{}", e.node)?;
                 comma_separated_fmt(f, v, |x, f| x.node.fmt(f), false)?;
                 f.write_str("]")
+            }
+            Expr::SetComprehension(ref e, ref v) => {
+                write!(f, "{{{}", e.node)?;
+                comma_separated_fmt(f, v, |x, f| x.node.fmt(f), false)?;
+                f.write_str("}}")
             }
             Expr::DictComprehension((ref k, ref v), ref c) => {
                 write!(f, "{{{}: {}", k.node, v.node)?;

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -218,6 +218,15 @@ Operand: AstExpr = {
     ListComp,
     <l:@L> "{" <e:COMMA<DictEntry>> "}" <r:@R>
         => Expr::Dict(e).to_ast(file_span.subspan(l, r)),
+     <l:@L> "{" <e:Test> "}" <r:@R> => Expr::Set(vec![e]).to_ast(file_span.subspan(l, r)),
+     SetComp,
+     // Must contain at least one element - {} is an empty dict not set.
+     <l:@L> "{" <e1:Test> "," <es:COMMA<Test>> "}" <r:@R>
+             => {
+                 let mut es = es;
+                 es.insert(0, e1);
+                 Expr::Set(es).to_ast(file_span.subspan(l, r))
+             },
     DictComp,
     <l:@L> "(" <e:TestList?> ")" <r:@R>
         => match e {
@@ -231,6 +240,10 @@ DictEntry: (AstExpr, AstExpr) = <Test> ":" <Test> => (<>);
 ListComp: AstExpr = ASTE<ListComp_>;
 ListComp_: Expr = "[" <Test> <CompClause>  "]"
     => Expr::ListComprehension(<>);
+
+SetComp: AstExpr = ASTE<SetComp_>;
+SetComp_: Expr = "{" <Test> <CompClause> "}"
+    => Expr::SetComprehension(<>);
 
 DictComp: AstExpr = ASTE<DictComp_>;
 DictComp_: Expr = "{" <DictEntry> <CompClause>"}"

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -159,6 +159,8 @@ pub enum ValueError {
     UnsupportedRecursiveDataStructure,
     /// It is not allowed to mutate a structure during iteration.
     MutationDuringIteration,
+    /// A type was used which isn't supported with the current feature set. Wraps the type name.
+    TypeNotSupported(String),
 }
 
 /// A simpler error format to return as a ValueError
@@ -235,6 +237,9 @@ impl SyntaxError for ValueError {
                         ValueError::MutationDuringIteration => {
                             "Cannot mutate an iterable while iterating".to_owned()
                         }
+                        ValueError::TypeNotSupported(ref t) => {
+                            format!("Attempt to construct unsupported type ({})", t)
+                        }
                         ValueError::DiagnosedError(..) => unreachable!(),
                     }),
                 };
@@ -295,11 +300,14 @@ impl SyntaxError for ValueError {
                         ValueError::MutationDuringIteration => {
                             "This operation mutate an iterable for an iterator is borrowed.".to_owned()
                         }
+                        ValueError::TypeNotSupported(ref t) => {
+                            format!("Type `{}` is not supported. Perhaps you need to enable some crate feature?", t)
+                        }
                         ValueError::DiagnosedError(..) => unreachable!(),
                     },
                     code: Some(
                         match self {
-                            ValueError::OperationNotSupported { .. } => NOT_SUPPORTED_ERROR_CODE,
+                            ValueError::OperationNotSupported { .. } | ValueError::TypeNotSupported(..) => NOT_SUPPORTED_ERROR_CODE,
                             ValueError::TypeNotX { .. } => NOT_SUPPORTED_ERROR_CODE,
                             ValueError::DivisionByZero => DIVISION_BY_ZERO_ERROR_CODE,
                             ValueError::CannotMutateImmutableValue => IMMUTABLE_ERROR_CODE,


### PR DESCRIPTION
Pants allows the use of sets in BUILD files, so this is useful for experimenting with starlark in Pants.

Equality and ordering semantics are slightly weird here; sets preserve insertion order, but are considered equal ignoring order. Ordering comparison of sets is consistent with this (and consistent in general), but ill-defined; it's not based on number of elements, or anything like that, it just uses a combined hash of the contents so that hash is consistent with eq.

This also is slightly different from the dict implementation in that it doesn't rely on `Value` implementing `Hash` and instead uses a wrapper type so that callers are forced to eagerly handle unhashable types, rather than us panicing. I'd be interested in extending this to the dict type, if that's agree to be useful, too.