### PR TITLE
Start REPL if no arguments given

### DIFF
--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -90,10 +90,11 @@ fn main() {
                 } else {
                     Dialect::Bzl
                 };
+                let free_args_empty = matches.free.is_empty();
                 for i in matches.free.into_iter() {
                     maybe_print_or_exit(eval_file(&i, dialect, &mut global.child(&i)));
                 }
-                if opt_repl {
+                if opt_repl || (free_args_empty && command.is_none()) {
                     println!("Welcome to Starlark REPL, press Ctrl+D to exit.");
                     repl(&global, dialect);
                 }


### PR DESCRIPTION
Before this commit, `starlark-repl` command immediately exited when
no args specified.

It starts REPL now.

New behavior matches Python or Go Starlark command line interpreters.

```
% cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.77s
     Running `target/debug/starlark-repl`
Welcome to Starlark REPL, press Ctrl+D to exit.
>>>
```