### PR TITLE
Fix line numbers in test output

### DIFF
--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -33,7 +33,7 @@ fn read_input(path: &str) -> Vec<(usize, String)> {
         .split("\n---\n")
         .map(|x| (0, x.to_owned()))
         .collect();
-    let mut idx = 1;
+    let mut idx = 0;
     for mut el in &mut v {
         el.0 = idx;
         idx += el.1.chars().filter(|x| *x == '\n').count() + 2 // 2 = separator new lines


### PR DESCRIPTION
Without this commit line numbers start with 2.

With this commit:

```
% cat tests/rust-testcases/tmp.sky
l[0]
```

```
% cargo test --test rust_tests test_tmp
...
error[CM01]: Variable 'l' not found
 --> /Users/nga/devel/left/starlark-rust/starlark/tests/rust-testcases/tmp.sky:1:1
  |
1 | l[0]
  | ^ Variable was not found

test test_tmp ... FAILED
...
```

So first line has line number 1 now.