### PR TITLE
Run clippy shard on stable, not nightly

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -9,6 +9,6 @@ case "$1" in
     ;;
   clippy)
     echo "Installing clippy..."
-    rustup component add clippy --toolchain=nightly || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+    rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
     ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     rust: nightly
   - name: "Rust: clippy"
     env: ACTION=clippy
-    rust: nightly
+    rust: stable
   - name: "Rust: doc"
     env: ACTION=doc
     rust: stable


### PR DESCRIPTION
Clippy on nightly sometimes breaks if the compiler internals change.