### PR TITLE
* and ** args now mapped to Vec and LinkedHashMap in macros

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -87,7 +87,7 @@ starlark_module! {print_function =>
     print(*args) {
         let mut r = String::new();
         let mut first = true;
-        for arg in args.iter()? {
+        for arg in args {
             if !first {
                 r.push_str(" ");
             }

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -26,12 +26,12 @@ use crate::syntax::errors::SyntaxError;
 use crate::syntax::lexer::{LexerIntoIter, LexerItem};
 use crate::syntax::parser::{parse, parse_file, parse_lexer};
 use crate::values::dict::Dictionary;
-use crate::values::function::FunctionParameter;
+use crate::values::function::{FunctionArg, FunctionParameter};
 use crate::values::*;
 use codemap::{CodeMap, Span, Spanned};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
+use linked_hash_map::LinkedHashMap;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 macro_rules! eval_vector {
@@ -348,7 +348,7 @@ fn eval_call<T: FileLoader + 'static>(
     context: &mut EvaluationContext<T>,
 ) -> EvalResult {
     let npos = eval_vector!(pos, context);
-    let mut nnamed = HashMap::new();
+    let mut nnamed = LinkedHashMap::new();
     for &(ref k, ref v) in named.iter() {
         nnamed.insert(k.eval(context)?.to_str(), v.eval(context)?);
     }
@@ -884,7 +884,7 @@ pub fn eval_def(
     signature: &[FunctionParameter],
     stmts: &AstStatement,
     env: Environment,
-    args: Vec<Value>,
+    args: Vec<FunctionArg>,
     map: Arc<Mutex<CodeMap>>,
 ) -> ValueResult {
     // argument binding
@@ -895,7 +895,7 @@ pub fn eval_def(
             | FunctionParameter::WithDefaultValue(ref v, ..)
             | FunctionParameter::ArgsArray(ref v)
             | FunctionParameter::KWArgsDict(ref v) => {
-                if let Err(x) = env.set(v, it2.next().unwrap().clone()) {
+                if let Err(x) = env.set(v, it2.next().unwrap().clone().into()) {
                     return Err(x.into());
                 }
             }

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -155,7 +155,7 @@ starlark_module! {global =>
         let ret = Set::empty();
         for el in this.iter()? {
             let mut is_in_any_other = false;
-            for other in others.iter()? {
+            for other in &others {
                 if other.is_in(&el)?.to_bool() {
                     is_in_any_other = true;
                     break;
@@ -260,7 +260,7 @@ starlark_module! {global =>
         let ret = Set::empty();
         for el in this.iter()? {
             let mut is_in_every_other = true;
-            for other in others.iter()? {
+            for other in &others {
                 if !other.is_in(&el)?.to_bool() {
                     is_in_every_other = false;
                     break;
@@ -574,7 +574,7 @@ starlark_module! {global =>
         for el in this.iter()? {
             Set::insert_if_absent(&ret, el)?;
         }
-        for other in others.iter()? {
+        for other in others {
             for el in other.iter()? {
                 Set::insert_if_absent(&ret, el)?;
             }
@@ -604,7 +604,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     set.update(this, *others) {
-        for other in others.iter()? {
+        for other in others {
             for el in other.iter()? {
                 Set::insert_if_absent(&this, el)?;
             }

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -341,8 +341,8 @@ starlark_module! {global =>
             )
         }
 
-        for k in kwargs.iter()? {
-            this.set_at(k.clone(), kwargs.at(k)?)?
+        for (k, v) in kwargs {
+            this.set_at(k.into(), v)?;
         }
         ok!(None)
     }

--- a/starlark/src/stdlib/macros.rs
+++ b/starlark/src/stdlib/macros.rs
@@ -83,27 +83,27 @@ macro_rules! starlark_signature_extraction {
     ($args:ident $call_stack:ident $env:ident env $e:ident ) => { let $e = $env; };
     ($args:ident $call_stack:ident $env:ident * $t:ident) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_args_array()?;
     };
     ($args:ident $call_stack:ident $env:ident ** $t:ident) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_kw_args_dict()?;
     };
     ($args:ident $call_stack:ident $env:ident # $t:ident) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
     };
     ($args:ident $call_stack:ident $env:ident $t:ident) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
     };
     ($args:ident $call_stack:ident $env:ident # $t:ident = $e:expr) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
     };
     ($args:ident $call_stack:ident $env:ident $t:ident = $e:expr) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
     };
     ($args:ident $call_stack:ident $env:ident call_stack $e:ident, $($rest:tt)*) => {
         let $e = $call_stack;
@@ -115,32 +115,32 @@ macro_rules! starlark_signature_extraction {
     };
     ($args:ident $call_stack:ident $env:ident * $t:ident, $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_args_array()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident ** $t:ident,  $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_kw_args_dict()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident # $t:ident, $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident $t:ident, $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident # $t:ident = $e:expr, $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident $t:ident = $e:expr, $($rest:tt)* ) => {
         #[allow(unused_mut)]
-        let mut $t = $args.next().unwrap();
+        let mut $t = $args.next().unwrap().into_normal()?;
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
 }
@@ -153,9 +153,9 @@ macro_rules! starlark_fun {
         pub fn $fn(
             __call_stack: &[(String, String)],
             __env: $crate::environment::Environment,
-            args: Vec<$crate::values::Value>
+            args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
-            let mut __args = args.iter();
+            let mut __args = args.into_iter();
             starlark_signature_extraction!(__args __call_stack __env $($signature)*);
             $($content)*
         }
@@ -165,7 +165,7 @@ macro_rules! starlark_fun {
         pub fn $fn(
             __call_stack: &[(String, String)],
             __env: $crate::environment::Environment,
-            args: Vec<$crate::values::Value>
+            args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
             let mut __args = args.into_iter();
             starlark_signature_extraction!(__args __call_stack __env $($signature)*);
@@ -180,7 +180,7 @@ macro_rules! starlark_fun {
         pub fn $fn(
             __call_stack: &[(String, String)],
             __env: $crate::environment::Environment,
-            args: Vec<$crate::values::Value>
+            args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
             let mut __args = args.into_iter();
             starlark_signature_extraction!(__args __call_stack __env $($signature)*);
@@ -193,7 +193,7 @@ macro_rules! starlark_fun {
         pub fn $fn(
             __call_stack: &[(String, String)],
             __env: $crate::environment::Environment,
-            args: Vec<$crate::values::Value>
+            args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
             let mut __args = args.into_iter();
             starlark_signature_extraction!(__args __call_stack __env $($signature)*);

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -15,6 +15,7 @@
 //! Methods for the `string` type.
 
 use crate::values::*;
+use std::convert::TryFrom;
 use std::str::FromStr;
 
 // Errors -- UF = User Failure -- Failure that should be expected by the user (e.g. from a fail()).
@@ -431,7 +432,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     string.format(this, *args, **kwargs) {
-        let mut it = args.iter()?;
+        let mut it = args.iter().cloned();
         let this = this.to_str();
         let mut captured_by_index = false;
         let mut captured_by_order = false;
@@ -465,8 +466,8 @@ starlark_module! {global =>
                         &mut it,
                         &mut captured_by_index,
                         &mut captured_by_order,
-                        &args,
-                        &kwargs)?;
+                        &Value::from(args.clone()),
+                        &Value::try_from(kwargs.clone()).unwrap())?;
                     capture.clear();
                 },
                 (.., "}") => starlark_err!(

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -500,7 +500,7 @@ pub trait TypedValue {
         call_stack: &[(String, String)],
         env: Environment,
         positional: Vec<Value>,
-        named: HashMap<String, Value>,
+        named: LinkedHashMap<String, Value>,
         args: Option<Value>,
         kwargs: Option<Value>,
     ) -> ValueResult;
@@ -775,7 +775,7 @@ macro_rules! not_supported {
     };
     (call) => {
         fn call(&self, _call_stack: &[(String, String)], _env: $crate::environment::Environment,
-                _positional: Vec<$crate::values::Value>, _named: ::std::collections::HashMap<String, $crate::values::Value>,
+                _positional: Vec<$crate::values::Value>, _named: ::linked_hash_map::LinkedHashMap<String, $crate::values::Value>,
                 _args: Option<$crate::values::Value>, _kwargs: Option<$crate::values::Value>) -> $crate::values::ValueResult {
             Err($crate::values::ValueError::OperationNotSupported {
                 op: "call()".to_owned(), left: self.get_type().to_owned(), right: None })
@@ -1147,7 +1147,7 @@ impl Value {
         call_stack: &[(String, String)],
         env: Environment,
         positional: Vec<Value>,
-        named: HashMap<String, Value>,
+        named: LinkedHashMap<String, Value>,
         args: Option<Value>,
         kwargs: Option<Value>,
     ) -> ValueResult {


### PR DESCRIPTION
* `*args` in macros now have type `Vec<Value>`
* `**kargs` in macros now have type `LinkedHashMap<String, Value>`

In a couple of functions `HashMap<String, Value>` was replaced with
`LinkedHashMap<String, Value>` and as a side effect this code:

```
def f(**kwargs): print(kwargs)

f(a=1, b=2, c=3)
```

is now deterministic and always outputs:

```
{"a": 1, "b": 2, "c": 3}
```