### PR TITLE
Benchmarking groundwork

### DIFF
--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -31,9 +31,11 @@ predicates = "1"
 tempfile = ">=3, <3.0.5"
 
 [lib]
+bench = false
 
 [[bin]]
 name = "starlark-repl"
+bench = false
 
 [features]
 default = ["linked_hash_set"]

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -29,6 +29,7 @@ linked-hash-map = "0.5.1"
 linked_hash_set = { version = "0.1.3", optional = true }
 
 [lib]
+bench = false
 
 [features]
 trace = []

--- a/starlark/benches/benchutil/mod.rs
+++ b/starlark/benches/benchutil/mod.rs
@@ -1,0 +1,82 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codemap::CodeMap;
+use codemap_diagnostic::{ColorConfig, Emitter};
+use linked_hash_map::LinkedHashMap;
+use starlark::eval::simple::eval;
+use starlark::stdlib::{global_environment, structs};
+use starlark::syntax::dialect::Dialect;
+use starlark::values::error::ValueError;
+use std::fs::File;
+use std::io::Read;
+use std::sync::{Arc, Mutex};
+use test::Bencher;
+
+pub fn do_bench(bencher: &mut Bencher, path: &str) {
+    let mut content = String::new();
+    let mut file = File::open(path).unwrap();
+    file.read_to_string(&mut content).unwrap();
+    drop(file);
+
+    let map = Arc::new(Mutex::new(CodeMap::new()));
+    let global = global_environment();
+    let global = structs::global(global);
+    global.freeze();
+    let mut prelude = global.child("PRELUDE");
+    eval(
+        &map,
+        "PRELUDE",
+        r#"
+def assert_eq(x, y):
+  if x != y:
+    fail("%r != %r" % (x, y))
+
+def assert_(cond, msg="assertion failed"):
+  if not cond:
+    fail(msg)
+"#,
+        starlark::syntax::dialect::Dialect::Bzl,
+        &mut prelude,
+    )
+    .unwrap();
+    prelude.freeze();
+
+    let mut env = prelude.child("run");
+    match eval(&map, path, &content, Dialect::Bzl, &mut env) {
+        Ok(_) => (),
+        Err(p) => {
+            Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[p]);
+            panic!();
+        }
+    }
+
+    env.freeze();
+
+    let bench_func = env.get("bench").expect("bench function is not found");
+
+    bencher.iter(|| {
+        let env = env.child("bench");
+        match bench_func.call(&[], env, Vec::new(), LinkedHashMap::new(), None, None) {
+            Ok(r) => r,
+            Err(ValueError::DiagnosedError(e)) => {
+                Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[e]);
+                panic!();
+            }
+            Err(e) => {
+                panic!("{:?}", e);
+            }
+        }
+    });
+}

--- a/starlark/benches/rust-benches/bubble_sort.sky
+++ b/starlark/benches/rust-benches/bubble_sort.sky
@@ -1,0 +1,11 @@
+def bubble_sort(array):
+    array = list(array)
+    for i in range(len(array)):
+        # TODO: https://github.com/google/starlark-rust/issues/98
+        for j in range((len(array) - i) - 1):
+            if array[j] > array[j + 1]:
+                array[j], array[j + 1] = array[j + 1], array[j]
+    return array
+
+def bench():
+    assert_eq([2, 3, 4, 5, 6, 7, 9], bubble_sort([9, 3, 5, 4, 7, 2, 6]))

--- a/starlark/benches/rust-benches/empty.sky
+++ b/starlark/benches/rust-benches/empty.sky
@@ -1,0 +1,4 @@
+# Benching evaluation of empty function
+
+def bench():
+    pass

