### PR TITLE
Add README.md to tests directory

### DIFF
--- a/starlark/tests/README.md
+++ b/starlark/tests/README.md
@@ -1,0 +1,9 @@
+## Rust Starlark implementation test
+
+* `go-testcases` are taken from
+  [Go implementation](https://github.com/google/starlark-go/tree/master/starlark/testdata)
+* `java-testcases` are taken from
+  [Java implementation](https://github.com/bazelbuild/bazel/tree/master/src/test/starlark/testdata)
+* `rust-testcases` are written for this project
+
+Certain Java and Go testcases were modified or removed to match this implemenetation.


### PR DESCRIPTION
README.md contains links to original Java and Go test cases, which can be useful to understand how much Rust implementation diverged from Java and Go implementations.