### PR TITLE
Return Option from downcast_apply instead of panicking

### DIFF
--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -61,15 +61,12 @@ impl Set {
         v: &Value,
         f: &Fn(&mut LinkedHashSet<ValueWrapper>) -> ValueResult,
     ) -> ValueResult {
-        if v.get_type() != "set" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut Set| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut Set| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 
     pub fn compare<Return>(
@@ -80,11 +77,11 @@ impl Set {
             &LinkedHashSet<ValueWrapper>,
         ) -> Result<Return, ValueError>,
     ) -> Result<Return, ValueError> {
-        if v1.get_type() != "set" || v2.get_type() != "set" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            v1.downcast_apply(|v1: &Set| v2.downcast_apply(|v2: &Set| f(&v1.content, &v2.content)))
-        }
+        v1.downcast_apply(|v1: &Set| {
+            v2.downcast_apply(|v2: &Set| f(&v1.content, &v2.content))
+                .unwrap_or(Err(ValueError::IncorrectParameterType))
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -38,26 +38,20 @@ impl Dictionary {
         v: &Value,
         f: &dyn Fn(&LinkedHashMap<Value, Value>) -> Result<Return, ValueError>,
     ) -> Result<Return, ValueError> {
-        if v.get_type() != "dict" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            v.downcast_apply(|x: &Dictionary| -> Result<Return, ValueError> { f(&x.content) })
-        }
+        v.downcast_apply(|x: &Dictionary| -> Result<Return, ValueError> { f(&x.content) })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 
     pub fn mutate(
         v: &Value,
         f: &dyn Fn(&mut LinkedHashMap<Value, Value>) -> ValueResult,
     ) -> ValueResult {
-        if v.get_type() != "dict" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -46,15 +46,12 @@ impl List {
     }
 
     pub fn mutate(v: &Value, f: &dyn Fn(&mut Vec<Value>) -> ValueResult) -> ValueResult {
-        if v.get_type() != "list" {
-            Err(ValueError::IncorrectParameterType)
-        } else {
-            let mut v = v.clone();
-            v.downcast_apply_mut(|x: &mut List| -> ValueResult {
-                x.mutability.test()?;
-                f(&mut x.content)
-            })
-        }
+        let mut v = v.clone();
+        v.downcast_apply_mut(|x: &mut List| -> ValueResult {
+            x.mutability.test()?;
+            f(&mut x.content)
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
     }
 }
 

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1624,19 +1624,25 @@ impl dyn TypedValue {
 
 impl Value {
     /// A convenient wrapper around any_apply to actually operate on the underlying type
-    pub fn downcast_apply<T: Any + TypedValue, F, Return>(&self, f: F) -> Return
+    pub fn downcast_apply<T: Any + TypedValue, F, Return>(&self, f: F) -> Option<Return>
     where
         F: Fn(&T) -> Return,
     {
-        self.any_apply(&move |x| f(x.downcast_ref().unwrap()))
+        self.any_apply(&move |x| match x.downcast_ref() {
+            Some(x) => Some(f(x)),
+            None => None,
+        })
     }
 
     /// A convenient wrapper around any_apply_mut to actually operate on the underlying type
-    pub fn downcast_apply_mut<T: Any + TypedValue, F, Return>(&mut self, f: F) -> Return
+    pub fn downcast_apply_mut<T: Any + TypedValue, F, Return>(&mut self, f: F) -> Option<Return>
     where
         F: Fn(&mut T) -> Return,
     {
-        self.any_apply_mut(&move |x| f(x.downcast_mut().unwrap()))
+        self.any_apply_mut(&move |x| match x.downcast_mut() {
+            Some(x) => Some(f(x)),
+            None => None,
+        })
     }
 
     pub fn convert_index(&self, len: i64) -> Result<i64, ValueError> {


### PR DESCRIPTION
Makes code easier to read and safer.

In particular, with this patch, in a couple of places, downcast is
used to check underlying type instead of string type comparison.