### PR TITLE
Support TERM=dumb

### DIFF
--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 codemap = "0.1.1"
-codemap-diagnostic = "0.1"
+codemap-diagnostic = "0.1.1"
 getopts = "0.2"
 linefeed = "0.5.3"
 starlark = { path = "../starlark" }

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -23,7 +23,7 @@ lalrpop = "0.16.0"
 
 [dependencies]
 codemap = "0.1.1"
-codemap-diagnostic = "0.1"
+codemap-diagnostic = "0.1.1"
 lalrpop-util = "0.16.0"
 linked-hash-map = "0.5.1"
 linked_hash_set = { version = "0.1.3", optional = true }

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -28,7 +28,7 @@ pub struct EvalError {
 
 impl EvalError {
     pub fn write_to_stderr(self) {
-        Emitter::stderr(ColorConfig::Always, Some(&self.codemap.lock().unwrap()))
+        Emitter::stderr(ColorConfig::Auto, Some(&self.codemap.lock().unwrap()))
             .emit(&[self.diagnostic])
     }
 }


### PR DESCRIPTION
Before this change, if TERM=dumb and starlark-repl output an error, it would panic instead of outputting the error because it tried to output control codes which weren't supported by the terminal.

Fixes #53.