### PR TITLE
Explicitly name match clause variants

### DIFF
--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -235,7 +235,7 @@ impl SyntaxError for ValueError {
                         ValueError::MutationDuringIteration => {
                             "Cannot mutate an iterable while iterating".to_owned()
                         }
-                        _ => unreachable!(),
+                        ValueError::DiagnosedError(..) => unreachable!(),
                     }),
                 };
                 Diagnostic {
@@ -295,7 +295,7 @@ impl SyntaxError for ValueError {
                         ValueError::MutationDuringIteration => {
                             "This operation mutate an iterable for an iterator is borrowed.".to_owned()
                         }
-                        _ => unreachable!(),
+                        ValueError::DiagnosedError(..) => unreachable!(),
                     },
                     code: Some(
                         match self {


### PR DESCRIPTION
This means that people who add new ValueError variants will be prompted
by the compiler to add a case for their new variant, rather than getting
panics at runtime.