### PR TITLE
Make dictionary implemenation panic-safe

### DIFF
--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -344,7 +344,7 @@ impl TypedValue for Function {
                     while args_iter.next().is_some() {}
                 }
                 FunctionParameter::KWArgsDict(..) => {
-                    v.push(Value::from(kwargs_dict.clone()));
+                    v.push(Value::try_from(kwargs_dict.clone())?);
                     kwargs_dict.clear();
                 }
             }

--- a/starlark/src/values/hashed_value.rs
+++ b/starlark/src/values/hashed_value.rs
@@ -1,0 +1,71 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error-safe value and hash pair.
+
+use crate::values::{Value, ValueError};
+use core::borrow::BorrowMut;
+use std::hash::{Hash, Hasher};
+
+/// A pair of value and cached value hash.
+///
+/// This struct contains both value and a precomputed hash of that value.
+/// If a value is not hashable, this error is raised at `DictionaryKey` construction.
+/// So the implementation of `Hash` for this struct does not need to handle `hash` errors.
+#[derive(Eq, Clone)]
+pub struct HashedValue {
+    hash: u64,
+    value: Value,
+}
+
+impl From<HashedValue> for Value {
+    fn from(key: HashedValue) -> Value {
+        key.value
+    }
+}
+
+impl HashedValue {
+    /// Returns error if the value is non hashable.
+    pub fn new(value: Value) -> Result<HashedValue, ValueError> {
+        let hash = value.get_hash()?;
+        Ok(HashedValue { hash, value })
+    }
+
+    /// Get precomputed hash.
+    pub fn get_hash(&self) -> u64 {
+        self.hash
+    }
+
+    /// Get contained value.
+    pub fn get_value(&self) -> &Value {
+        &self.value
+    }
+
+    /// Freeze the value, should be no-op since only immutable values can be hashed.
+    pub fn freeze(&mut self) {
+        self.value.borrow_mut().freeze();
+    }
+}
+
+impl PartialEq for HashedValue {
+    fn eq(&self, other: &HashedValue) -> bool {
+        self.hash == other.hash && self.value == other.value
+    }
+}
+
+impl Hash for HashedValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash)
+    }
+}

--- a/starlark/src/values/string.rs
+++ b/starlark/src/values/string.rs
@@ -189,6 +189,7 @@ impl TypedValue for String {
     /// # use starlark::values::*;
     /// # use starlark::values::string;
     /// # use std::collections::HashMap;
+    /// # use std::convert::TryFrom;
     /// # assert!(
     /// // "Hello %s, your score is %d" % ("Bob", 75) == "Hello Bob, your score is 75"
     /// Value::from("Hello %s, your score is %d").percent(Value::from(("Bob", 75))).unwrap()
@@ -201,7 +202,7 @@ impl TypedValue for String {
     /// # );
     /// // "%(greeting)s, %(audience)s" % {"greeting": "Hello", "audience": "world"} ==
     /// //      "Hello, world"
-    /// let mut d = Value::from(HashMap::<Value, Value>::new());
+    /// let mut d = Value::try_from(HashMap::<String, Value>::new()).unwrap();
     /// d.set_at(Value::from("greeting"), Value::from("Hello"));
     /// d.set_at(Value::from("audience"), Value::from("world"));
     /// # assert!(
@@ -326,6 +327,7 @@ impl TypedValue for String {
 mod tests {
     use super::super::Value;
     use std::collections::HashMap;
+    use std::convert::TryFrom;
 
     #[test]
     fn test_to_repr() {
@@ -429,7 +431,7 @@ mod tests {
         );
         // "%(greeting)s, %(audience)s" % {"greeting": "Hello", "audience": "world"} ==
         //      "Hello, world"
-        let mut d = Value::from(HashMap::<Value, Value>::new());
+        let mut d = Value::try_from(HashMap::<String, Value>::new()).unwrap();
         d.set_at(Value::from("greeting"), Value::from("Hello"))
             .unwrap();
         d.set_at(Value::from("audience"), Value::from("world"))

--- a/starlark/tests/rust-testcases/dict.sky
+++ b/starlark/tests/rust-testcases/dict.sky
@@ -1,0 +1,3 @@
+# Dict tests
+
+{[]: 1 for x in [1]}    ### Value is not hashable


### PR DESCRIPTION
`Value` no longer implements `Hash`, `DictionaryKey` now wraps
`Dictionary` key and contains precomputed hash.

`Dictionary` implementation no longer has `.unwrap()` calls.

As a side effect this code no longer panics, but returns a proper
error.

```
{[]: 1 for x in [1]}
```