### PR TITLE
Push RefCell from Value down to TypedValue implementations

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -48,7 +48,7 @@ use starlark::eval::eval_lexer;
 use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
-use starlark::values::Value;
+use starlark::values::{NoneValue, Value};
 use std::env;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -97,7 +97,7 @@ starlark_module! {print_function =>
             r.push_str(&arg.to_str());
         }
         eprintln!("{}", r);
-        Ok(Value::new(None))
+        Ok(Value::new_imm(NoneValue))
     }
 }
 

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -18,6 +18,7 @@ use crate::values::hashed_value::HashedValue;
 use crate::values::*;
 
 use crate::linked_hash_set::value::Set;
+use linked_hash_set::LinkedHashSet;
 
 // Errors -- UF = User Failure -- Failure that should be expected by the user (e.g. from a fail()).
 pub const SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE: &str = "UF30";
@@ -36,10 +37,10 @@ starlark_module! {global =>
     ///
     /// With no argument, `set()` returns a new empty set.
     set(#a = None) {
-        let s = Set::empty();
+        let mut s = LinkedHashSet::new();
         if a.get_type() != "NoneType" {
             for x in a.iter()? {
-                Set::insert_if_absent(&s, x)?;
+                s.insert_if_absent(HashedValue::new(x)?);
             }
         }
         ok!(s)
@@ -71,7 +72,7 @@ starlark_module! {global =>
     /// ```
     set.add(this, #el) {
         Set::insert_if_absent(&this, el)?;
-        ok!(None)
+        Ok(Value::new_imm(NoneValue))
     }
 
     /// set.clear: clear a set
@@ -95,7 +96,7 @@ starlark_module! {global =>
     set.clear(this) {
         Set::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -117,7 +118,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     set.copy(this) {
-        let ret = Set::empty();
+        let ret = Set::new_value(Default::default());
         for el in this.iter()? {
             Set::insert_if_absent(&ret, el)?;
         }
@@ -152,11 +153,11 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     set.difference(this, *others) {
-        let ret = Set::empty();
+        let ret = Set::new_value(Default::default());
         for el in this.iter()? {
             let mut is_in_any_other = false;
             for other in &others {
-                if other.is_in(&el)?.to_bool() {
+                if other.is_in(&el)? {
                     is_in_any_other = true;
                     break;
                 }
@@ -190,7 +191,7 @@ starlark_module! {global =>
         Set::mutate(&this, &|x| {
             let mut values = Vec::with_capacity(previous_length);
             for el in x.iter() {
-                if !other.is_in(el.get_value())?.to_bool() {
+                if !other.is_in(el.get_value())? {
                     values.push(el.clone());
                 }
             }
@@ -198,7 +199,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -225,7 +226,7 @@ starlark_module! {global =>
     set.discard(this, #needle) {
         Set::mutate(&this, &|x| {
             x.remove(&HashedValue::new(needle.clone())?);
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -257,11 +258,11 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     set.intersection(this, *others) {
-        let ret = Set::empty();
+        let ret = Set::new_value(Default::default());
         for el in this.iter()? {
             let mut is_in_every_other = true;
             for other in &others {
-                if !other.is_in(&el)?.to_bool() {
+                if !other.is_in(&el)? {
                     is_in_every_other = false;
                     break;
                 }
@@ -296,7 +297,7 @@ starlark_module! {global =>
         Set::mutate(&this, &|x| {
             let mut values = Vec::with_capacity(previous_length);
             for el in x.iter() {
-                if other.is_in(el.get_value())?.to_bool() {
+                if other.is_in(el.get_value())? {
                     values.push(el.clone());
                 }
             }
@@ -304,7 +305,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -459,7 +460,7 @@ starlark_module! {global =>
             ok!(x.remove(&HashedValue::new(needle.clone())?))
         });
         if did_remove?.to_bool() {
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         } else {
             starlark_err!(
                 SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE,
@@ -539,7 +540,7 @@ starlark_module! {global =>
             for item in symmetric_difference.iter()? {
                 s.insert(HashedValue::new(item)?);
             }
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -570,7 +571,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     set.union(this, *others) {
-        let ret = Set::empty();
+        let ret = Set::new_value(Default::default());
         for el in this.iter()? {
             Set::insert_if_absent(&ret, el)?;
         }
@@ -609,6 +610,6 @@ starlark_module! {global =>
                 Set::insert_if_absent(&this, el)?;
             }
         }
-        ok!(None)
+        Ok(Value::new_imm(NoneValue))
     }
 }

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -52,7 +52,7 @@ starlark_module! {global =>
             &this,
             &|x: &mut LinkedHashMap<HashedValue, Value>| -> ValueResult {
                 x.clear();
-                ok!(None)
+                Ok(Value::new_imm(NoneValue))
             }
         )
     }
@@ -134,7 +134,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     dict.keys(this) {
-        let v : Vec<Value> = this.iter()?.collect();
+        let v : Vec<Value> = this.iter()?;
         ok!(v)
     }
 
@@ -323,7 +323,7 @@ starlark_module! {global =>
                         "list of non-pairs".to_owned()
                     )
                 }
-                this.set_at(v.at(Value::new(0))?, v.at(Value::new(1))?)?;
+                this.set_at(v.at(Value::new_imm(0))?, v.at(Value::new_imm(1))?)?;
             },
             "dict" => for k in pairs.iter()? {
                 this.set_at(k.clone(), pairs.at(k)?)?
@@ -344,7 +344,7 @@ starlark_module! {global =>
         for (k, v) in kwargs {
             this.set_at(k.into(), v)?;
         }
-        ok!(None)
+        Ok(Value::new_imm(NoneValue))
     }
 
     /// [dict.values](

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -55,7 +55,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &|x| {
             x.push(el.clone()?);
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -80,7 +80,7 @@ starlark_module! {global =>
     list.clear(this) {
         list::List::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -109,10 +109,11 @@ starlark_module! {global =>
     /// ```
     list.extend(this, #other) {
         let this_cloned = this.clone();
-        let other_cloned: Result<Vec<_>, _>  = other.iter()?.map(|v| v.clone_for_container_value(&this_cloned)).collect();
+        let other_cloned: Result<Vec<_>, _>  = other.iter()?.into_iter()
+            .map(|v| v.clone_for_container_value(&this_cloned)).collect();
         list::List::mutate(&this, &|x| {
             x.extend(other_cloned.clone()?);
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -147,7 +148,7 @@ starlark_module! {global =>
     /// ```
     list.index(this, #needle, #start = 0, #end = None) {
         convert_indices!(this, start, end);
-        let mut it = this.iter()?.skip(start).take(end - start);
+        let mut it = this.iter()?.into_iter().skip(start).take(end - start);
         if let Some(offset) = it.position(|x| x == needle) {
             ok!((offset + start) as i64)
         } else {
@@ -189,7 +190,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &move |x| {
             x.insert(index, el.clone()?);
-            ok!(None)
+            Ok(Value::new_imm(NoneValue))
         })
     }
 
@@ -260,11 +261,11 @@ starlark_module! {global =>
     /// ```
     list.remove(this, #needle) {
         let for_it = this.clone();
-        let mut it = for_it.iter()?;
+        let mut it = for_it.iter()?.into_iter();
         if let Some(offset) = it.position(|x| x == needle) {
             list::List::mutate(&this, &|x| {
                 x.remove(offset);
-                ok!(None)
+                Ok(Value::new_imm(NoneValue))
             })
         } else {
             starlark_err!(

--- a/starlark/src/stdlib/macros.rs
+++ b/starlark/src/stdlib/macros.rs
@@ -270,14 +270,14 @@ macro_rules! starlark_signatures {
 ///     // #a argument will be binded to a `a` Rust value, the '#' prevent the argument from
 ///     // being used by name when calling the method.
 ///     __str__(#a) {
-///       Ok(Value::new(a.to_str().to_owned()))
+///       Ok(Value::new_imm(a.to_str().to_owned()))
 ///     }
 ///
 ///     // Declare a function my_fun that takes one positional parameter 'a', a named and
 ///     // positional parameter 'b', a args array 'args' and a keyword dictionary `kwargs`
 ///     my_fun(#a, b, c = 1, *args, **kwargs) {
 ///       // ...
-/// # Ok(Value::new(true))
+/// # Ok(Value::new_imm(true))
 ///     }
 ///
 ///     // It is also possible to capture the calling environment with `env name`
@@ -309,8 +309,8 @@ macro_rules! starlark_signatures {
 /// # use starlark::values::*;
 /// # use starlark::environment::Environment;
 /// # starlark_module!{ my_starlark_module =>
-/// #     __str__(#a) { Ok(Value::new(a.to_str().to_owned())) }
-/// #     my_fun(#a, b, c = 1, *args, **kwargs) { Ok(Value::new(true)) }
+/// #     __str__(#a) { Ok(Value::new_imm(a.to_str().to_owned())) }
+/// #     my_fun(#a, b, c = 1, *args, **kwargs) { Ok(Value::new_imm(true)) }
 /// # }
 /// # fn main() {
 /// #    let env =
@@ -332,7 +332,7 @@ macro_rules! starlark_signatures {
 ///     // The first argument is always self in that module but we use "this" because "self" is a
 ///     // a rust keyword.
 ///     string.hello(this) {
-///        Ok(Value::new(
+///        Ok(Value::new_imm(
 ///            format!("Hello, {}", this.to_str())
 ///        ))
 ///     }

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -800,7 +800,7 @@ starlark_module! {global =>
     string.join(this, #to_join) {
         let this = this.to_str();
         ok!(
-            to_join.iter()?.fold(
+            to_join.iter()?.into_iter().fold(
                 Ok(String::new()),
                 |a, x| {
                     check_string!(x, join);
@@ -1379,8 +1379,8 @@ mod tests {
     #[test]
     fn test_format_capture() {
         let args = Value::from(vec!["1", "2", "3"]);
-        let mut kwargs = dict::Dictionary::new();
-        let mut it = args.iter().unwrap();
+        let mut kwargs = dict::Dictionary::new_value(Default::default());
+        let mut it = args.iter().unwrap().into_iter();
         let mut captured_by_index = false;
         let mut captured_by_order = false;
 
@@ -1457,7 +1457,7 @@ mod tests {
         )
         .is_err());
         captured_by_order = false;
-        it = args.iter().unwrap();
+        it = args.iter().unwrap().into_iter();
         assert_eq!(
             format_capture(
                 "{1",

--- a/starlark/src/values/immutable.rs
+++ b/starlark/src/values/immutable.rs
@@ -1,0 +1,284 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common data struct for immutable types.
+
+use crate::environment::Environment;
+use crate::values::{default_compare, TypedValue, Value, ValueError, ValueResult};
+use linked_hash_map::LinkedHashMap;
+use std::any::Any;
+use std::cmp::Ordering;
+
+/// Common interface for mutable and immutable operations.
+pub trait ReadableContent: Sized + 'static {
+    fn get_type() -> &'static str;
+
+    /// Return a list of values to be used in freeze or descendant check operations.
+    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a>;
+
+    fn to_repr(&self) -> String;
+
+    fn to_str(&self) -> String {
+        // Delegate to repr by default
+        self.to_repr()
+    }
+
+    fn to_bool(&self) -> bool;
+
+    fn to_int(&self) -> Result<i64, ValueError>;
+
+    fn at(&self, index: Value) -> ValueResult;
+
+    fn slice(
+        &self,
+        start: Option<Value>,
+        stop: Option<Value>,
+        stride: Option<Value>,
+    ) -> ValueResult;
+
+    fn length(&self) -> Result<i64, ValueError>;
+
+    fn get_hash(&self) -> Result<u64, ValueError>;
+
+    fn is_in(&self, other: &Value) -> Result<bool, ValueError>;
+
+    fn iter(&self) -> Result<Vec<Value>, ValueError>;
+
+    fn plus(&self) -> ValueResult;
+    fn minus(&self) -> ValueResult;
+
+    fn add(&self, other: &Self) -> Result<Self, ValueError>;
+    fn sub(&self, other: &Self) -> Result<Self, ValueError>;
+    fn div(&self, other: &Self) -> Result<Self, ValueError>;
+    fn floor_div(&self, other: &Self) -> Result<Self, ValueError>;
+    fn mul(&self, other: Value) -> ValueResult;
+    fn pipe(&self, other: Value) -> ValueResult;
+
+    fn dir_attr(&self) -> Result<Vec<String>, ValueError>;
+    fn has_attr(&self, _attribute: &str) -> Result<bool, ValueError>;
+    fn get_attr(&self, attribute: &str) -> ValueResult;
+
+    fn percent(&self, other: Value) -> ValueResult;
+
+    fn compare(&self, other: &Self, recursion: u32) -> Result<Ordering, ValueError>;
+
+    fn call(
+        &self,
+        call_stack: &[(String, String)],
+        env: Environment,
+        positional: Vec<Value>,
+        named: LinkedHashMap<String, Value>,
+        args: Option<Value>,
+        kwargs: Option<Value>,
+    ) -> ValueResult;
+}
+
+pub trait ImmutableContent: ReadableContent {}
+
+pub struct Immutable<D: ImmutableContent> {
+    pub content: D,
+}
+
+impl<D: ImmutableContent + Default> Default for Immutable<D> {
+    fn default() -> Immutable<D> {
+        Immutable::new(Default::default())
+    }
+}
+
+impl<D: ImmutableContent> Immutable<D> {
+    pub fn new(content: D) -> Immutable<D> {
+        Immutable { content }
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new_value(value: D) -> Value
+    where
+        Self: TypedValue,
+    {
+        Value::new(Immutable { content: value })
+    }
+}
+
+impl<D: ImmutableContent> TypedValue for Immutable<D> {
+    fn immutable(&self) -> bool {
+        true
+    }
+
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut Any {
+        self
+    }
+
+    fn freeze(&self) {
+        for v in self.content.values_for_descendant_check_and_freeze() {
+            v.freeze();
+        }
+    }
+
+    fn freeze_for_iteration(&self) {}
+
+    fn unfreeze_for_iteration(&self) {}
+
+    fn to_str(&self) -> String {
+        self.content.to_str()
+    }
+
+    fn to_repr(&self) -> String {
+        self.content.to_repr()
+    }
+
+    fn get_type(&self) -> &'static str {
+        D::get_type()
+    }
+
+    fn to_bool(&self) -> bool {
+        self.content.to_bool()
+    }
+
+    fn to_int(&self) -> Result<i64, ValueError> {
+        self.content.to_int()
+    }
+
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        self.content.get_hash()
+    }
+
+    fn is_descendant(&self, other: &TypedValue) -> bool {
+        self.content
+            .values_for_descendant_check_and_freeze()
+            .any(|x| x.is_descendant(other))
+    }
+
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
+        match other.as_any().downcast_ref::<Self>() {
+            Some(other) => self.content.compare(&other.content, recursion),
+            None => default_compare(self, other),
+        }
+    }
+
+    fn call(
+        &self,
+        call_stack: &[(String, String)],
+        env: Environment,
+        positional: Vec<Value>,
+        named: LinkedHashMap<String, Value>,
+        args: Option<Value>,
+        kwargs: Option<Value>,
+    ) -> Result<Value, ValueError> {
+        self.content
+            .call(call_stack, env, positional, named, args, kwargs)
+    }
+
+    fn at(&self, index: Value) -> Result<Value, ValueError> {
+        self.content.at(index)
+    }
+
+    fn set_at(&self, index: Value, _new_value: Value) -> Result<(), ValueError> {
+        Err(ValueError::OperationNotSupported {
+            op: "[] =".to_owned(),
+            left: D::get_type().to_owned(),
+            right: Some(index.get_type().to_owned()),
+        })
+    }
+
+    fn slice(
+        &self,
+        start: Option<Value>,
+        stop: Option<Value>,
+        stride: Option<Value>,
+    ) -> Result<Value, ValueError> {
+        self.content.slice(start, stop, stride)
+    }
+
+    fn iter(&self) -> Result<Vec<Value>, ValueError> {
+        self.content.iter()
+    }
+
+    fn length(&self) -> Result<i64, ValueError> {
+        self.content.length()
+    }
+
+    fn get_attr(&self, attribute: &str) -> Result<Value, ValueError> {
+        self.content.get_attr(attribute)
+    }
+
+    fn has_attr(&self, attribute: &str) -> Result<bool, ValueError> {
+        self.content.has_attr(attribute)
+    }
+
+    fn set_attr(&self, attribute: &str, _new_value: Value) -> Result<(), ValueError> {
+        Err(ValueError::OperationNotSupported {
+            op: format!(".{} =", attribute),
+            left: D::get_type().to_owned(),
+            right: None,
+        })
+    }
+
+    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
+        self.content.dir_attr()
+    }
+
+    fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
+        self.content.is_in(other)
+    }
+
+    fn plus(&self) -> Result<Value, ValueError> {
+        self.content.plus()
+    }
+
+    fn minus(&self) -> Result<Value, ValueError> {
+        self.content.minus()
+    }
+
+    fn add(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| self.content.add(&other.content).map(Value::new_imm))
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn sub(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| self.content.sub(&other.content).map(Value::new_imm))
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn mul(&self, other: Value) -> Result<Value, ValueError> {
+        self.content.mul(other)
+    }
+
+    fn percent(&self, other: Value) -> Result<Value, ValueError> {
+        self.content.percent(other)
+    }
+
+    fn div(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| self.content.div(&other.content).map(Value::new_imm))
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn floor_div(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| {
+                self.content.floor_div(&other.content).map(Value::new_imm)
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn pipe(&self, other: Value) -> Result<Value, ValueError> {
+        self.content.pipe(other)
+    }
+}

--- a/starlark/src/values/mutable.rs
+++ b/starlark/src/values/mutable.rs
@@ -1,0 +1,334 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common data struct for mutable types.
+
+use crate::environment::Environment;
+use crate::values::immutable::ReadableContent;
+use crate::values::{default_compare, TypedValue, Value, ValueError, ValueResult};
+use linked_hash_map::LinkedHashMap;
+use std::any::Any;
+use std::cell::{Cell, RefCell};
+use std::cmp::Ordering;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+/// A helper enum for defining the level of mutability of an iterable.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+enum IterableMutability {
+    Mutable,
+    Immutable,
+    FrozenForIteration,
+}
+
+impl IterableMutability {
+    /// Tests the mutability value and return the appropriate error
+    ///
+    /// This method is to be called simply `mutability.test()?` to return
+    /// an error if the current container is no longer mutable.
+    pub fn test(self) -> Result<(), ValueError> {
+        match self {
+            IterableMutability::Mutable => Ok(()),
+            IterableMutability::Immutable => Err(ValueError::CannotMutateImmutableValue),
+            IterableMutability::FrozenForIteration => Err(ValueError::MutationDuringIteration),
+        }
+    }
+}
+
+/// Mutable object without common header.
+pub trait MutableContent: ReadableContent + Default {
+    /// Check if `set_at` is implemented for this type.
+    fn set_at_check(&self, index: &Value) -> Result<(), ValueError>;
+
+    fn set_at(&mut self, index: Value, new_value: Value) -> Result<(), ValueError>;
+
+    /// Check if `set_at` is implemented for this type.
+    fn set_attr_check(&self, attribute: &str) -> Result<(), ValueError>;
+
+    fn set_attr(&mut self, attribute: &str, new_value: Value) -> Result<(), ValueError>;
+}
+
+/// Common implementation of mutable data types list, dict and set.
+pub struct Mutable<D: MutableContent> {
+    mutability: Cell<IterableMutability>,
+    pub content: RefCell<D>,
+}
+
+impl<D: MutableContent> Default for Mutable<D> {
+    fn default() -> Mutable<D> {
+        Mutable::new(Default::default())
+    }
+}
+
+impl<D: MutableContent> Mutable<D> {
+    /// Freezes the current value, can be used when implementing the `freeze` function
+    /// of the [TypedValue] trait.
+    pub fn mutability_freeze(&self) {
+        self.mutability.set(IterableMutability::FrozenForIteration)
+    }
+
+    pub fn apply<Return>(
+        v: &Value,
+        f: &dyn Fn(&D) -> Result<Return, ValueError>,
+    ) -> Result<Return, ValueError>
+    where
+        Self: TypedValue,
+    {
+        v.downcast_apply(|x: &Self| -> Result<Return, ValueError> { f(x.content.borrow().deref()) })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    pub fn mutate(v: &Value, f: &Fn(&mut D) -> ValueResult) -> ValueResult
+    where
+        Self: TypedValue,
+    {
+        v.downcast_apply(|x: &Self| -> ValueResult {
+            x.mutability.get().test()?;
+            f(x.content.borrow_mut().deref_mut())
+        })
+        .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    pub fn new(content: D) -> Mutable<D> {
+        Mutable {
+            mutability: Cell::new(IterableMutability::Mutable),
+            content: RefCell::new(content),
+        }
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new_value(content: D) -> Value
+    where
+        Self: TypedValue,
+    {
+        Value::new(Mutable::new(content))
+    }
+}
+
+impl<D: MutableContent> TypedValue for Mutable<D> {
+    fn freeze(&self) {
+        self.mutability_freeze();
+        for v in self
+            .content
+            .borrow()
+            .values_for_descendant_check_and_freeze()
+        {
+            v.freeze();
+        }
+    }
+
+    fn immutable(&self) -> bool {
+        self.mutability.get() == IterableMutability::Immutable
+    }
+
+    fn freeze_for_iteration(&self) {
+        match self.mutability.get() {
+            IterableMutability::Immutable => {}
+            IterableMutability::FrozenForIteration => panic!("already frozen"),
+            IterableMutability::Mutable => {
+                self.mutability.set(IterableMutability::FrozenForIteration);
+            }
+        }
+    }
+
+    /// Unfreezes the current value for iterating over, to be used to implement the
+    /// `unfreeze_for_iteration` function of the [TypedValue] trait.
+    fn unfreeze_for_iteration(&self) {
+        match self.mutability.get() {
+            IterableMutability::Immutable => {}
+            IterableMutability::FrozenForIteration => {
+                self.mutability.set(IterableMutability::Mutable);
+            }
+            IterableMutability::Mutable => {
+                panic!("not fronzen");
+            }
+        }
+    }
+
+    fn to_str(&self) -> String {
+        self.content.borrow().to_str()
+    }
+
+    fn to_repr(&self) -> String {
+        self.content.borrow().to_repr()
+    }
+
+    fn get_type(&self) -> &'static str {
+        D::get_type()
+    }
+    fn to_bool(&self) -> bool {
+        self.content.borrow().to_bool()
+    }
+
+    fn compare(&self, other: &dyn TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
+        match other.as_any().downcast_ref::<Self>() {
+            Some(other) => self
+                .content
+                .borrow()
+                .compare(&other.content.borrow(), recursion),
+            None => default_compare(self, other),
+        }
+    }
+
+    fn at(&self, index: Value) -> ValueResult {
+        self.content.borrow().at(index)
+    }
+
+    fn length(&self) -> Result<i64, ValueError> {
+        self.content.borrow().length()
+    }
+
+    fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
+        self.content.borrow().is_in(other)
+    }
+
+    fn is_descendant(&self, other: &dyn TypedValue) -> bool {
+        let try_borrowed = self.content.try_borrow();
+        if let Ok(borrowed) = try_borrowed {
+            borrowed
+                .values_for_descendant_check_and_freeze()
+                .any(|x| x.is_descendant(other))
+        } else {
+            // We have already borrowed mutably this value, which means we are trying to mutate it, assigning other to it.
+            true
+        }
+    }
+
+    fn iter(&self) -> Result<Vec<Value>, ValueError> {
+        self.content.borrow().iter()
+    }
+
+    fn set_at(&self, index: Value, new_value: Value) -> Result<(), ValueError> {
+        self.content.borrow().set_at_check(&index)?;
+        self.mutability.get().test()?;
+        let new_value = new_value.clone_for_container(self)?;
+        self.content.borrow_mut().set_at(index, new_value)
+    }
+
+    fn add(&self, other: Value) -> ValueResult {
+        other
+            .downcast_apply(|other: &Self| {
+                let sum = self.content.borrow().add(&other.content.borrow())?;
+                Ok(Value::new(Mutable::new(sum)))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn mul(&self, other: Value) -> ValueResult {
+        self.content.borrow().mul(other)
+    }
+
+    fn slice(
+        &self,
+        start: Option<Value>,
+        stop: Option<Value>,
+        stride: Option<Value>,
+    ) -> Result<Value, ValueError> {
+        self.content.borrow().slice(start, stop, stride)
+    }
+
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        self.content.borrow().get_hash()
+    }
+
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut Any {
+        self
+    }
+
+    fn to_int(&self) -> Result<i64, ValueError> {
+        self.content.borrow().to_int()
+    }
+
+    fn call(
+        &self,
+        call_stack: &[(String, String)],
+        env: Environment,
+        positional: Vec<Value>,
+        named: LinkedHashMap<String, Value>,
+        args: Option<Value>,
+        kwargs: Option<Value>,
+    ) -> Result<Value, ValueError> {
+        self.content
+            .borrow()
+            .call(call_stack, env, positional, named, args, kwargs)
+    }
+
+    fn get_attr(&self, attribute: &str) -> Result<Value, ValueError> {
+        self.content.borrow().get_attr(attribute)
+    }
+
+    fn has_attr(&self, attribute: &str) -> Result<bool, ValueError> {
+        self.content.borrow().has_attr(attribute)
+    }
+
+    fn set_attr(&self, attribute: &str, new_value: Value) -> Result<(), ValueError> {
+        self.content.borrow_mut().set_attr_check(attribute)?;
+        let new_value = new_value.clone_for_container(self)?;
+        self.content.borrow_mut().set_attr(attribute, new_value)
+    }
+
+    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
+        self.content.borrow().dir_attr()
+    }
+
+    fn plus(&self) -> Result<Value, ValueError> {
+        self.content.borrow().plus()
+    }
+
+    fn minus(&self) -> Result<Value, ValueError> {
+        self.content.borrow().minus()
+    }
+
+    fn sub(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| {
+                Ok(Value::new(Mutable::new(
+                    self.content.borrow().sub(&other.content.borrow())?,
+                )))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn percent(&self, other: Value) -> Result<Value, ValueError> {
+        self.content.borrow().percent(other)
+    }
+
+    fn div(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| {
+                Ok(Mutable::new_value(
+                    self.content.borrow().div(&other.content.borrow())?,
+                ))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn floor_div(&self, other: Value) -> Result<Value, ValueError> {
+        other
+            .downcast_apply(|other: &Self| {
+                Ok(Mutable::new_value(
+                    self.content.borrow().floor_div(&other.content.borrow())?,
+                ))
+            })
+            .unwrap_or(Err(ValueError::IncorrectParameterType))
+    }
+
+    fn pipe(&self, other: Value) -> Result<Value, ValueError> {
+        self.content.borrow().pipe(other)
+    }
+}

--- a/starlark/tests/rust-testcases/bool.sky
+++ b/starlark/tests/rust-testcases/bool.sky
@@ -1,3 +1,3 @@
 # Boolean tests
 
-True + 9223372036854775807   ###  + not supported
+True + 9223372036854775807   ###  Type of parameters mismatch


### PR DESCRIPTION
`Value` is `Rc<TypedValue>` now.

This is done mainly to avoid (potentially panicking) borrow calls
in functions which do not need to access data, e. g. `get_type` or
`freeze_for_iteration`.

Also it should be a bit cheaper now, because borrows/unborrows no
longer happen for immutable types like `int` or `string`.

Two traits and two structs introduced:

```
// to be implemented by immutable types
trait ImmutableContent {}
// to be implemented by mutable types
trait MutableContent {}

struct Immutable<D: ImmutableContent> { content: D }
struct Mutable<D: MutableContent> { content: RefCell<D>, mutability: ... }
```

`TypedValue` is implemented now by `Mutable` and `Immutable` structs
only, and type providers should implement `ImmtableContent` and
`MutableContent` traits.

`Value::iter()` and `TypedValue::iter()` now return `Vec<Value>`
instead of iterator. This practually changes nothing because
previously `Value::iter()` was collecting values to `Vec` before
returning an iterator. But we need to figure out how to return
proper iterator from `iter()` functions.