### PR TITLE
Optional parameters in native functions

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -903,6 +903,9 @@ pub fn eval_def(
                     return Err(x.into());
                 }
             }
+            FunctionParameter::Optional(..) => {
+                unreachable!("optional parameters only exist in native functions")
+            }
         }
     }
     let mut ctx = EvaluationContext {

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -35,9 +35,9 @@ starlark_module! {global =>
     /// iterable sequence x.
     ///
     /// With no argument, `set()` returns a new empty set.
-    set(#a = None) {
+    set(?#a) {
         let s = Set::empty();
-        if a.get_type() != "NoneType" {
+        if let Some(a) = a {
             for x in a.iter()? {
                 Set::insert_if_absent(&s, x)?;
             }

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -217,11 +217,10 @@ starlark_module! {global =>
     /// x == [1]
     /// # )"#).unwrap());
     /// ```
-    list.pop(this, #index = None) {
-        let index = if index.get_type() == "NoneType" {
-            this.length()? - 1
-        } else {
-            index.to_int()?
+    list.pop(this, ?#index) {
+        let index = match index {
+            Some(index) => index.to_int()?,
+            None => this.length()? - 1,
         };
         if index < 0 || index >= this.length()? {
             return Err(ValueError::IndexOutOfBound(index));

--- a/starlark/src/stdlib/macros.rs
+++ b/starlark/src/stdlib/macros.rs
@@ -30,6 +30,12 @@ macro_rules! starlark_signature {
     ($signature:ident # $t:ident) => {
         $signature.push($crate::values::function::FunctionParameter::Normal(format!("${}", stringify!($t))));
     };
+    ($signature:ident ? $t:ident) => {
+        $signature.push($crate::values::function::FunctionParameter::Optional(stringify!($t).to_owned()));
+    };
+    ($signature:ident ? # $t:ident) => {
+        $signature.push($crate::values::function::FunctionParameter::Optional(format!("${}", stringify!($t))));
+    };
     ($signature:ident $t:ident) => {
         $signature.push($crate::values::function::FunctionParameter::Normal(stringify!($t).to_owned()));
     };
@@ -64,6 +70,12 @@ macro_rules! starlark_signature {
     ($signature:ident # $t:ident, $($rest:tt)* ) => {
         starlark_signature!($signature # $t); starlark_signature!($signature $($rest)*);
     };
+    ($signature:ident ? $t:ident, $($rest:tt)* ) => {
+        starlark_signature!($signature ? $t); starlark_signature!($signature $($rest)*);
+    };
+    ($signature:ident ? # $t:ident, $($rest:tt)* ) => {
+        starlark_signature!($signature ? # $t); starlark_signature!($signature $($rest)*);
+    };
     ($signature:ident $t:ident, $($rest:tt)* ) => {
         starlark_signature!($signature $t); starlark_signature!($signature $($rest)*);
     };
@@ -92,6 +104,14 @@ macro_rules! starlark_signature_extraction {
     ($args:ident $call_stack:ident $env:ident # $t:ident) => {
         #[allow(unused_mut)]
         let mut $t = $args.next().unwrap().into_normal()?;
+    };
+    ($args:ident $call_stack:ident $env:ident ? $t:ident) => {
+        #[allow(unused_mut)]
+        let mut $t = $args.next().unwrap().into_optional()?;
+    };
+    ($args:ident $call_stack:ident $env:ident ? # $t:ident) => {
+        #[allow(unused_mut)]
+        let mut $t = $args.next().unwrap().into_optional()?;
     };
     ($args:ident $call_stack:ident $env:ident $t:ident) => {
         #[allow(unused_mut)]
@@ -123,6 +143,14 @@ macro_rules! starlark_signature_extraction {
     };
     ($args:ident $call_stack:ident $env:ident # $t:ident, $($rest:tt)* ) => {
         starlark_signature_extraction!($args $call_stack $env # $t);
+        starlark_signature_extraction!($args $call_stack $env $($rest)*);
+    };
+    ($args:ident $call_stack:ident $env:ident ? $t:ident, $($rest:tt)* ) => {
+        starlark_signature_extraction!($args $call_stack $env ? $t);
+        starlark_signature_extraction!($args $call_stack $env $($rest)*);
+    };
+    ($args:ident $call_stack:ident $env:ident ? # $t:ident, $($rest:tt)* ) => {
+        starlark_signature_extraction!($args $call_stack $env ? # $t);
         starlark_signature_extraction!($args $call_stack $env $($rest)*);
     };
     ($args:ident $call_stack:ident $env:ident $t:ident, $($rest:tt)* ) => {

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -913,15 +913,14 @@ starlark_module! {global =>
     /// "banana".replace("a", "o", 2)	 == "bonona"
     /// # )"#).unwrap());
     /// ```
-    string.replace(this, #old, #new, #count = None) {
+    string.replace(this, #old, #new, ?#count) {
         check_string!(old, replace);
         check_string!(new, replace);
         let (this, old, new) = (this.to_str(), old.to_str(), new.to_str());
         ok!(
-            if count.get_type() == "NoneType" {
-                this.replace(old.as_str(), new.as_str())
-            } else {
-                this.replacen(old.as_str(), new.as_str(), count.to_int()? as usize)
+            match count {
+                None => this.replace(old.as_str(), new.as_str()),
+                Some(count) => this.replacen(old.as_str(), new.as_str(), count.to_int()? as usize),
             }
         )
     }


### PR DESCRIPTION
Operations like

```
list(None)
```

should result in an error, not an empty list.

Although, in most cases, the issue could be fixed by carefully
selecting default values, e. g. `list` macro could be changed to

```
list(#a = List::new()) { ... }
```

I thought explicit support of optional parameters might be useful.

Note optional parameters do not exist in Starlark language, but
neither do unnamed positional parameters.