### PR TITLE
Fix cargo test in starlark folder

### DIFF
--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -106,7 +106,7 @@ fn sets() {
     assert_eq!(err.level, codemap_diagnostic::Level::Error);
     assert_eq!(
         err.code,
-        Some(crate::values::NOT_SUPPORTED_ERROR_CODE.to_string())
+        Some(crate::values::error::NOT_SUPPORTED_ERROR_CODE.to_string())
     );
 }
 


### PR DESCRIPTION
`cargo test --all` in the repository root seems to enable all
features, and `cargo test` in `starlark` directory before this
commit fails with:

```
error[E0425]: cannot find value `NOT_SUPPORTED_ERROR_CODE` in module `crate::values`
   --> starlark/src/eval/tests.rs:109:29
    |
109 |         Some(crate::values::NOT_SUPPORTED_ERROR_CODE.to_string())
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^ not found in `crate::values`
help: possible candidate is found in another module, you can import it into scope
    |
15  | use crate::values::error::NOT_SUPPORTED_ERROR_CODE;
    |
```

Failing code above is compiled when feature `linked_hash_set` is not enabled.