### PR TITLE
Move type impls out of values mod

### DIFF
--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define the bool type for Starlark.
+
+use crate::values::*;
+
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Value::new(b)
+    }
+}
+
+/// Define the bool type
+impl TypedValue for bool {
+    immutable!();
+    any!();
+    default_compare!();
+    fn to_repr(&self) -> String {
+        if *self {
+            "True".to_owned()
+        } else {
+            "False".to_owned()
+        }
+    }
+    fn to_int(&self) -> Result<i64, ValueError> {
+        Ok(if *self { 1 } else { 0 })
+    }
+    fn get_type(&self) -> &'static str {
+        "bool"
+    }
+    fn to_bool(&self) -> bool {
+        *self
+    }
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        Ok(self.to_int().unwrap() as u64)
+    }
+    fn is_descendant(&self, _other: &TypedValue) -> bool {
+        false
+    }
+}

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -236,6 +236,26 @@ impl TypedValue for Dictionary {
     }
 }
 
+impl<T1: Into<Value> + Eq + Hash + Clone, T2: Into<Value> + Eq + Clone> TryFrom<HashMap<T1, T2>>
+    for Value
+{
+    type Error = ValueError;
+
+    fn try_from(a: HashMap<T1, T2>) -> Result<Value, ValueError> {
+        Ok(Value::new(dict::Dictionary::try_from(a)?))
+    }
+}
+
+impl<T1: Into<Value> + Eq + Hash + Clone, T2: Into<Value> + Eq + Clone>
+    TryFrom<LinkedHashMap<T1, T2>> for Value
+{
+    type Error = ValueError;
+
+    fn try_from(a: LinkedHashMap<T1, T2>) -> Result<Value, ValueError> {
+        Ok(Value::new(dict::Dictionary::try_from(a)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -1,0 +1,185 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define the int type for Starlark.
+
+use crate::values::*;
+
+// A convenient macro for testing and documentation.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! int_op {
+    ($v1:tt. $op:ident($v2:expr)) => {
+        $crate::values::Value::new($v1)
+            .$op($crate::values::Value::new($v2))
+            .unwrap()
+            .to_int()
+            .unwrap()
+    };
+    ($v1:tt. $op:ident()) => {
+        $crate::values::Value::new($v1)
+            .$op()
+            .unwrap()
+            .to_int()
+            .unwrap()
+    };
+}
+
+macro_rules! from_int {
+    ($x: ty, $y: tt) => {
+        impl From<$x> for Value {
+            fn from(a: $x) -> Value {
+                #[allow(clippy::cast_lossless)]
+                Value::new(a as $y)
+            }
+        }
+    };
+}
+
+from_int!(i8, i64);
+from_int!(i16, i64);
+from_int!(i32, i64);
+from_int!(u8, i64);
+from_int!(u16, i64);
+from_int!(u32, i64);
+// TODO: check for overflow
+from_int!(u64, i64);
+
+impl From<i64> for Value {
+    fn from(v: i64) -> Self {
+        Value::new(v)
+    }
+}
+
+fn i64_arith_bin_op<F>(left: i64, right: Value, op: &'static str, f: F) -> ValueResult
+where
+    F: FnOnce(i64, i64) -> Result<i64, ValueError>,
+{
+    right
+        .downcast_apply(move |right: &i64| Ok(Value::new(f(left, *right)?)))
+        .unwrap_or_else(|| {
+            Err(ValueError::OperationNotSupported {
+                op: op.to_owned(),
+                left: left.get_type().to_owned(),
+                right: Some(right.get_type().to_owned()),
+            })
+        })
+}
+
+/// Define the int type
+impl TypedValue for i64 {
+    immutable!();
+    any!();
+    default_compare!();
+    fn to_str(&self) -> String {
+        format!("{}", self)
+    }
+    fn to_repr(&self) -> String {
+        self.to_str()
+    }
+    fn to_int(&self) -> Result<i64, ValueError> {
+        Ok(*self)
+    }
+    fn get_type(&self) -> &'static str {
+        "int"
+    }
+    fn to_bool(&self) -> bool {
+        *self != 0
+    }
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        Ok(*self as u64)
+    }
+    fn plus(&self) -> ValueResult {
+        Ok(Value::new(*self))
+    }
+    fn minus(&self) -> ValueResult {
+        match self.checked_neg() {
+            Some(r) => Ok(Value::new(r)),
+            None => Err(ValueError::IntegerOverflow),
+        }
+    }
+    fn add(&self, other: Value) -> ValueResult {
+        i64_arith_bin_op(*self, other, "+", |a, b| {
+            a.checked_add(b).ok_or(ValueError::IntegerOverflow)
+        })
+    }
+    fn sub(&self, other: Value) -> ValueResult {
+        i64_arith_bin_op(*self, other, "-", |a, b| {
+            a.checked_sub(b).ok_or(ValueError::IntegerOverflow)
+        })
+    }
+    fn mul(&self, other: Value) -> ValueResult {
+        let other_i64 = other.downcast_apply(|other: &i64| {
+            self.checked_mul(*other).ok_or(ValueError::IntegerOverflow)
+        });
+        match other_i64 {
+            Some(r) => r.map(Value::new),
+            None => other.mul(Value::new(*self)),
+        }
+    }
+    fn percent(&self, other: Value) -> ValueResult {
+        i64_arith_bin_op(*self, other, "%", |a, b| {
+            if b == 0 {
+                return Err(ValueError::DivisionByZero);
+            }
+            // In Rust `i64::min_value() % -1` is overflow, but we should eval it to zero.
+            if *self == i64::min_value() && b == -1 {
+                return Ok(0);
+            }
+            let r = a % b;
+            if r == 0 {
+                Ok(0)
+            } else {
+                Ok(if b.signum() != r.signum() { r + b } else { r })
+            }
+        })
+    }
+    fn div(&self, other: Value) -> ValueResult {
+        self.floor_div(other)
+    }
+    fn floor_div(&self, other: Value) -> ValueResult {
+        i64_arith_bin_op(*self, other, "//", |a, b| {
+            if b == 0 {
+                return Err(ValueError::DivisionByZero);
+            }
+            let sig = b.signum() * a.signum();
+            let offset = if sig < 0 && a % b != 0 { 1 } else { 0 };
+            match a.checked_div(b) {
+                Some(div) => Ok(div - offset),
+                None => Err(ValueError::IntegerOverflow),
+            }
+        })
+    }
+
+    fn is_descendant(&self, _other: &TypedValue) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::int_op;
+
+    #[test]
+    fn test_arithmetic_operators() {
+        assert_eq!(1, int_op!(1.plus())); // 1.plus() = +1 = 1
+        assert_eq!(-1, int_op!(1.minus())); // 1.minus() = -1
+        assert_eq!(3, int_op!(1.add(2))); // 1.add(2) = 1 + 2 = 3
+        assert_eq!(-1, int_op!(1.sub(2))); // 1.sub(2) = 1 - 2 = -1
+        assert_eq!(6, int_op!(2.mul(3))); // 2.mul(3) = 2 * 3 = 6
+                                          // Remainder of the floored division: 5.percent(3) = 5 % 3 = 2
+        assert_eq!(2, int_op!(5.percent(3)));
+        assert_eq!(3, int_op!(7.div(2))); // 7.div(2) = 7 / 2 = 3
+    }
+}

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -22,17 +22,18 @@ pub struct List {
     content: Vec<Value>,
 }
 
-impl<T: Into<Value> + Clone> From<Vec<T>> for List {
+impl<T: Into<Value>> From<Vec<T>> for List {
     fn from(a: Vec<T>) -> List {
-        let mut result = List {
+        List {
             mutability: IterableMutability::Mutable,
-            content: Vec::new(),
-        };
-        for x in a.iter() {
-            let v: Value = x.clone().into();
-            result.content.push(v);
+            content: a.into_iter().map(Into::into).collect(),
         }
-        result
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(a: Vec<T>) -> Value {
+        Value::new(List::from(a))
     }
 }
 

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -1,0 +1,46 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define the None type for Starlark.
+
+use crate::values::*;
+
+/// Define the NoneType type
+impl TypedValue for Option<()> {
+    immutable!();
+    any!();
+    default_compare!();
+    fn to_repr(&self) -> String {
+        "None".to_owned()
+    }
+    fn get_type(&self) -> &'static str {
+        "NoneType"
+    }
+    fn to_bool(&self) -> bool {
+        false
+    }
+    // just took the result of hash(None) in macos python 2.7.10 interpreter.
+    fn get_hash(&self) -> Result<u64, ValueError> {
+        Ok(9_223_380_832_852_120_682)
+    }
+    fn is_descendant(&self, _other: &TypedValue) -> bool {
+        false
+    }
+}
+
+impl From<Option<()>> for Value {
+    fn from(_a: Option<()>) -> Value {
+        Value::new(None)
+    }
+}

--- a/starlark/src/values/string.rs
+++ b/starlark/src/values/string.rs
@@ -17,7 +17,7 @@ use crate::values::*;
 use std;
 use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 
 impl TypedValue for String {
     immutable!();
@@ -314,6 +314,18 @@ impl TypedValue for String {
         } else {
             Ok(Value::new(res))
         }
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Value::new(s)
+    }
+}
+
+impl<'a> From<&'a str> for Value {
+    fn from(a: &'a str) -> Value {
+        Value::new(a.to_owned())
     }
 }
 

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -433,6 +433,56 @@ impl TypedValue for Tuple {
     }
 }
 
+impl From<()> for Value {
+    fn from(_a: ()) -> Value {
+        Value::new(Tuple::from(()))
+    }
+}
+
+macro_rules! from_tuple {
+    ($x: ty) => {
+        impl From<$x> for Value {
+            fn from(a: $x) -> Value {
+                Value::new(a)
+            }
+        }
+    };
+    ($x: ty, $y: tt) => {
+        impl<T: Into<Value> + Clone> From<$x> for Value {
+            fn from(a: $x) -> Value {
+                Value::new($y::from(a))
+            }
+        }
+    };
+    ($x: ty, $y: tt, noT) => {
+        impl From<$x> for Value {
+            fn from(a: $x) -> Value {
+                #[allow(clippy::cast_lossless)]
+                Value::new(a as $y)
+            }
+        }
+    };
+    ($y: tt, $($x: tt),+) => {
+        impl<$($x: Into<Value> + Clone),+> From<($($x),+)> for Value {
+            fn from(a: ($($x),+)) -> Value {
+                Value::new($y::from(a))
+            }
+        }
+
+    };
+}
+
+from_tuple!((T,), Tuple);
+from_tuple!(Tuple, T1, T2);
+from_tuple!(Tuple, T1, T2, T3);
+from_tuple!(Tuple, T1, T2, T3, T4);
+from_tuple!(Tuple, T1, T2, T3, T4, T5);
+from_tuple!(Tuple, T1, T2, T3, T4, T5, T6);
+from_tuple!(Tuple, T1, T2, T3, T4, T5, T6, T7);
+from_tuple!(Tuple, T1, T2, T3, T4, T5, T6, T7, T8);
+from_tuple!(Tuple, T1, T2, T3, T4, T5, T6, T7, T8, T9);
+from_tuple!(Tuple, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Before this commit `values/mod.rs` is 1700 lines, close to recommended
file length limit.