### PR TITLE
Make certain builtin function parameters unnamed

### DIFF
--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -118,7 +118,7 @@ starlark_module! {global_functions =>
     /// all([0, False]) == False
     /// # )").unwrap());
     /// ```
-    all(x) {
+    all(#x) {
         for i in x.iter()? {
             if !i.to_bool() {
                 return Ok(Value::new(false));
@@ -182,7 +182,7 @@ starlark_module! {global_functions =>
     /// chr(0x1F63F) == '😿'
     /// # )").unwrap());
     /// ```
-    chr(i) {
+    chr(#i) {
         let cp = i.to_int()? as u32;
         match std::char::from_u32(cp) {
             Some(x) => Ok(Value::new(x.to_string())),
@@ -290,7 +290,7 @@ starlark_module! {global_functions =>
     /// "capitalize" in dir("abc")
     /// # ))).unwrap());
     /// ```
-    dir(env env, x) {
+    dir(env env, #x) {
         let mut result = env.list_type_value(&x);
         if let Ok(v) = x.dir_attr() {
             result.extend(v);

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -296,7 +296,7 @@ starlark_module! {global =>
     /// "hello, world!".count("o", 7, 12) == 1  # in "world"
     /// # )"#).unwrap());
     /// ```
-    string.count(this, #needle, start = 0, end = None) {
+    string.count(this, #needle, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -360,7 +360,7 @@ starlark_module! {global =>
     /// "bonbon".find("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.find(this, #needle, start = 0, end = None) {
+    string.find(this, #needle, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -515,7 +515,7 @@ starlark_module! {global =>
     /// "bonbon".index("on", 2, 5) # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.index(this, #needle, start = 0, end = None) {
+    string.index(this, #needle, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -947,7 +947,7 @@ starlark_module! {global =>
     /// "bonbon".rfind("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.rfind(this, #needle, start = 0, end = None) {
+    string.rfind(this, #needle, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -982,7 +982,7 @@ starlark_module! {global =>
     /// "bonbon".rindex("on", 2, 5)   # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.rindex(this, #needle, start = 0, end = None) {
+    string.rindex(this, #needle, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();


### PR DESCRIPTION
Spec is not clear whether e. g. `chr(i=33)` is allowed.  I used Go
and Python implementations as reference.