### PR TITLE
Replace not_supported!() macros with default impls

### DIFF
--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -110,7 +110,7 @@ impl TypedValue for Set {
     /// assert_eq!("[1]", Value::from(vec![1]).to_str());
     /// assert_eq!("[]", Value::from(Vec::<i64>::new()).to_str());
     /// ```
-    fn to_str(&self) -> String {
+    fn to_repr(&self) -> String {
         format!(
             "{{{}}}",
             self.content
@@ -125,11 +125,6 @@ impl TypedValue for Set {
         )
     }
 
-    fn to_repr(&self) -> String {
-        self.to_str()
-    }
-
-    not_supported!(to_int);
     fn get_type(&self) -> &'static str {
         "set"
     }
@@ -254,10 +249,6 @@ impl TypedValue for Set {
             .fold(Wrapping(0_u64), |acc, v| acc + v)
             .0)
     }
-
-    not_supported!(mul, set_at);
-    not_supported!(attr, function);
-    not_supported!(plus, minus, sub, div, pipe, percent, floor_div);
 }
 
 #[cfg(test)]

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -36,11 +36,9 @@ impl TypedValue for StarlarkStruct {
         }
     }
 
-    not_supported!(freeze_for_iteration);
+    fn freeze_for_iteration(&mut self) {}
 
-    fn to_str(&self) -> String {
-        self.to_repr()
-    }
+    fn unfreeze_for_iteration(&mut self) {}
 
     fn to_repr(&self) -> String {
         let mut r = "struct(".to_owned();
@@ -60,33 +58,10 @@ impl TypedValue for StarlarkStruct {
         "struct"
     }
 
-    fn to_bool(&self) -> bool {
-        true
-    }
-
     fn is_descendant(&self, other: &TypedValue) -> bool {
         self.fields
             .values()
             .any(|x| x.same_as(other) || x.is_descendant(other))
-    }
-
-    fn get_attr(&self, attribute: &str) -> Result<Value, ValueError> {
-        match self.fields.get(attribute) {
-            Some(v) => Ok(v.clone()),
-            None => Err(ValueError::OperationNotSupported {
-                op: attribute.to_owned(),
-                left: self.to_repr(),
-                right: None,
-            }),
-        }
-    }
-
-    fn has_attr(&self, attribute: &str) -> Result<bool, ValueError> {
-        Ok(self.fields.contains_key(attribute))
-    }
-
-    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
-        Ok(self.fields.keys().cloned().collect())
     }
 
     fn compare(&self, other: &TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
@@ -118,10 +93,24 @@ impl TypedValue for StarlarkStruct {
         }
     }
 
-    not_supported!(binop);
-    not_supported!(is_in, call);
-    not_supported!(set_attr);
-    not_supported!(iter, length, slice, set_at, at, get_hash, to_int);
+    fn get_attr(&self, attribute: &str) -> Result<Value, ValueError> {
+        match self.fields.get(attribute) {
+            Some(v) => Ok(v.clone()),
+            None => Err(ValueError::OperationNotSupported {
+                op: attribute.to_owned(),
+                left: self.to_repr(),
+                right: None,
+            }),
+        }
+    }
+
+    fn has_attr(&self, attribute: &str) -> Result<bool, ValueError> {
+        Ok(self.fields.contains_key(attribute))
+    }
+
+    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
+        Ok(self.fields.keys().cloned().collect())
+    }
 }
 
 starlark_module! { global =>

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -117,7 +117,7 @@ impl TypedValue for Dictionary {
     }
     define_iterable_mutability!(mutability);
 
-    fn to_str(&self) -> String {
+    fn to_repr(&self) -> String {
         format!(
             "{{{}}}",
             self.content
@@ -130,10 +130,6 @@ impl TypedValue for Dictionary {
                     accum + ", " + &s.1
                 })
         )
-    }
-
-    fn to_repr(&self) -> String {
-        self.to_str()
     }
 
     fn get_type(&self) -> &'static str {
@@ -238,9 +234,6 @@ impl TypedValue for Dictionary {
             Err(ValueError::IncorrectParameterType)
         }
     }
