### PR TITLE
Return the correct line number for chunked file in integration tests.

### DIFF
--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -103,9 +103,10 @@ def assert_(cond, msg="assertion failed"):
         } else {
             ""
         };
+        let content = std::iter::repeat("\n").take(offset).collect::<String>() + &content;
         match eval(
             &map,
-            &format!("{}<{}>", path, offset),
+            &path,
             &content,
             starlark::syntax::dialect::Dialect::Bzl,
             &mut prelude.child(&path),


### PR DESCRIPTION
Inject a random number of new line to report the correct line number
in integration  tests.

Thanks @adonovan for suggesting to do that :)