### PR TITLE
Return error on integer overflow

### DIFF
--- a/starlark/tests/go-testcases/int.sky
+++ b/starlark/tests/go-testcases/int.sky
@@ -149,10 +149,13 @@ assert_(-1 > -2)
 maxint64 = 9223372036854775807 # = 2^63
 minint64 = -maxint64 - 1       # = -2^64
 assert_eq(str(maxint64), "9223372036854775807")
-assert_eq(str(maxint64+1), "-9223372036854775808")
+# Overflow
+# assert_eq(str(maxint64+1), "9223372036854775808")
 assert_eq(str(minint64), "-9223372036854775808")
-assert_eq(str(minint64-1), "9223372036854775807")
-assert_eq(str(minint64 * minint64), "0")
+# Overflow
+# assert_eq(str(minint64-1), "-9223372036854775809")
+# Overflow
+# assert_eq(str(minint64 * minint64), "85070591730234615865843651857942052864")
 
 # string formatting
 assert_eq("%o %x %d" % (0o755, 0xDEADBEEF, 42), "755 deadbeef 42")

--- a/starlark/tests/rust-testcases/bool.sky
+++ b/starlark/tests/rust-testcases/bool.sky
@@ -1,0 +1,3 @@
+# Boolean tests
+
+True + 9223372036854775807   ###  Integer overflow

--- a/starlark/tests/rust-testcases/int.sky
+++ b/starlark/tests/rust-testcases/int.sky
@@ -1,0 +1,19 @@
+# Integer tests
+
+9223372036854775807 + 1      ###  Integer overflow
+---
+-9223372036854775807 - 2     ###  Integer overflow
+---
+9223372036854775807 * 2      ###  Integer overflow
+---
+int_min = -9223372036854775807 - 1
+-int_min                     ###  Integer overflow
+---
+int_min = -9223372036854775807 - 1
+int_min // -1                ###  Integer overflow
+---
+int_min = -9223372036854775807 - 1
+assert_eq(0, int_min % -1)
+assert_eq(0, int_min % int_min)
+assert_eq(9223372036854775806, int_min % 9223372036854775807)
+assert_eq(-1, 9223372036854775807 % int_min)


### PR DESCRIPTION
Before this commit certain integer operations did wrapping on
overflow or caused Rust panic.

It is explicit integer overflow error now.

Note while Go implementation has proper big integer implementation,
Java implementation returns error on overflow: https://git.io/fjZs9.

I also believe it is safer to return error than overflow quietly.