### PR TITLE
A refactoring and an example of embedding Starlark in Rust

### DIFF
--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -61,15 +61,12 @@ impl Set {
         v: &Value,
         f: &Fn(&mut LinkedHashSet<ValueWrapper>) -> ValueResult,
     ) -> ValueResult {
-        if v.get_type() != "set" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut Set| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut Set| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 
     pub fn compare<Return>(
@@ -80,11 +77,11 @@ impl Set {
             &LinkedHashSet<ValueWrapper>,
         ) -> Result<Return, ValueError>,
     ) -> Result<Return, ValueError> {
-        if v1.get_type() != "set" || v2.get_type() != "set" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            v1.downcast_apply(|v1: &Set| v2.downcast_apply(|v2: &Set| f(&v1.content, &v2.content)))
-        }
+        v1.downcast_apply(|v1: &Set| {
+            v2.downcast_apply(|v2: &Set| f(&v1.content, &v2.content))
+                .unwrap_or(Err(ValueError::IncorrectParameterType))
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -38,26 +38,20 @@ impl Dictionary {
         v: &Value,
         f: &dyn Fn(&LinkedHashMap<Value, Value>) -> Result<Return, ValueError>,
     ) -> Result<Return, ValueError> {
-        if v.get_type() != "dict" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            v.downcast_apply(|x: &Dictionary| -> Result<Return, ValueError> { f(&x.content) })
-        }
+        v.downcast_apply(|x: &Dictionary| -> Result<Return, ValueError> { f(&x.content) })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 
     pub fn mutate(
         v: &Value,
         f: &dyn Fn(&mut LinkedHashMap<Value, Value>) -> ValueResult,
     ) -> ValueResult {
-        if v.get_type() != "dict" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/interop.rs
+++ b/starlark/src/values/interop.rs
@@ -1,0 +1,228 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for easier interop with Rust.
+
+use std::convert::TryFrom;
+
+use crate::values::dict::Dictionary;
+use crate::values::{TypedValue, Value, ValueError};
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+
+/// Type convertible from Starlark value.
+pub trait StarlarkParameterToRust: Sized {
+    /// Convert a value from Starlark
+    fn from_starlark(value: Value) -> Result<Self, ValueError>;
+}
+
+impl StarlarkParameterToRust for Value {
+    fn from_starlark(value: Value) -> Result<Self, ValueError> {
+        Ok(value)
+    }
+}
+
+impl StarlarkParameterToRust for String {
+    fn from_starlark(value: Value) -> Result<String, ValueError> {
+        value
+            .downcast_apply(String::clone)
+            .ok_or(ValueError::IncorrectParameterType)
+    }
+}
+
+impl StarlarkParameterToRust for bool {
+    fn from_starlark(value: Value) -> Result<bool, ValueError> {
+        value
+            .downcast_apply(|i: &bool| *i)
+            .ok_or(ValueError::IncorrectParameterType)
+    }
+}
+
+impl StarlarkParameterToRust for i64 {
+    fn from_starlark(value: Value) -> Result<i64, ValueError> {
+        value
+            .downcast_apply(|i: &i64| *i)
+            .ok_or(ValueError::IncorrectParameterType)
+    }
+}
+
+impl StarlarkParameterToRust for u64 {
+    fn from_starlark(value: Value) -> Result<u64, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                u64::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for u32 {
+    fn from_starlark(value: Value) -> Result<u32, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                u32::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for i32 {
+    fn from_starlark(value: Value) -> Result<i32, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                i32::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for u16 {
+    fn from_starlark(value: Value) -> Result<u16, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                u16::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for i16 {
+    fn from_starlark(value: Value) -> Result<i16, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                i16::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for u8 {
+    fn from_starlark(value: Value) -> Result<u8, ValueError> {
+        value
+            .downcast_apply(|i: &i64| u8::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i)))
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for i8 {
+    fn from_starlark(value: Value) -> Result<i8, ValueError> {
+        value
+            .downcast_apply(|i: &i64| i8::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i)))
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for usize {
+    fn from_starlark(value: Value) -> Result<usize, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                usize::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl StarlarkParameterToRust for isize {
+    fn from_starlark(value: Value) -> Result<isize, ValueError> {
+        value
+            .downcast_apply(|i: &i64| {
+                isize::try_from(*i).map_err(|_| ValueError::IndexOutOfBound(*i))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+impl<T: StarlarkParameterToRust> StarlarkParameterToRust for Vec<T> {
+    fn from_starlark(value: Value) -> Result<Self, ValueError> {
+        let mut r = Vec::new();
+        // Any iterable can be converted to Vec
+        for item in value.iter()? {
+            r.push(T::from_starlark(item)?);
+        }
+        Ok(r)
+    }
+}
+
+impl<K, V, S> StarlarkParameterToRust for HashMap<K, V, S>
+where
+    K: StarlarkParameterToRust + Eq + Hash,
+    V: StarlarkParameterToRust,
+    S: BuildHasher + Default,
+{
+    fn from_starlark(value: Value) -> Result<Self, ValueError> {
+        value
+            .downcast_apply(|dict: &Dictionary| {
+                let mut r = HashMap::default();
+                for key in dict.iter()? {
+                    let entry_value = value.at(key.clone())?;
+                    r.insert(K::from_starlark(key)?, V::from_starlark(entry_value)?);
+                }
+                Ok(r)
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::values::list::List;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn from_starlark_basic() {
+        assert_eq!(Ok(17usize), usize::from_starlark(Value::new(17i64)));
+
+        let result = u8::from_starlark(Value::new(300));
+        if let Err(ValueError::IndexOutOfBound(300)) = result {
+            // OK
+        } else {
+            panic!("{:?}", result);
+        }
+
+        let result = u8::from_starlark(Value::new("ab".to_owned()));
+        if let Err(ValueError::IncorrectParameterType) = result {
+            // OK
+        } else {
+            panic!("{:?}", result);
+        }
+    }
+
+    #[test]
+    fn from_starlark_list() {
+        let list = List::new();
+        List::mutate(&list, &|vec| {
+            vec.push(Value::new(12i64));
+            vec.push(Value::new(13i64));
+            Ok(Value::new(Some(())))
+        })
+        .unwrap();
+        assert_eq!(Ok(vec![12, 13]), Vec::<u32>::from_starlark(list));
+    }
+
+    #[test]
+    fn from_starlark_dict() {
+        let dict = Dictionary::new();
+        Dictionary::mutate(&dict, &|dict| {
+            dict.insert(Value::new(10i64), Value::new(true));
+            dict.insert(Value::new(12i64), Value::new(false));
+            Ok(Value::new(Some(())))
+        })
+        .unwrap();
+        assert_eq!(
+            Ok(HashMap::from_iter(vec![(10, true), (12, false)])),
+            HashMap::<u32, bool>::from_starlark(dict)
+        );
+    }
+}

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -46,15 +46,12 @@ impl List {
     }
 
     pub fn mutate(v: &Value, f: &dyn Fn(&mut Vec<Value>) -> ValueResult) -> ValueResult {
-        if v.get_type() != "list" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut List| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut List| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -53,6 +53,10 @@ impl List {
         })
         .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
+
+    pub fn values(&self) -> &[Value] {
+        &self.content
+    }
 }
 
 impl TypedValue for List {

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1624,7 +1624,7 @@ impl dyn TypedValue {
 
 impl Value {
     /// A convenient wrapper around any_apply to actually operate on the underlying type
-    pub fn downcast_apply<T: Any, F, Return>(&self, f: F) -> Return
+    pub fn downcast_apply<T: Any + TypedValue, F, Return>(&self, f: F) -> Return
     where
         F: Fn(&T) -> Return,
     {
@@ -1632,7 +1632,7 @@ impl Value {
     }
 
     /// A convenient wrapper around any_apply_mut to actually operate on the underlying type
-    pub fn downcast_apply_mut<T: Any, F, Return>(&mut self, f: F) -> Return
+    pub fn downcast_apply_mut<T: Any + TypedValue, F, Return>(&mut self, f: F) -> Return
     where
         F: Fn(&mut T) -> Return,
     {

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1624,19 +1624,25 @@ impl dyn TypedValue {
 
 impl Value {
     /// A convenient wrapper around any_apply to actually operate on the underlying type
-    pub fn downcast_apply<T: Any + TypedValue, F, Return>(&self, f: F) -> Return
+    pub fn downcast_apply<T: Any + TypedValue, F, Return>(&self, f: F) -> Option<Return>
     where
         F: Fn(&T) -> Return,
     {
-        self.any_apply(&move |x| f(x.downcast_ref().unwrap()))
+        self.any_apply(&move |x| match x.downcast_ref() {
+            Some(x) => Some(f(x)),
+            None => None,
+        })
     }
 
     /// A convenient wrapper around any_apply_mut to actually operate on the underlying type
-    pub fn downcast_apply_mut<T: Any + TypedValue, F, Return>(&mut self, f: F) -> Return
+    pub fn downcast_apply_mut<T: Any + TypedValue, F, Return>(&mut self, f: F) -> Option<Return>
     where
         F: Fn(&mut T) -> Return,
     {
-        self.any_apply_mut(&move |x| f(x.downcast_mut().unwrap()))
+        self.any_apply_mut(&move |x| match x.downcast_mut() {
+            Some(x) => Some(f(x)),
+            None => None,
+        })
     }
 
     pub fn convert_index(&self, len: i64) -> Result<i64, ValueError> {

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1663,6 +1663,7 @@ impl Value {
 // Submodules
 pub mod dict;
 pub mod function;
+pub mod interop;
 pub mod list;
 pub mod string;
 pub mod tuple;

--- a/starlark/tests/example.rs
+++ b/starlark/tests/example.rs
@@ -1,0 +1,96 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codemap::CodeMap;
+use starlark::eval::simple::eval;
+use starlark::stdlib::global_environment;
+use starlark::syntax::dialect::Dialect;
+use starlark::values::function::Function;
+use starlark::values::Value;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+/// An example of how to call Starlark from Rust program.
+#[test]
+fn call_starlark_from_rust() {
+    let program = "def inc(x): return x + 1";
+    let map = Arc::new(Mutex::new(CodeMap::new()));
+    let global = global_environment();
+    global.freeze();
+    let mut env = global.child("my");
+    eval(&map, "inline.bzl", program, Dialect::Bzl, &mut env).unwrap();
+    let inc = env.get("inc").unwrap();
+    let result = inc
+        .call(
+            &[],
+            env.child("call"),
+            vec![Value::new(17)],
+            HashMap::new(),
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(18, result.to_int().unwrap());
+}
+
+/// An example how to inject a Rust function into a Starlark program.
+#[test]
+fn call_rust_from_starlark() {
+    let program = "build_house();\
+                   plant_tree('oak');\
+                   plant_tree('birch');\
+                   ";
+    let map = Arc::new(Mutex::new(CodeMap::new()));
+    let global = global_environment();
+
+    #[derive(Default)]
+    struct Ground {
+        houses: u32,
+        trees: Vec<String>,
+    }
+
+    let ground = Rc::new(RefCell::new(Ground::default()));
+    let ground1 = ground.clone();
+    let ground2 = ground.clone();
+
+    global
+        .set(
+            "plant_tree",
+            Function::new_native_1("plant_tree".to_owned(), move |name| {
+                (*ground1).borrow_mut().trees.push(name);
+                Ok(())
+            }),
+        )
+        .unwrap();
+    global
+        .set(
+            "build_house",
+            Function::new_native_0("build_house".to_owned(), move || {
+                (*ground2).borrow_mut().houses += 1;
+                Ok(())
+            }),
+        )
+        .unwrap();
+    global.freeze();
+    let mut env = global.child("my");
+    eval(&map, "inline.bzl", program, Dialect::Bzl, &mut env).unwrap();
+
+    assert_eq!(
+        vec!["oak".to_owned(), "birch".to_owned()],
+        (*ground).borrow_mut().trees
+    );
+    assert_eq!(1, (*ground).borrow_mut().houses);
+}


### PR DESCRIPTION
Four commits:

* change `Value::downcast_apply*` parameters to accept only `TypedValue` for type safety
* change `Value::downcast_apply*` to return `Option<Return>` instead of panicking
* `Function::new_native_n` where n is 0, 1, 2 as easy easy setup of Rust callbacks and as example
* an example how to embed Starlark into Rust