-
-    not_supported!(plus, minus, sub, mul, div, pipe, percent, floor_div);
-    not_supported!(to_int, get_hash, slice, attr, function);
 }
 
 #[cfg(test)]

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -297,14 +297,9 @@ impl TypedValue for Function {
         repr(&self.function_type, &self.signature)
     }
 
-    not_supported!(to_int);
     fn get_type(&self) -> &'static str {
         "function"
     }
-    fn to_bool(&self) -> bool {
-        true
-    }
-    not_supported!(get_hash);
 
     fn compare(&self, other: &dyn TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
         if other.get_type() == "function" {
@@ -407,8 +402,9 @@ impl TypedValue for Function {
         )
     }
 
-    not_supported!(binop);
-    not_supported!(container);
+    fn is_descendant(&self, _other: &TypedValue) -> bool {
+        false
+    }
 }
 
 impl TypedValue for WrappedMethod {
@@ -423,9 +419,6 @@ impl TypedValue for WrappedMethod {
     }
     fn get_type(&self) -> &'static str {
         "function"
-    }
-    fn to_bool(&self) -> bool {
-        true
     }
     fn compare(&self, other: &dyn TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
         self.method.compare_underlying(other, recursion)
@@ -450,7 +443,7 @@ impl TypedValue for WrappedMethod {
             .call(call_stack, env, positional, named, args, kwargs)
     }
 
-    not_supported!(to_int, get_hash);
-    not_supported!(binop);
-    not_supported!(container);
+    fn is_descendant(&self, _other: &TypedValue) -> bool {
+        false
+    }
 }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -79,7 +79,7 @@ impl TypedValue for List {
     /// assert_eq!("[1]", Value::from(vec![1]).to_str());
     /// assert_eq!("[]", Value::from(Vec::<i64>::new()).to_str());
     /// ```
-    fn to_str(&self) -> String {
+    fn to_repr(&self) -> String {
         format!(
             "[{}]",
             self.content
@@ -94,11 +94,6 @@ impl TypedValue for List {
         )
     }
 
-    fn to_repr(&self) -> String {
-        self.to_str()
-    }
-
-    not_supported!(to_int);
     fn get_type(&self) -> &'static str {
         "list"
     }
@@ -255,9 +250,6 @@ impl TypedValue for List {
         self.content[i] = new_value.clone_for_container(self)?;
         Ok(())
     }
-
-    not_supported!(attr, function, get_hash);
-    not_supported!(plus, minus, sub, div, pipe, percent, floor_div);
 }
 
 #[cfg(test)]

--- a/starlark/src/values/string.rs
+++ b/starlark/src/values/string.rs
@@ -35,7 +35,6 @@ impl TypedValue for String {
         )
     }
 
-    not_supported!(to_int);
     fn get_type(&self) -> &'static str {
         "string"
     }
@@ -316,11 +315,6 @@ impl TypedValue for String {
             Ok(Value::new(res))
         }
     }
-
-    not_supported!(iterable);
-    not_supported!(set_indexable);
-    not_supported!(attr, function);
-    not_supported!(plus, minus, sub, div, pipe, floor_div);
 }
 
 #[cfg(test)]

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -270,7 +270,11 @@ impl TypedValue for Tuple {
         }
     }
 
-    fn to_str(&self) -> String {
+    fn freeze_for_iteration(&mut self) {}
+
+    fn unfreeze_for_iteration(&mut self) {}
+
+    fn to_repr(&self) -> String {
         format!(
             "({}{})",
             self.content
@@ -285,12 +289,6 @@ impl TypedValue for Tuple {
             if self.content.len() == 1 { "," } else { "" }
         )
     }
-
-    fn to_repr(&self) -> String {
-        self.to_str()
-    }
-
-    not_supported!(to_int);
     fn get_type(&self) -> &'static str {
         "tuple"
     }
@@ -433,11 +431,6 @@ impl TypedValue for Tuple {
             Err(ValueError::IncorrectParameterType)
         }
     }
-
-    not_supported!(freeze_for_iteration);
-    not_supported!(set_indexable);
-    not_supported!(attr, function);
-    not_supported!(plus, minus, sub, div, pipe, percent, floor_div);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Current (before this commit) strategy requires too much effort when
embedding Starlark Rust (when implementing custom data types). In
particular:

* all functions need to be explicitly listed, even when only a
  couple of them are really needed
* `not_supported!()` macro is not exported by the crate