### PR TITLE
Prohibit arithmetic operations on bool

### DIFF
--- a/starlark/tests/rust-testcases/bool.sky
+++ b/starlark/tests/rust-testcases/bool.sky
@@ -1,3 +1,3 @@
 # Boolean tests
 
-True + 9223372036854775807   ###  Integer overflow
+True + 9223372036854775807   ###  + not supported


### PR DESCRIPTION
The Starlark spec does not define arithmetic operations on bool
parameters: https://git.io/fjnV4

Both Go and Java implementations do not allow arithmetic operations
on bool parameters too.

Python though converts bool to int the same way Starlark Rust did
before this commit.