--- a/starlark/benches/rust_benches.rs
+++ b/starlark/benches/rust_benches.rs
@@ -1,0 +1,24 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[feature(test)]` only works in nightly
+#![cfg(rustc_nightly)]
+#![feature(test)]
+
+extern crate test;
+mod benchutil;
+use crate::benchutil::do_bench;
+use test::Bencher;
+
+include!(concat!(env!("OUT_DIR"), "/benches/rust-benches.rs"));

--- a/starlark/build.rs
+++ b/starlark/build.rs
@@ -11,17 +11,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
+use std::{env, process};
 extern crate lalrpop;
 
 fn main() {
-    conformance_test_cases("tests/java-testcases");
-    conformance_test_cases("tests/rust-testcases");
-    conformance_test_cases("tests/go-testcases");
+    let nightly = query_rust_version_is_nightly();
+
+    test_cases("tests/java-testcases", &TestOrBench::Test);
+    test_cases("tests/rust-testcases", &TestOrBench::Test);
+    test_cases("tests/go-testcases", &TestOrBench::Test);
+    if nightly {
+        println!("cargo:rustc-cfg=rustc_nightly");
+        // Benches only work in nightly
+        test_cases("benches/rust-benches", &TestOrBench::Bench);
+    }
     lalrpop();
 }
 
@@ -36,7 +43,71 @@ fn lalrpop() {
         .unwrap();
 }
 
-fn conformance_test_cases(path: &str) {
+// % rustc +stable --version
+// rustc 1.26.0 (a77568041 2018-05-07)
+// % rustc +beta --version
+// rustc 1.27.0-beta.1 (03fb2f447 2018-05-09)
+// % rustc +nightly --version
+// rustc 1.27.0-nightly (acd3871ba 2018-05-10)
+fn version_is_nightly(version: &str) -> bool {
+    version.contains("nightly")
+}
+
+fn query_rust_version_is_nightly() -> bool {
+    let rustc = env::var("RUSTC").expect("RUSTC unset");
+
+    let mut child = process::Command::new(rustc)
+        .args(&["--version"])
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
+        .spawn()
+        .expect("spawn rustc");
+
+    let mut rustc_version = String::new();
+
+    child
+        .stdout
+        .as_mut()
+        .expect("stdout")
+        .read_to_string(&mut rustc_version)
+        .expect("read_to_string");
+    assert!(child.wait().expect("wait").success());
+
+    version_is_nightly(&rustc_version)
+}
+
+enum TestOrBench {
+    Test,
+    Bench,
+}
+
+fn format_test_content(path: &Path, test_or_bench: &TestOrBench) -> String {
+    let test_name = path.file_stem().unwrap().to_str().unwrap();
+    match test_or_bench {
+        TestOrBench::Test => format!(
+            r#"
+#[test]
+fn test_{}() {{
+    do_conformance_test("{}")
+}}
+"#,
+            test_name,
+            path.to_str().unwrap(),
+        ),
+        TestOrBench::Bench => format!(
+            r#"
+#[bench]
+fn bench_{}(bencher: &mut Bencher) {{
+    do_bench(bencher, "{}")
+}}
+"#,
+            test_name,
+            path.to_str().unwrap(),
+        ),
+    }
+}
+
+fn test_cases(path: &str, test_or_bench: &TestOrBench) {
     println!("cargo:rerun-if-changed={}", path);
     let outfile_path = Path::new(&env::var("OUT_DIR").unwrap()).join(format!("{}.rs", path));
     fs::create_dir_all(outfile_path.parent().unwrap()).unwrap();
@@ -47,21 +118,11 @@ fn conformance_test_cases(path: &str) {
     let paths = fs::read_dir(d).unwrap();
     for p in paths {
         let path_entry = p.unwrap().path();
-        let path = path_entry.strip_prefix(&base).unwrap().to_str().unwrap();
         if path_entry.extension().unwrap().to_str().unwrap() != "md" {
             // Exclude markdown files
-            write!(
-                outfile,
-                r#"
-#[test]
-fn test_{}() {{
-    do_conformance_test("{}")
-}}
-        "#,
-                path_entry.file_stem().unwrap().to_str().unwrap(),
-                path
-            )
-            .unwrap();
+            let content =
+                format_test_content(path_entry.strip_prefix(base).unwrap(), test_or_bench);
+            outfile.write(content.as_bytes()).unwrap();
         }
     }
 }


### PR DESCRIPTION
Certain parts of Starlark Rust might need optimization.

This diff adds skeleton benchmarks.

`empty.sky` is the empty file to understand how long it takes to
parse and evaluate empty file.

`naive_sort.sky` is a simple sort implementation.

Current bench results are:

```
% cargo bench
    Finished release [optimized] target(s) in 0.25s
     Running target/release/deps/rust_benches-80cb4cf71a69319e

running 2 tests
test bench_empty      ... bench:       1,822 ns/iter (+/- 166)
test bench_naive_sort ... bench:     199,729 ns/iter (+/- 6,203)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out
```

Benches are explicitly excluded from the compilation on non-nightly,
because only nightly supports benches, and because
`cargo check --all --all-targets` should not fail on stable.