### PR TITLE
Do not allow comparison between object of different type

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -172,8 +172,7 @@ impl Into<Diagnostic> for EvalException {
                 level: Level::Error,
                 message: format!(
                     "Disallowed ordered comparison between types {} and {}.",
-                    type1,
-                    type2,
+                    type1, type2,
                 ),
                 code: Some(COMPARISON_ERROR_CODE.to_owned()),
                 spans: vec![SpanLabel {

--- a/starlark/tests/go-testcases/misc.sky
+++ b/starlark/tests/go-testcases/misc.sky
@@ -36,17 +36,25 @@
 #   tuple slice
 #   interpolate with %c, %%
 
+---
+# Ordered comparisons of different types are disallowed.
+None < False   ### [CE06]
+---
+False < list   ### [CE06]
+---
+list < {}      ### [CE06]
+---
 def lam(): None
-
-# All comparisons are legal
-None < False
-False < list
-list < {}
-{} < lam
-lam < 0
-0 < []
-[] < ""
-"" < ()
+{} < lam       ### [CE06]
+---
+def lam(): None
+lam < 0        ### [CE06]
+---
+0 < []         ### [CE06]
+---
+[] < ""        ### [CE06]
+---
+"" < ()        ### [CE06]
 
 ---
 # cyclic data structures

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -5,6 +5,18 @@
 assert_eq(6or(), 6)
 # 6burgle still generates a parse error.
 6burgle  ### [CP01]
+<<<<<<< HEAD
 ---
 # https://github.com/google/starlark-rust/issues/56: Non whitespace after 0 should be allowed.
 assert_eq(0in[1,2,3], False)
+||||||| merged common ancestors
+---
+=======
+---
+# https://github.com/google/starlark-rust/issues#54: Comparison between different subtypes should be forbidden
+0 < True       ### [CE06]
+---
+"s" < 0        ### [CE06]
+---
+False < None   ### [CE06]
+>>>>>>> Do not allow comparison between object of different type

--- a/starlark/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark/tests/rust-testcases/josharian_fuzzing.sky
@@ -5,13 +5,9 @@
 assert_eq(6or(), 6)
 # 6burgle still generates a parse error.
 6burgle  ### [CP01]
-<<<<<<< HEAD
 ---
 # https://github.com/google/starlark-rust/issues/56: Non whitespace after 0 should be allowed.
 assert_eq(0in[1,2,3], False)
-||||||| merged common ancestors
----
-=======
 ---
 # https://github.com/google/starlark-rust/issues#54: Comparison between different subtypes should be forbidden
 0 < True       ### [CE06]
@@ -19,4 +15,3 @@ assert_eq(0in[1,2,3], False)
 "s" < 0        ### [CE06]
 ---
 False < None   ### [CE06]
->>>>>>> Do not allow comparison between object of different type


### PR DESCRIPTION
This is explicitely disallowed in the spec: https://github.com/bazelbuild/starlark/blob/master/spec.md#comparisons.

Fixes #54.