### PR TITLE
Use RefCell only for mutable types and more

### DIFF
--- a/starlark/src/linked_hash_set/set_impl.rs
+++ b/starlark/src/linked_hash_set/set_impl.rs
@@ -20,9 +20,15 @@ use std::hash::Hash;
 /// `LinkedHashSet` is a tiny wrapper around `LinkedHashMap`.
 ///
 /// Using `LinkedHashMap` directly to avoid adding extra dependency.
-#[derive(PartialEq, Eq, Debug, Clone, Default)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub(crate) struct LinkedHashSet<K: Eq + Hash> {
     map: LinkedHashMap<K, ()>,
+}
+
+impl<K: Eq + Hash> Default for LinkedHashSet<K> {
+    fn default() -> Self {
+        LinkedHashSet::new()
+    }
 }
 
 impl<K: Eq + Hash> LinkedHashSet<K> {

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -104,9 +104,7 @@ starlark_module! {global =>
     /// ```
     dict.items(this) {
         let this = this.downcast_ref::<Dictionary>().unwrap();
-        let v : Vec<Value> =
-            this.get_content().iter().map(|x| Value::from((x.0.get_value().clone(), x.1.clone()))).collect();
-        ok!(v)
+        ok!(this.items())
     }
 
     /// [dict.keys](
@@ -170,7 +168,7 @@ starlark_module! {global =>
                 let key_error = format!("Key '{}' not found in '{}'", key.to_repr(), this.to_repr());
                 starlark_err!(
                     DICT_KEY_NOT_FOUND_ERROR_CODE,
-                    key_error.clone(),
+                    key_error,
                     "not found".to_owned()
                 );
             } else {
@@ -346,8 +344,7 @@ starlark_module! {global =>
     /// ```
     dict.values(this) {
         let this = this.downcast_ref::<Dictionary>().unwrap();
-        let v : Vec<Value> = this.get_content().iter().map(|x| x.1.clone()).collect();
-        ok!(v)
+        ok!(this.values())
     }
 }
 
@@ -372,10 +369,9 @@ mod tests {
 
     #[test]
     fn test_get() {
-        starlark_ok!(
-            r#"x = {"one": 1, "two": 2}; (
-            x.get("one") == 1 and x.get("three") == None and x.get("three", 0) == 0)"#
-        );
+        starlark_ok!(r#"x = {"one": 1, "two": 2}; (x.get("one") == 1)"#);
+        starlark_ok!(r#"x = {"one": 1, "two": 2}; (x.get("three") == None)"#);
+        starlark_ok!(r#"x = {"one": 1, "two": 2}; (x.get("three", 0) == 0)"#);
     }
 
     #[test]

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -296,6 +296,7 @@ mod tests {
 
     #[test]
     fn test_pop() {
+        starlark_ok!(r#"x = [1, 2, 3]; x.pop() == 3"#);
         starlark_ok!(r#"x = [1, 2, 3]; (x.pop() == 3 and x.pop() == 2 and x == [1])"#);
     }
 

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -300,7 +300,6 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     string.count(this: String, #needle: String, #start = 0, #end = NoneType::None) {
-        check_string!(needle, count);
         convert_indices!(this, start, end);
         let n = needle.as_str();
         let mut counter = 0 as i64;
@@ -330,7 +329,6 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     string.endswith(this: String, #suffix: String) {
-        check_string!(suffix, endswith);
         ok!(this.ends_with(suffix.as_str()))
     }
 
@@ -514,7 +512,6 @@ starlark_module! {global =>
     /// # )"#).is_err());
     /// ```
     string.index(this: String, #needle: String, #start = 0, #end = NoneType::None) {
-        check_string!(needle, count);
         convert_indices!(this, start, end);
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.find(needle.as_str()) {
@@ -900,8 +897,6 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     string.replace(this: String, #old: String, #new: String, ?#count: Option<usize>) {
-        check_string!(old, replace);
-        check_string!(new, replace);
         ok!(
             match count {
                 None => this.replace(old.as_str(), new.as_str()),

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -17,6 +17,7 @@
 use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
+use std::iter;
 
 impl From<bool> for Value {
     fn from(b: bool) -> Self {
@@ -26,14 +27,8 @@ impl From<bool> for Value {
 
 /// Define the bool type
 impl TypedValue for bool {
-    immutable!();
-    any!();
-    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
-        Ok(*self == *other.downcast_ref::<bool>().unwrap())
-    }
-    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
-        Ok(self.cmp(&*other.downcast_ref::<bool>().unwrap()))
-    }
+    type Holder = Immutable<Self>;
+    const TYPE: &'static str = "bool";
     fn to_repr(&self) -> String {
         if *self {
             "True".to_owned()
@@ -44,16 +39,21 @@ impl TypedValue for bool {
     fn to_int(&self) -> Result<i64, ValueError> {
         Ok(if *self { 1 } else { 0 })
     }
-    fn get_type(&self) -> &'static str {
-        "bool"
-    }
     fn to_bool(&self) -> bool {
         *self
     }
     fn get_hash(&self) -> Result<u64, ValueError> {
         Ok(self.to_int().unwrap() as u64)
     }
-    fn is_descendant(&self, _other: &TypedValue) -> bool {
-        false
+
+    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+        Box::new(iter::empty())
+    }
+
+    fn equals(&self, other: &bool) -> Result<bool, ValueError> {
+        Ok(self == other)
+    }
+    fn compare(&self, other: &bool) -> Result<Ordering, ValueError> {
+        Ok(self.cmp(other))
     }
 }

--- a/starlark/src/values/iter.rs
+++ b/starlark/src/values/iter.rs
@@ -14,8 +14,8 @@
 
 //! Iterable for Starlark objects.
 
+use crate::values::mutability::RefOrRef;
 use crate::values::Value;
-use std::cell::Ref;
 
 /// Type to be implemented by types which are iterable.
 pub trait TypedIterable: 'static {
@@ -25,11 +25,11 @@ pub trait TypedIterable: 'static {
 
 /// Iterable which contains borrowed reference to a sequence.
 pub struct RefIterable<'a> {
-    r: Ref<'a, TypedIterable>,
+    r: RefOrRef<'a, TypedIterable>,
 }
 
 impl<'a> RefIterable<'a> {
-    pub fn new(r: Ref<'a, TypedIterable>) -> RefIterable<'a> {
+    pub fn new(r: RefOrRef<'a, TypedIterable>) -> RefIterable<'a> {
         RefIterable { r }
     }
 

--- a/starlark/src/values/mutability.rs
+++ b/starlark/src/values/mutability.rs
@@ -1,0 +1,202 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Mutability-related utilities.
+
+use crate::values::ValueError;
+use std::cell::{BorrowError, Cell, Ref, RefCell, RefMut};
+use std::fmt;
+use std::ops::Deref;
+
+/// A helper enum for defining the level of mutability of an iterable.
+#[derive(PartialEq, Eq, Hash, Debug, Copy, Clone)]
+pub enum IterableMutability {
+    Mutable,
+    Immutable,
+    FrozenForIteration,
+}
+
+impl IterableMutability {
+    /// Tests the mutability value and return the appropriate error
+    ///
+    /// This method is to be called simply `mutability.test()?` to return
+    /// an error if the current container is no longer mutable.
+    pub fn test(self) -> Result<(), ValueError> {
+        match self {
+            IterableMutability::Mutable => Ok(()),
+            IterableMutability::Immutable => Err(ValueError::CannotMutateImmutableValue),
+            IterableMutability::FrozenForIteration => Err(ValueError::MutationDuringIteration),
+        }
+    }
+}
+
+/// `std::cell::Ref<T>` or `&T`
+pub enum RefOrRef<'a, T: ?Sized + 'a> {
+    Ptr(&'a T),
+    Borrowed(Ref<'a, T>),
+}
+
+impl<'a, T: ?Sized + 'a> Deref for RefOrRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            RefOrRef::Ptr(p) => p,
+            RefOrRef::Borrowed(p) => p.deref(),
+        }
+    }
+}
+
+impl<'a, T: ?Sized + 'a> RefOrRef<'a, T> {
+    pub fn map<U: ?Sized, F>(orig: RefOrRef<'a, T>, f: F) -> RefOrRef<'a, U>
+    where
+        F: FnOnce(&T) -> &U,
+    {
+        match orig {
+            RefOrRef::Ptr(p) => RefOrRef::Ptr(f(p)),
+            RefOrRef::Borrowed(p) => RefOrRef::Borrowed(Ref::map(p, f)),
+        }
+    }
+}
+
+/// Container for data which is either `RefCell` or immutable data.
+pub trait RefCellOrImmutable {
+    type Content;
+
+    fn new(value: Self::Content) -> Self;
+    fn borrow(&self) -> RefOrRef<'_, Self::Content>;
+    fn try_borrow(&self) -> Result<RefOrRef<Self::Content>, BorrowError>;
+    fn borrow_mut(&self) -> RefMut<'_, Self::Content>;
+    fn as_ptr(&self) -> *const Self::Content;
+}
+
+/// Container for immutable data
+#[derive(Debug)]
+pub struct ImmutableCell<T>(T);
+
+impl<T> RefCellOrImmutable for RefCell<T> {
+    type Content = T;
+
+    fn new(value: T) -> Self {
+        RefCell::new(value)
+    }
+
+    fn borrow(&self) -> RefOrRef<T> {
+        RefOrRef::Borrowed(RefCell::borrow(self))
+    }
+
+    fn try_borrow(&self) -> Result<RefOrRef<T>, BorrowError> {
+        RefCell::try_borrow(self).map(RefOrRef::Borrowed)
+    }
+
+    fn borrow_mut(&self) -> RefMut<Self::Content> {
+        RefCell::borrow_mut(self)
+    }
+
+    fn as_ptr(&self) -> *const T {
+        RefCell::as_ptr(self)
+    }
+}
+
+impl<T> RefCellOrImmutable for ImmutableCell<T> {
+    type Content = T;
+
+    fn new(value: T) -> Self {
+        ImmutableCell(value)
+    }
+
+    fn borrow(&self) -> RefOrRef<T> {
+        RefOrRef::Ptr(&self.0)
+    }
+
+    fn try_borrow(&self) -> Result<RefOrRef<T>, BorrowError> {
+        Ok(RefOrRef::Ptr(&self.0))
+    }
+
+    fn borrow_mut(&self) -> RefMut<Self::Content> {
+        panic!("immutable value cannot be mutably borrowed")
+    }
+
+    fn as_ptr(&self) -> *const T {
+        &self.0 as *const T
+    }
+}
+
+/// Holder for mutability flag, either cell or always immutable.
+pub trait MutabilityCell: fmt::Debug {
+    fn get(&self) -> IterableMutability;
+    fn freeze(&self);
+    fn freeze_for_iteration(&self);
+    fn unfreeze_for_iteration(&self);
+    fn new() -> Self;
+}
+
+#[derive(Debug)]
+pub struct ImmutableMutability;
+#[derive(Debug)]
+pub struct MutableMutability(Cell<IterableMutability>);
+
+impl MutabilityCell for ImmutableMutability {
+    fn get(&self) -> IterableMutability {
+        IterableMutability::Immutable
+    }
+
+    fn freeze(&self) {}
+
+    fn freeze_for_iteration(&self) {}
+
+    fn unfreeze_for_iteration(&self) {}
+
+    /// Create a new cell, initialized to mutable for mutable types,
+    /// and immutable for immutable types.
+    fn new() -> Self {
+        ImmutableMutability
+    }
+}
+
+impl MutabilityCell for MutableMutability {
+    fn get(&self) -> IterableMutability {
+        self.0.get()
+    }
+
+    fn freeze(&self) {
+        match self.0.get() {
+            IterableMutability::FrozenForIteration => panic!("attempt to freeze during iteration"),
+            IterableMutability::Immutable => {}
+            IterableMutability::Mutable => self.0.set(IterableMutability::Immutable),
+        }
+    }
+
+    /// Freezes the current value for iterating over.
+    fn freeze_for_iteration(&self) {
+        match self.0.get() {
+            IterableMutability::Immutable => {}
+            IterableMutability::FrozenForIteration => panic!("already frozen"),
+            IterableMutability::Mutable => self.0.set(IterableMutability::FrozenForIteration),
+        }
+    }
+
+    /// Unfreezes the current value for iterating over.
+    fn unfreeze_for_iteration(&self) {
+        match self.0.get() {
+            IterableMutability::Immutable => {}
+            IterableMutability::FrozenForIteration => self.0.set(IterableMutability::Mutable),
+            IterableMutability::Mutable => panic!("not frozen"),
+        }
+    }
+
+    fn new() -> Self {
+        MutableMutability(Cell::new(IterableMutability::Mutable))
+    }
+}

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -17,30 +17,32 @@
 use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
+use std::iter;
 
 /// Define the NoneType type
+#[derive(Debug)]
 pub enum NoneType {
     None,
 }
 
+/// Define the NoneType type
 impl TypedValue for NoneType {
-    immutable!();
-    any!();
-    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
-        // assert type
-        other.downcast_ref::<NoneType>().unwrap();
+    type Holder = Immutable<Self>;
+    const TYPE: &'static str = "NoneType";
+
+    fn equals(&self, _other: &NoneType) -> Result<bool, ValueError> {
         Ok(true)
     }
-    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
-        // assert type
-        other.downcast_ref::<NoneType>().unwrap();
+    fn compare(&self, _other: &NoneType) -> Result<Ordering, ValueError> {
         Ok(Ordering::Equal)
     }
+
+    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+        Box::new(iter::empty())
+    }
+
     fn to_repr(&self) -> String {
         "None".to_owned()
-    }
-    fn get_type(&self) -> &'static str {
-        "NoneType"
     }
     fn to_bool(&self) -> bool {
         false
@@ -48,9 +50,6 @@ impl TypedValue for NoneType {
     // just took the result of hash(None) in macos python 2.7.10 interpreter.
     fn get_hash(&self) -> Result<u64, ValueError> {
         Ok(9_223_380_832_852_120_682)
-    }
-    fn is_descendant(&self, _other: &TypedValue) -> bool {
-        false
     }
 }
 

--- a/starlark/tests/go-testcases/string.sky
+++ b/starlark/tests/go-testcases/string.sky
@@ -85,7 +85,7 @@ assert_eq("abc"[2], "c")
 # x[i] = ...
 x2 = "abc"
 def f(): x2[1] = 'B'
-f() ### Immutable
+f() ### [] = not supported for types string and int
 ---
 
 # slicing, x[i:j]

--- a/starlark/tests/rust-testcases/bool.sky
+++ b/starlark/tests/rust-testcases/bool.sky
@@ -1,3 +1,3 @@
 # Boolean tests
 
-True + 9223372036854775807   ###  + not supported
+True + 9223372036854775807   ###  Type of parameters mismatch


### PR DESCRIPTION
This is the third iteration of refactoring of how mutability
implemented in Starlark Rust.

Here is the top-down outline:

```
// No longer RefCell here
struct Value(Rc<ValueHolderInterface>);

// crate-private
trait ValueHolderInterface {
    fn plus(&self) -> Result<Value, ValueError>;
    // and all other operations
}

// the only implementation of `ValueHolderInterface`
struct ValueHolder<T: TypedValue> {
    // empty for immutable types and `Cell<IterableMutability>` otherwise
    mutability: T::Mutability::MutabilityCell;
    // `RefCell` for immutable or just value for mutables
    content: T::Mutability::Cell;
}

trait TypedValue {
    // either `Mutable` or `Immutable`
    type Mutability: Mutability<Content=Self>;
}

trait Mutability { ... }

// empty structs, both implement `Mutability`
struct Immutable;
struct Mutable;
```

The good parts are:

First, `RefCell` is no longer used for immutable types.

Second, `RefCell` borrowing is no longer needed for querying `Value`
type or freezing for iteration.

Third, `TypedValue` now has only three abstract members:

```
trait TypedValue {
    type Holder: Mutability<Content = Self>;
    const TYPE: &'static str;
    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> ...;
}
```

Fourth, `TypedValue` is `Sized` now and certain operations (like
`add` or `compare`) now accept `Self` as the second parameter, so
implementations do need to perform downcasting (downcasting is done
once in `ValueHolder` implementation).

So implementing minimal `TypedValue` correctly is much easier now.

Fifth, `TypedValue::TYPE` is now an associated constant, not a
virtual function, to make it clear it never changes.