### PR TITLE
Replace downcast_apply with downcast_ref

### DIFF
--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -49,20 +49,23 @@ impl Dictionary {
         v: &Value,
         f: &dyn Fn(&LinkedHashMap<HashedValue, Value>) -> Result<Return, ValueError>,
     ) -> Result<Return, ValueError> {
-        v.downcast_apply(|x: &Dictionary| -> Result<Return, ValueError> { f(&x.content) })
-            .unwrap_or(Err(ValueError::IncorrectParameterType))
+        match v.downcast_ref::<Dictionary>() {
+            Some(x) => f(&x.content),
+            None => Err(ValueError::IncorrectParameterType),
+        }
     }
 
     pub fn mutate(
         v: &Value,
         f: &dyn Fn(&mut LinkedHashMap<HashedValue, Value>) -> ValueResult,
     ) -> ValueResult {
-        let mut v = v.clone();
-        v.downcast_apply_mut(|x: &mut Dictionary| -> ValueResult {
-            x.mutability.test()?;
-            f(&mut x.content)
-        })
-        .unwrap_or(Err(ValueError::IncorrectParameterType))
+        match v.downcast_mut::<Dictionary>() {
+            Some(mut x) => {
+                x.mutability.test()?;
+                f(&mut x.content)
+            }
+            None => Err(ValueError::IncorrectParameterType),
+        }
     }
 }
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -47,12 +47,13 @@ impl List {
     }
 
     pub fn mutate(v: &Value, f: &dyn Fn(&mut Vec<Value>) -> ValueResult) -> ValueResult {
-        let mut v = v.clone();
-        v.downcast_apply_mut(|x: &mut List| -> ValueResult {
-            x.mutability.test()?;
-            f(&mut x.content)
-        })
-        .unwrap_or(Err(ValueError::IncorrectParameterType))
+        match v.downcast_mut::<List>() {
+            Some(mut x) => {
+                x.mutability.test()?;
+                f(&mut x.content)
+            }
+            None => Err(ValueError::IncorrectParameterType),
+        }
     }
 }
 


### PR DESCRIPTION
... and replace `downcast_apply_mut` with `downcast_mut` in `Value`.

I think working with `Ref` or `RefMut` is easier than providing
callbacks.

Similar signature change is done in WIP PR #94. If changing to `Ref`
and `RefMut` is not right, I should rewrite #94 back to `downcast_apply`.