### PR TITLE
Remove redundant closures

### DIFF
--- a/starlark/src/syntax/lexer.rs
+++ b/starlark/src/syntax/lexer.rs
@@ -1428,7 +1428,7 @@ def test(a):
 test("abc")
 "#,
         )
-        .map(|x| x.unwrap())
+        .map(Result::unwrap)
         .collect();
         assert_eq!(expected, actual);
     }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -85,14 +85,15 @@ impl TypedValue for List {
     fn to_str(&self) -> String {
         format!(
             "[{}]",
-            self.content.iter().map(Value::to_repr).enumerate().fold(
-                "".to_string(),
-                |accum, s| if s.0 == 0 {
+            self.content
+                .iter()
+                .map(Value::to_repr)
+                .enumerate()
+                .fold("".to_string(), |accum, s| if s.0 == 0 {
                     accum + &s.1
                 } else {
                     accum + ", " + &s.1
-                },
-            )
+                },)
         )
     }
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -85,7 +85,7 @@ impl TypedValue for List {
     fn to_str(&self) -> String {
         format!(
             "[{}]",
-            self.content.iter().map(|x| x.to_repr(),).enumerate().fold(
+            self.content.iter().map(Value::to_repr).enumerate().fold(
                 "".to_string(),
                 |accum, s| if s.0 == 0 {
                     accum + &s.1

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -273,14 +273,15 @@ impl TypedValue for Tuple {
     fn to_str(&self) -> String {
         format!(
             "({}{})",
-            self.content.iter().map(Value::to_repr).enumerate().fold(
-                "".to_string(),
-                |accum, s| if s.0 == 0 {
+            self.content
+                .iter()
+                .map(Value::to_repr)
+                .enumerate()
+                .fold("".to_string(), |accum, s| if s.0 == 0 {
                     accum + &s.1
                 } else {
                     accum + ", " + &s.1
-                },
-            ),
+                },),
             if self.content.len() == 1 { "," } else { "" }
         )
     }

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -273,7 +273,7 @@ impl TypedValue for Tuple {
     fn to_str(&self) -> String {
         format!(
             "({}{})",
-            self.content.iter().map(|x| x.to_repr(),).enumerate().fold(
+            self.content.iter().map(Value::to_repr).enumerate().fold(
                 "".to_string(),
                 |accum, s| if s.0 == 0 {
                     accum + &s.1


### PR DESCRIPTION
This fixes clippy since the last clippy update.