### PR TITLE
Function parameter types in macros

### DIFF
--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -1,0 +1,162 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parameter conversion utilities for `starlark_module!` macros.
+
+use crate::values::dict::Dictionary;
+use crate::values::error::ValueError;
+use crate::values::{TypedValue, Value};
+use linked_hash_map::LinkedHashMap;
+use std::convert::TryInto;
+use std::hash::Hash;
+
+/// Types implementing this type may appear in function parameter types
+/// in `starlark_module!` macro function signatures.
+pub trait TryParamConvertFromValue: Sized {
+    fn try_from(source: Value) -> Result<Self, ValueError>;
+}
+
+impl<T: TryParamConvertFromValue> TryParamConvertFromValue for Vec<T> {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        let mut r = Vec::new();
+        for item in source.iter()? {
+            r.push(T::try_from(item)?);
+        }
+        Ok(r)
+    }
+}
+
+impl<K: TryParamConvertFromValue + Hash + Eq, V: TryParamConvertFromValue> TryParamConvertFromValue
+    for LinkedHashMap<K, V>
+{
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        Dictionary::apply(&source, &|dict| {
+            let mut r = LinkedHashMap::new();
+            for (k, v) in dict {
+                r.insert(K::try_from(k.get_value().clone())?, V::try_from(v.clone())?);
+            }
+            Ok(r)
+        })
+    }
+}
+
+impl TryParamConvertFromValue for Value {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        Ok(source)
+    }
+}
+
+impl<T: TypedValue + Clone + 'static> TryParamConvertFromValue for T {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        source
+            .downcast_apply(T::clone)
+            .ok_or(ValueError::IncorrectParameterType)
+    }
+}
+
+impl TryParamConvertFromValue for i32 {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        let source = i64::try_from(source)?;
+        source
+            .try_into()
+            .map_err(|_| ValueError::IncorrectParameterType)
+    }
+}
+
+impl TryParamConvertFromValue for u32 {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        let source = i64::try_from(source)?;
+        source
+            .try_into()
+            .map_err(|_| ValueError::IncorrectParameterType)
+    }
+}
+
+impl TryParamConvertFromValue for u64 {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        let source = i64::try_from(source)?;
+        source
+            .try_into()
+            .map_err(|_| ValueError::IncorrectParameterType)
+    }
+}
+
+impl TryParamConvertFromValue for usize {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        let source = i64::try_from(source)?;
+        source
+            .try_into()
+            .map_err(|_| ValueError::IncorrectParameterType)
+    }
+}
+
+/// Starlark `None` or another value.
+pub enum EitherValueOrNone<T> {
+    None,
+    NotNone(T),
+}
+
+impl<T: TryParamConvertFromValue> TryParamConvertFromValue for EitherValueOrNone<T> {
+    fn try_from(source: Value) -> Result<Self, ValueError> {
+        if source.get_type() == "NoneType" {
+            Ok(EitherValueOrNone::None)
+        } else {
+            Ok(EitherValueOrNone::NotNone(T::try_from(source)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::starlark_fun;
+    use crate::starlark_module;
+    use crate::starlark_parse_param_type;
+    use crate::starlark_signature;
+    use crate::starlark_signature_extraction;
+    use crate::starlark_signatures;
+
+    use crate::eval::simple::eval;
+    use crate::stdlib::global_environment;
+    use crate::syntax::dialect::Dialect;
+    use crate::values::Value;
+    use codemap::CodeMap;
+    use std::sync::{Arc, Mutex};
+
+    starlark_module! { global =>
+        cc_binary(name: String, srcs: Vec<String> = Vec::new()) {
+            // real implementation may write it to a global variable
+            Ok(Value::new(format!("{:?} {:?}", name, srcs)))
+        }
+    }
+
+    #[test]
+    fn test_simple() {
+        let env = global_environment();
+        let env = global(env);
+        env.freeze();
+
+        let mut env = env.child("my");
+
+        let r = eval(
+            &Arc::new(Mutex::new(CodeMap::new())),
+            "test_simple.star",
+            "cc_binary(name='star', srcs=['a.cc', 'b.cc'])",
+            Dialect::Build,
+            &mut env,
+        )
+        .unwrap();
+
+        assert_eq!(r#""star" ["a.cc", "b.cc"]"#, r.to_str());
+    }
+}

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -219,10 +219,10 @@ starlark_module! {global =>
     /// "hello, world!".capitalize() == "Hello, World!"
     /// # )"#).unwrap());
     /// ```
-    string.capitalize(this) {
+    string.capitalize(this: String) {
         let mut last_space = true;
         let mut result = String::new();
-        for c in this.to_str().chars() {
+        for c in this.chars() {
             if !c.is_alphanumeric() {
                 last_space = true;
                 result.push(c);
@@ -263,9 +263,9 @@ starlark_module! {global =>
     /// list("Hello, 世界".codepoints()) == [72, 101, 108, 108, 111, 44, 32, 19990, 30028]
     /// # )"#).unwrap());
     /// ```
-    string.codepoints(this) {
+    string.codepoints(this: String) {
         // Note that we return a list here... Which is not equivalent to the go implementation.
-        let v : Vec<i64> = this.to_str().chars().map(|x| i64::from(u32::from(x))).collect();
+        let v : Vec<i64> = this.chars().map(|x| i64::from(u32::from(x))).collect();
         ok!(v)
     }
 
@@ -298,11 +298,9 @@ starlark_module! {global =>
     /// "hello, world!".count("o", 7, 12) == 1  # in "world"
     /// # )"#).unwrap());
     /// ```
-    string.count(this, #needle, #start = 0, #end = None) {
+    string.count(this: String, #needle: String, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
-        let this = this.to_str();
-        let needle = needle.to_str();
         let n = needle.as_str();
         let mut counter = 0 as i64;
         let mut s = this.as_str().get(start..end).unwrap();
@@ -330,9 +328,9 @@ starlark_module! {global =>
     /// "filename.sky".endswith(".sky") == True
     /// # )"#).unwrap());
     /// ```
-    string.endswith(this, #suffix) {
+    string.endswith(this: String, #suffix: String) {
         check_string!(suffix, endswith);
-        ok!(this.to_str().ends_with(suffix.to_str().as_str()))
+        ok!(this.ends_with(suffix.as_str()))
     }
 
     /// [string.find](
@@ -362,10 +360,8 @@ starlark_module! {global =>
     /// "bonbon".find("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.find(this, #needle, #start = 0, #end = None) {
-        check_string!(needle, count);
+    string.find(this: String, #needle: String, #start = 0, #end = None) {
         convert_indices!(this, start, end);
-        let this = this.to_str();
         let needle = needle.to_str();
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.find(needle.as_str()) {
@@ -432,9 +428,8 @@ starlark_module! {global =>
     /// "Is {0!r} {0!s}?".format("heterological") == "Is \"heterological\" heterological?"
     /// # )"#).unwrap());
     /// ```
-    string.format(this, *args, **kwargs) {
+    string.format(this: String, *args, **kwargs) {
         let mut it = args.iter().cloned();
-        let this = this.to_str();
         let mut captured_by_index = false;
         let mut captured_by_order = false;
         let mut result = String::new();
@@ -517,11 +512,9 @@ starlark_module! {global =>
     /// "bonbon".index("on", 2, 5) # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.index(this, #needle, #start = 0, #end = None) {
+    string.index(this: String, #needle: String, #start = 0, #end = None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
-        let this = this.to_str();
-        let needle = needle.to_str();
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.find(needle.as_str()) {
                 ok!((offset + start) as i64);
@@ -552,8 +545,7 @@ starlark_module! {global =>
     /// "Catch-22".isalnum() == False
     /// # )"#).unwrap());
     /// ```
-    string.isalnum(this) {
-        let this = this.to_str();
+    string.isalnum(this: String) {
         if this.is_empty() {
             ok!(false);
         }
@@ -585,8 +577,7 @@ starlark_module! {global =>
     /// "".isalpha() == False
     /// # )"#).unwrap());
     /// ```
-    string.isalpha(this) {
-        let this = this.to_str();
+    string.isalpha(this: String) {
         if this.is_empty() {
             ok!(false);
         }
@@ -618,8 +609,7 @@ starlark_module! {global =>
     /// "".isdigit() == False
     /// # )"#).unwrap());
     /// ```
-    string.isdigit(this) {
-        let this = this.to_str();
+    string.isdigit(this: String) {
         if this.is_empty() {
             ok!(false);
         }
@@ -652,9 +642,9 @@ starlark_module! {global =>
     /// "123".islower() == False
     /// # )"#).unwrap());
     /// ```
-    string.islower(this) {
+    string.islower(this: String) {
         let mut result = false;
-        for c in this.to_str().chars() {
+        for c in this.chars() {
             if c.is_uppercase() {
                 ok!(false);
             } else if c.is_lowercase() {
@@ -684,8 +674,7 @@ starlark_module! {global =>
     /// "".isspace() == False
     /// # )"#).unwrap());
     /// ```
-    string.isspace(this) {
-        let this = this.to_str();
+    string.isspace(this: String) {
         if this.is_empty() {
             ok!(false);
         }
@@ -721,11 +710,11 @@ starlark_module! {global =>
     /// "123".istitle() == False
     /// # )"#).unwrap());
     /// ```
-    string.istitle(this) {
+    string.istitle(this: String) {
         let mut last_space = true;
         let mut result = false;
 
-        for c in this.to_str().chars() {
+        for c in this.chars() {
             if !c.is_alphabetic() {
                 last_space = true;
             } else {
@@ -766,9 +755,9 @@ starlark_module! {global =>
     /// "123".isupper() == False
     /// # )"#).unwrap());
     /// ```
-    string.isupper(this) {
+    string.isupper(this: String) {
         let mut result = false;
-        for c in this.to_str().chars() {
+        for c in this.chars() {
             if c.is_lowercase() {
                 ok!(false);
             } else if c.is_uppercase() {
@@ -798,8 +787,7 @@ starlark_module! {global =>
     /// "a".join("ctmrn".split_codepoints()) == "catamaran"
     /// # )"#).unwrap());
     /// ```
-    string.join(this, #to_join) {
-        let this = this.to_str();
+    string.join(this: String, #to_join) {
         ok!(
             to_join.iter()?.fold(
                 Ok(String::new()),
@@ -830,8 +818,8 @@ starlark_module! {global =>
     /// "Hello, World!".lower() == "hello, world!"
     /// # )"#).unwrap());
     /// ```
-    string.lower(this) {
-        ok!(this.to_str().to_lowercase())
+    string.lower(this: String) {
+        ok!(this.to_lowercase())
     }
 
     /// [string.lstrip](
@@ -848,8 +836,8 @@ starlark_module! {global =>
     /// "  hello  ".lstrip() == "hello  "
     /// # )"#).unwrap());
     /// ```
-    string.lstrip(this) {
-        ok!(this.to_str().trim_start())
+    string.lstrip(this: String) {
+        ok!(this.trim_start())
     }
 
     /// [string.partition](
@@ -871,7 +859,7 @@ starlark_module! {global =>
     /// "one/two/three".partition("/")	 == ("one", "/", "two/three")
     /// # )"#).unwrap());
     /// ```
-    string.partition(this, #needle = " ") {
+    string.partition(this: String, #needle = " ") {
         check_string!(needle, partition);
         let needle = needle.to_str();
         if needle.is_empty() {
@@ -881,7 +869,6 @@ starlark_module! {global =>
                 "Empty separtor".to_owned()
             )
         }
-        let this = this.to_str();
         if let Some(offset) = this.find(needle.as_str()) {
             let offset2 = offset + needle.len();
             ok!((
@@ -914,14 +901,13 @@ starlark_module! {global =>
     /// "banana".replace("a", "o", 2)	 == "bonona"
     /// # )"#).unwrap());
     /// ```
-    string.replace(this, #old, #new, ?#count) {
+    string.replace(this: String, #old: String, #new: String, ?#count: Option<usize>) {
         check_string!(old, replace);
         check_string!(new, replace);
-        let (this, old, new) = (this.to_str(), old.to_str(), new.to_str());
         ok!(
             match count {
                 None => this.replace(old.as_str(), new.as_str()),
-                Some(count) => this.replacen(old.as_str(), new.as_str(), count.to_int()? as usize),
+                Some(count) => this.replacen(old.as_str(), new.as_str(), count as usize),
             }
         )
     }
@@ -948,11 +934,8 @@ starlark_module! {global =>
     /// "bonbon".rfind("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.rfind(this, #needle, #start = 0, #end = None) {
-        check_string!(needle, count);
+    string.rfind(this: String, #needle: String, #start = 0, #end = None) {
         convert_indices!(this, start, end);
-        let this = this.to_str();
-        let needle = needle.to_str();
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
                 ok!((offset + start) as i64);
@@ -983,12 +966,9 @@ starlark_module! {global =>
     /// "bonbon".rindex("on", 2, 5)   # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.rindex(this, #needle, #start = 0, #end = None) {
-        check_string!(needle, count);
+    string.rindex(this: String, #needle: String, #start = 0, #end = None) {
         convert_indices!(this, start, end);
-        let this = this.to_str();
-        let needle = needle.to_str();
-        if let Some(substring) = this.as_str().get(start..end) {
+        if let Some(substring) = this.get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
                 ok!((offset + start) as i64);
             }
@@ -1014,9 +994,7 @@ starlark_module! {global =>
     /// "one/two/three".rpartition("/")	 == ("one/two", "/", "three")
     /// # )"#).unwrap());
     /// ```
-    string.rpartition(this, #needle = " ") {
-        check_string!(needle, partition);
-        let needle = needle.to_str();
+    string.rpartition(this: String, #needle: String = " ".to_owned()) {
         if needle.is_empty() {
             starlark_err!(
                 INCORRECT_PARAMETER_TYPE_ERROR_CODE,
@@ -1059,8 +1037,7 @@ starlark_module! {global =>
     /// "one two  three".rsplit(None, 1) == ["one two", "three"]
     /// # )"#).unwrap());
     /// ```
-    string.rsplit(this, #sep = None, #maxsplit = None) {
-        let this = this.to_str();
+    string.rsplit(this: String, #sep = None, #maxsplit = None) {
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
         } else {
@@ -1105,7 +1082,7 @@ starlark_module! {global =>
     /// "  hello  ".rstrip() == "  hello"
     /// # )"#).unwrap());
     /// ```
-    string.rstrip(this) {
+    string.rstrip(this: String) {
         ok!(this.to_str().trim_end())
     }
 
@@ -1151,7 +1128,7 @@ starlark_module! {global =>
     /// "banana".split("n", 1) == ["ba", "ana"]
     /// # )"#).unwrap());
     /// ```
-    string.split(this, #sep = None, #maxsplit = None) {
+    string.split(this: String, #sep = None, #maxsplit = None) {
         let this = this.to_str();
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
@@ -1205,7 +1182,7 @@ starlark_module! {global =>
     /// list("Hello, 世界".split_codepoints()) == ["H", "e", "l", "l", "o", ",", " ", "世", "界"]
     /// # )"#).unwrap());
     /// ```
-    string.split_codepoints(this) {
+    string.split_codepoints(this: String) {
         let v : Vec<String> = this.to_str().chars().map(|x| x.to_string()).collect();
         ok!(v)
     }
@@ -1233,7 +1210,7 @@ starlark_module! {global =>
     /// "one\n\ntwo".splitlines(True) == ["one\n", "\n", "two"]
     /// # )"#).unwrap());
     /// ```
-    string.splitlines(this, #keepends = false) {
+    string.splitlines(this: String, #keepends = false) {
         check_type!(keepends, "string.splitlines", bool);
         let this = this.to_str();
         let mut s = this.as_str();
@@ -1278,7 +1255,7 @@ starlark_module! {global =>
     /// "filename.sky".startswith("filename") == True
     /// # )"#).unwrap());
     /// ```
-    string.startswith(this, #prefix) {
+    string.startswith(this: String, #prefix) {
         check_string!(prefix, startswith);
         ok!(this.to_str().starts_with(prefix.to_str().as_str()))
     }
@@ -1297,8 +1274,8 @@ starlark_module! {global =>
     /// "  hello  ".strip() == "hello"
     /// # )"#).unwrap());
     /// ```
-    string.strip(this) {
-        ok!(this.to_str().trim())
+    string.strip(this: String) {
+        ok!(this.trim())
     }
 
     /// [string.title](
@@ -1317,7 +1294,7 @@ starlark_module! {global =>
     /// "hElLo, WoRlD!".title() == "Hello, World!"
     /// # )"#).unwrap());
     /// ```
-    string.title(this) {
+    string.title(this: String) {
         let mut last_space = true;
         let mut result = String::new();
         for c in this.to_str().chars() {
@@ -1356,7 +1333,7 @@ starlark_module! {global =>
     /// "Hello, World!".upper() == "HELLO, WORLD!"
     /// # )"#).unwrap());
     /// ```
-    string.upper(this) {
+    string.upper(this: String) {
         ok!(this.to_str().to_uppercase())
     }
 }

--- a/starlark/src/values/error.rs
+++ b/starlark/src/values/error.rs
@@ -60,6 +60,8 @@ pub enum ValueError {
     CannotMutateImmutableValue,
     /// Trying to apply incorrect parameter type, e.g. for slicing.
     IncorrectParameterType,
+    /// Trying to apply incorrect parameter type, e.g. for slicing.
+    IncorrectParameterTypeNamed(&'static str),
     /// Trying to access an index outside of the value range,
     IndexOutOfBound(i64),
     /// The value is not hashable but was requested for a hash structure (e.g. dictionary).
@@ -139,6 +141,9 @@ impl SyntaxError for ValueError {
                         ValueError::IncorrectParameterType => {
                             "Type of parameters mismatch".to_owned()
                         }
+                        ValueError::IncorrectParameterTypeNamed(_) => {
+                            "Type of parameters mismatch".to_owned()
+                        }
                         ValueError::IndexOutOfBound(..) => "Index out of bound".to_owned(),
                         ValueError::NotHashableValue => "Value is not hashable".to_owned(),
                         ValueError::KeyNotFound(..) => "Key not found".to_owned(),
@@ -182,6 +187,9 @@ impl SyntaxError for ValueError {
                         ValueError::IncorrectParameterType => {
                             "Type of parameters mismatch".to_owned()
                         }
+                        ValueError::IncorrectParameterTypeNamed(name) => {
+                            format!("Type of parameters {} mismatch", name)
+                        }
                         ValueError::IndexOutOfBound(ref b) => {
                             format!("Index {} is out of bound", b)
                         }
@@ -208,7 +216,7 @@ impl SyntaxError for ValueError {
                             ValueError::DivisionByZero => DIVISION_BY_ZERO_ERROR_CODE,
                             ValueError::IntegerOverflow => INTEGER_OVERFLOW_ERROR_CODE,
                             ValueError::CannotMutateImmutableValue => IMMUTABLE_ERROR_CODE,
-                            ValueError::IncorrectParameterType => {
+                            ValueError::IncorrectParameterType | ValueError::IncorrectParameterTypeNamed(..) => {
                                 INCORRECT_PARAMETER_TYPE_ERROR_CODE
                             }
                             ValueError::IndexOutOfBound(..) => OUT_OF_BOUND_ERROR_CODE,


### PR DESCRIPTION
`starlark_module!` macro function definitions can now optionally
specify function parameter type, and Starlark implementation will
take care of boring parameter conversion.

E. g. conversion of `Value` to `Vec<String>` previously required
explicit iteration over `Value` and downcasting each element to
`String`.

It is a simple type annotation now, and Starlark Rust embedding
should be much easier.

Example module definition:

```
starlark_module! { global =>
    cc_binary(name: String, srcs: Vec<String> = Vec::new()) {
        ...
    }
}
```