### PR TITLE
Consider letter other than 'x' and 'o' after a 0 as another token

### DIFF
--- a/starlark/src/syntax/grammar.tests.rs
+++ b/starlark/src/syntax/grammar.tests.rs
@@ -172,6 +172,15 @@ fn test_optional_whitespace() {
     );
 }
 
+// Regression test for https://github.com/google/starlark-rust/issues/56.
+#[test]
+fn test_optional_whitespace_after_0() {
+    assert_eq!(
+        unwrap_parse!("0in[1,2,3]"),
+        "(0 in [1, 2, 3])\n"
+    );
+}
+
 #[test]
 fn test_fncall_span() {
     let content = r#"def fn(a):

--- a/starlark/src/syntax/lexer.rs
+++ b/starlark/src/syntax/lexer.rs
@@ -676,7 +676,7 @@ impl Lexer {
                     self.pop();
                     self.consume_int_radix(2)
                 }
-                c if !c.is_alphanumeric() => self.end(Token::IntegerLiteral(0)),
+                c if !c.is_numeric() => self.end(Token::IntegerLiteral(0)),
                 _ => self.invalid(),
             }
         } else {
@@ -1196,9 +1196,11 @@ mod tests {
     #[test]
     fn test_number_collated_with_keywords_or_identifier() {
         let r =
-            collect_result("1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11");
+            collect_result("0in 1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11");
         assert_eq!(
             &[
+                Token::IntegerLiteral(0),
+                Token::In,
                 Token::IntegerLiteral(1),
                 Token::And,
                 Token::IntegerLiteral(2),

--- a/starlark/src/syntax/lexer.rs
+++ b/starlark/src/syntax/lexer.rs
@@ -1196,7 +1196,7 @@ mod tests {
     #[test]
     fn test_number_collated_with_keywords_or_identifier() {
         let r = collect_result(
-            "0in 1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11"
+            "0in 1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11",
         );
         assert_eq!(
             &[

--- a/starlark/src/syntax/lexer.rs
+++ b/starlark/src/syntax/lexer.rs
@@ -1195,8 +1195,9 @@ mod tests {
     // Regression test for https://github.com/google/starlark-rust/issues/44.
     #[test]
     fn test_number_collated_with_keywords_or_identifier() {
-        let r =
-            collect_result("0in 1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11");
+        let r = collect_result(
+            "0in 1and 2else 3load 4break 5for 6not 7not  in 8continue 10identifier11"
+        );
         assert_eq!(
             &[
                 Token::IntegerLiteral(0),

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -1,8 +1,10 @@
 # This file contains the list of example reported by https://github.com/josharian
 # as part of his fuzzing of starlark-rust
 
-# https://github.com/google/starlark-rust/issues#44: whitespace isn't required between some tokens
+# https://github.com/google/starlark-rust/issues/44: whitespace isn't required between some tokens
 assert_eq(6or(), 6)
 # 6burgle still generates a parse error.
 6burgle  ### [CP01]
 ---
+# https://github.com/google/starlark-rust/issues/56: Non whitespace after 0 should be allowed.
+assert_eq(0in[1,2,3], False)


### PR DESCRIPTION
Fixes #56.