### PR TITLE
Implement struct builtin

### DIFF
--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -16,7 +16,7 @@
 
 use getopts::Options;
 use starlark::eval::interactive::{eval, eval_file, EvalError};
-use starlark::stdlib::global_environment;
+use starlark::stdlib::{global_environment, structs};
 use starlark::syntax::dialect::Dialect;
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
@@ -84,7 +84,10 @@ fn main() {
                 }
 
                 let global = print_function(global_environment());
+                // `struct` is not a part of the Starlark spec, but may be useful in REPL.
+                let global = structs::global(global);
                 global.freeze();
+
                 let dialect = if build_file {
                     Dialect::Build
                 } else {

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -41,6 +41,7 @@ pub mod macros;
 pub mod dict;
 pub mod list;
 pub mod string;
+pub mod structs;
 
 starlark_module! {global_functions =>
     /// fail: fail the execution
@@ -963,7 +964,9 @@ fn add_set(env: Environment) -> Environment {
 #[doc(hidden)]
 pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    let mut env = global_environment().freeze().child("test");
+    let env = global_environment();
+    let env = structs::global(env);
+    let mut env = env.freeze().child("test");
     match eval(&map, "<test>", snippet, Dialect::Bzl, &mut env) {
         Ok(v) => Ok(v.to_bool()),
         Err(d) => {

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -1,0 +1,152 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of `struct` function.
+
+use crate::values::*;
+use linked_hash_map::LinkedHashMap;
+use std::cmp::Ordering;
+
+/// `struct()` implementation.
+pub struct StarlarkStruct {
+    fields: LinkedHashMap<String, Value>,
+}
+
+impl TypedValue for StarlarkStruct {
+    any!();
+
+    fn immutable(&self) -> bool {
+        true
+    }
+
+    fn freeze(&mut self) {
+        for x in self.fields.values() {
+            x.clone().freeze();
+        }
+    }
+
+    not_supported!(freeze_for_iteration);
+
+    fn to_str(&self) -> String {
+        self.to_repr()
+    }
+
+    fn to_repr(&self) -> String {
+        let mut r = "struct(".to_owned();
+        for (i, (name, value)) in self.fields.iter().enumerate() {
+            if i != 0 {
+                r.push_str(", ");
+            }
+            r.push_str(&name);
+            r.push_str("=");
+            r.push_str(&value.to_repr());
+        }
+        r.push_str(")");
+        r
+    }
+
+    fn get_type(&self) -> &'static str {
+        "struct"
+    }
+
+    fn to_bool(&self) -> bool {
+        true
+    }
+
+    fn is_descendant(&self, other: &TypedValue) -> bool {
+        self.fields
+            .values()
+            .any(|x| x.same_as(other) || x.is_descendant(other))
+    }
+
+    fn get_attr(&self, attribute: &str) -> Result<Value, ValueError> {
+        match self.fields.get(attribute) {
+            Some(v) => Ok(v.clone()),
+            None => Err(ValueError::OperationNotSupported {
+                op: attribute.to_owned(),
+                left: self.to_repr(),
+                right: None,
+            }),
+        }
+    }
+
+    fn has_attr(&self, attribute: &str) -> Result<bool, ValueError> {
+        Ok(self.fields.contains_key(attribute))
+    }
+
+    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
+        Ok(self.fields.keys().cloned().collect())
+    }
+
+    fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
+        match other.as_any().downcast_ref::<StarlarkStruct>() {
+            Some(other) => {
+                let mut self_keys: Vec<_> = self.fields.keys().collect();
+                let mut other_keys: Vec<_> = other.fields.keys().collect();
+                self_keys.sort();
+                other_keys.sort();
+                let mut self_keys = self_keys.into_iter();
+                let mut other_keys = other_keys.into_iter();
+                loop {
+                    match (self_keys.next(), other_keys.next()) {
+                        (None, None) => return Ok(Ordering::Equal),
+                        (None, Some(_)) => return Ok(Ordering::Less),
+                        (Some(_), None) => return Ok(Ordering::Greater),
+                        (Some(s_k), Some(o_k)) => {
+                            let s_v = self.fields.get(s_k).unwrap();
+                            let o_v = other.fields.get(o_k).unwrap();
+                            match s_v.compare(o_v, recursion + 1)? {
+                                Ordering::Equal => continue,
+                                ordering => return Ok(ordering),
+                            }
+                        }
+                    }
+                }
+            }
+            None => default_compare(self, other),
+        }
+    }
+
+    not_supported!(binop);
+    not_supported!(is_in, call);
+    not_supported!(set_attr);
+    not_supported!(iter, length, slice, set_at, at, get_hash, to_int);
+}
+
+starlark_module! { global =>
+    /// Creates a struct.
+    ///
+    /// `struct` creates a struct. It accepts keyword arguments, keys become struct field names,
+    /// and values become field values.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default("(
+    /// struct(host='localhost', port=80).port == 80
+    /// # )").unwrap());
+    /// # assert!(starlark_default("(
+    /// dir(struct(host='localhost', port=80)) == ['host', 'port']
+    /// # )").unwrap());
+    /// # assert!(starlark_default("(
+    /// dir(struct()) == []
+    /// # )").unwrap());
+    /// ```
+    struct_(**kwargs) {
+        Ok(Value::new(StarlarkStruct {
+            fields: kwargs
+        }))
+    }
+}

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -41,6 +41,10 @@ impl Dictionary {
         Value::new(Dictionary::new_typed())
     }
 
+    pub fn get_content(&self) -> &LinkedHashMap<HashedValue, Value> {
+        &self.content
+    }
+
     pub fn apply<Return>(
         v: &Value,
         f: &dyn Fn(&LinkedHashMap<HashedValue, Value>) -> Result<Return, ValueError>,

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -862,7 +862,7 @@ macro_rules! not_supported {
     };
     // Special type: iterable, sequence, indexable, container, function
     (iterable) => { not_supported!(iter, freeze_for_iteration); };
-    (sequence) => { not_supported!(length, is_in); };
+    (sequence) => { not_supported!(length, is_in, is_descendant); };
     (set_indexable) => { not_supported!(set_at); };
     (indexable) => { not_supported!(slice, at, set_indexable); };
     (attr) => { not_supported!(get_attr, has_attr, set_attr, dir_attr); };
@@ -878,7 +878,8 @@ macro_rules! not_supported {
                 left: other.get_type().to_owned(),
                 right: Some(self.get_type().to_owned()) })
         }
-        // We cannot have descendant if the is_in operation is not defined
+    };
+    (is_descendant) => {
         fn is_descendant(&self, _other: &dyn TypedValue) -> bool { false }
     };
     (add) => {

--- a/starlark/tests/go-testcases/struct.sky
+++ b/starlark/tests/go-testcases/struct.sky
@@ -1,0 +1,20 @@
+# Tests of Starlark 'struct' extension.
+# This is not a standard feature and the Go and Starlark APIs may yet change.
+
+assert_(str(struct), "<built-in function struct>")
+
+# struct is a constructor for "unbranded" structs.
+s = struct(host = "localhost", port = 80)
+assert_(s, s)
+assert_(s, struct(host = "localhost", port = 80))
+assert_(s != struct(host = "localhost", port = 81))
+assert_(type(s), "struct")
+assert_(str(s), 'struct(host = "localhost", port = 80)')
+assert_(s.host, "localhost")
+assert_(s.port, 80)
+s.protocol  ###   protocol
+---
+s = struct(host = "localhost", port = 80)
+assert_(dir(s), ["host", "port"])
+
+# The rest are tests for `gensym` which is not implemented

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -17,7 +17,7 @@
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::simple::eval;
-use starlark::stdlib::global_environment;
+use starlark::stdlib::{global_environment, structs};
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, Write};
@@ -76,6 +76,7 @@ fn assert_diagnostic(
 fn run_conformance_test(path: &str) -> bool {
     let map = Arc::new(Mutex::new(CodeMap::new()));
     let global = global_environment();
+    let global = structs::global(global);
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     eval(


### PR DESCRIPTION
`struct` builtin exists as extension in Go and Java implementations
of Starlark.

Go: https://git.io/fjnwl
Java: https://git.io/fjnwR

This diff makes it always available, but it need be hidden by the
flag because it is not in the spec.