### PR TITLE
Fix typo in check_type!{} macro

### DIFF
--- a/starlark/src/stdlib/macros.rs
+++ b/starlark/src/stdlib/macros.rs
@@ -397,8 +397,7 @@ macro_rules! check_type {
                         $fn,
                         "() expect a ",
                         stringify!($ty),
-                        " as first parameter while",
-                        "got a value of type {}."
+                        " as first parameter while got a value of type {}."
                     ),
                     $e.get_type()
                 ),


### PR DESCRIPTION
Fixes #63

```
% cargo run -- -c "''.splitlines('0')"
    Finished dev [unoptimized + debuginfo] target(s) in 3.53s
     Running `target/debug/starlark-repl -c ''\'''\''.splitlines('\''0'\'')'`
error[CV02]: string.splitlines() expect a bool as first parameter while got a value of type string.
 --> [command flag]:1:1
  |
1 | ''.splitlines('0')
  | ^^^^^^^^^^^^^^^^^^ type string while expected bool

```