### PR TITLE
If a number is followed by a character, simply consider it 2 token

### DIFF
--- a/starlark/src/syntax/grammar.tests.rs
+++ b/starlark/src/syntax/grammar.tests.rs
@@ -159,6 +159,19 @@ fn test_return() {
     assert_eq!(unwrap_parse!("def fn(): return"), "def fn():\n  return\n");
 }
 
+// Regression test for https://github.com/google/starlark-rust/issues/44.
+#[test]
+fn test_optional_whitespace() {
+    assert_eq!(
+        unwrap_parse!("6 or()"),
+        "(6 or ())\n"
+    );
+    assert_eq!(
+        unwrap_parse!("6or()"),
+        "(6 or ())\n"
+    );
+}
+
 #[test]
 fn test_fncall_span() {
     let content = r#"def fn(a):

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -1,0 +1,5 @@
+# This file contains the list of example reported by https://github.com/josharian
+# as part of his fuzzing of starlark-rust
+
+# https://github.com/google/starlark-rust/issues#44: whitespace isn't required between some tokens
+assert_eq(6 or (), 6)

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -2,4 +2,4 @@
 # as part of his fuzzing of starlark-rust
 
 # https://github.com/google/starlark-rust/issues#44: whitespace isn't required between some tokens
-assert_eq(6 or (), 6)
+assert_eq(6or(), 6)

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -3,3 +3,6 @@
 
 # https://github.com/google/starlark-rust/issues#44: whitespace isn't required between some tokens
 assert_eq(6or(), 6)
+# 6burgle still generates a parse error.
+6burgle  ### [CP01]
+---

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -56,7 +56,8 @@ fn assert_diagnostic(
         d.message.clone()
     } else {
         let label = d.spans[0].label.clone();
-        format!("{} ({})", d.message, label.unwrap())
+        let error_code = d.code.clone().unwrap_or_else(|| "".to_owned());
+        format!("[{}] {} ({})", error_code, d.message, label.unwrap())
     };
     if !msg.to_lowercase().contains(&expected) {
         io::stderr()


### PR DESCRIPTION
The implementation was assuming that 6a is an invalid identifier, but
it should actually be considered to be 2 different token. E.g. `6or()`
should yield `6` not an error.

Fixes #44.