### PR TITLE
Change None representation from Option<()> to ()

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -97,7 +97,7 @@ starlark_module! {print_function =>
             r.push_str(&arg.to_str());
         }
         eprintln!("{}", r);
-        Ok(Value::new(None))
+        Ok(Value::new(()))
     }
 }
 

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -470,7 +470,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for TransformedExpr<T> {
     }
 
     fn set(&self, context: &mut EvaluationContext<T>, new_value: Value) -> EvalResult {
-        let ok = Ok(Value::new(None));
+        let ok = Ok(Value::new(()));
         match self {
             TransformedExpr::List(ref v, ref span) | &TransformedExpr::Tuple(ref v, ref span) => {
                 let l = v.len() as i64;
@@ -696,7 +696,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstExpr {
     }
 
     fn set(&self, context: &mut EvaluationContext<T>, new_value: Value) -> EvalResult {
-        let ok = Ok(Value::new(None));
+        let ok = Ok(Value::new(()));
         match self.node {
             Expr::Tuple(ref v) | Expr::List(ref v) => {
                 let l = v.len() as i64;
@@ -738,11 +738,11 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
         match self.node {
             Statement::Break => Err(EvalException::Break(self.span)),
             Statement::Continue => Err(EvalException::Continue(self.span)),
-            Statement::Pass => Ok(Value::new(None)),
+            Statement::Pass => Ok(Value::new(())),
             Statement::Return(Some(ref e)) => {
                 Err(EvalException::Return(self.span, e.eval(context)?))
             }
-            Statement::Return(None) => Err(EvalException::Return(self.span, Value::new(None))),
+            Statement::Return(None) => Err(EvalException::Return(self.span, Value::new(()))),
             Statement::Expression(ref e) => e.eval(context),
             Statement::Assign(ref lhs, AssignOp::Assign, ref rhs) => {
                 let rhs = rhs.eval(context)?;
@@ -788,7 +788,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                 if cond.eval(context)?.to_bool() {
                     st.eval(context)
                 } else {
-                    Ok(Value::new(None))
+                    Ok(Value::new(()))
                 }
             }
             Statement::IfElse(ref cond, ref st1, ref st2) => {
@@ -806,7 +806,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                 ref st,
             ) => {
                 let mut iterable = e2.eval(context)?;
-                let mut result = Ok(Value::new(None));
+                let mut result = Ok(Value::new(()));
                 iterable.freeze_for_iteration();
                 for v in t!(iterable.iter(), span * span)? {
                     e1.set(context, v)?;
@@ -858,12 +858,12 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                     t!(context.env.import_symbol(&loadenv, &orig_name.node, &new_name.node),
                         span new_name.span.merge(orig_name.span))?
                 }
-                Ok(Value::new(None))
+                Ok(Value::new(()))
             }
             Statement::Statements(ref v) => {
                 let r = eval_vector!(v, context);
                 match r.len() {
-                    0 => Ok(Value::new(None)),
+                    0 => Ok(Value::new(())),
                     _ => Ok(r.last().unwrap().clone()),
                 }
             }
@@ -918,7 +918,7 @@ pub fn eval_def(
     match stmts.eval(&mut ctx) {
         Err(EvalException::Return(_s, ret)) => Ok(ret),
         Err(x) => Err(ValueError::DiagnosedError(x.into())),
-        Ok(..) => Ok(Value::new(None)),
+        Ok(..) => Ok(Value::new(())),
     }
 }
 

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -72,7 +72,7 @@ starlark_module! {global =>
     /// ```
     set.add(this, #el) {
         Set::insert_if_absent(&this, el)?;
-        ok!(None)
+        ok!(())
     }
 
     /// set.clear: clear a set
@@ -96,7 +96,7 @@ starlark_module! {global =>
     set.clear(this) {
         Set::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -199,7 +199,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -226,7 +226,7 @@ starlark_module! {global =>
     set.discard(this, #needle) {
         Set::mutate(&this, &|x| {
             x.remove(&HashedValue::new(needle.clone())?);
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -305,7 +305,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -405,7 +405,7 @@ starlark_module! {global =>
     /// x == set([3])
     /// # )"#).unwrap());
     /// ```
-    set.pop(this, #index = None) {
+    set.pop(this, #index = ()) {
         let length = this.length()?;
         let index = if index.get_type() == "NoneType" {
             length - 1
@@ -460,7 +460,7 @@ starlark_module! {global =>
             ok!(x.remove(&HashedValue::new(needle.clone())?))
         });
         if did_remove?.to_bool() {
-            ok!(None)
+            ok!(())
         } else {
             starlark_err!(
                 SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE,
@@ -540,7 +540,7 @@ starlark_module! {global =>
             for item in symmetric_difference.iter()? {
                 s.insert(HashedValue::new(item)?);
             }
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -610,6 +610,6 @@ starlark_module! {global =>
                 Set::insert_if_absent(&this, el)?;
             }
         }
-        ok!(None)
+        ok!(())
     }
 }

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -51,7 +51,7 @@ impl Set {
         let v = v.clone_for_container_value(set)?;
         Self::mutate(set, &|hashset| {
             hashset.insert_if_absent(HashedValue::new(v.clone())?);
-            Ok(Value::from(None))
+            Ok(Value::from(()))
         })
     }
 

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -53,7 +53,7 @@ starlark_module! {global =>
             &this,
             &|x: &mut LinkedHashMap<HashedValue, Value>| -> ValueResult {
                 x.clear();
-                ok!(None)
+                ok!(())
             }
         )
     }
@@ -82,7 +82,7 @@ starlark_module! {global =>
     /// x.get("three", 0) == 0
     /// # )"#).unwrap());
     /// ```
-    dict.get(this, #key, #default = None) {
+    dict.get(this, #key, #default = ()) {
         match this.at(key) {
             Err(ValueError::KeyNotFound(..)) => Ok(default),
             x => x
@@ -170,7 +170,7 @@ starlark_module! {global =>
     /// ```python
     /// x.pop("four")  # error: missing key
     /// ```
-    dict.pop(this, #key, #default = None) {
+    dict.pop(this, #key, #default = ()) {
         let key = HashedValue::new(key)?;
         let key_error = format!("Key '{}' not found in '{}'", key.get_value().to_repr(), this.to_repr());
         dict::Dictionary::mutate(
@@ -263,7 +263,7 @@ starlark_module! {global =>
     /// x == {"one": 1, "two": 2, "three": 0, "four": None}
     /// # )"#).unwrap());
     /// ```
-    dict.setdefault(this, #key, #default = None) {
+    dict.setdefault(this, #key, #default = ()) {
         let key = HashedValue::new(key)?;
         let cloned_default = default.clone_for_container_value(&this);
         dict::Dictionary::mutate(
@@ -346,7 +346,7 @@ starlark_module! {global =>
         for (k, v) in kwargs {
             this.set_at(k.into(), v)?;
         }
-        ok!(None)
+        ok!(())
     }
 
     /// [dict.values](

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -56,7 +56,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &|x| {
             x.push(el.clone()?);
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -81,7 +81,7 @@ starlark_module! {global =>
     list.clear(this) {
         list::List::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -113,7 +113,7 @@ starlark_module! {global =>
         let other_cloned: Result<Vec<_>, _>  = other.iter()?.map(|v| v.clone_for_container_value(&this_cloned)).collect();
         list::List::mutate(&this, &|x| {
             x.extend(other_cloned.clone()?);
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -146,7 +146,7 @@ starlark_module! {global =>
     /// x.index("a", -2) == 5  # bananA
     /// # )"#).unwrap());
     /// ```
-    list.index(this, #needle, #start = 0, #end = None) {
+    list.index(this, #needle, #start = 0, #end = ()) {
         convert_indices!(this, start, end);
         let mut it = this.iter()?.skip(start).take(end - start);
         if let Some(offset) = it.position(|x| x == needle) {
@@ -190,7 +190,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &move |x| {
             x.insert(index, el.clone()?);
-            ok!(None)
+            ok!(())
         })
     }
 
@@ -264,7 +264,7 @@ starlark_module! {global =>
         if let Some(offset) = it.position(|x| x == needle) {
             list::List::mutate(&this, &|x| {
                 x.remove(offset);
-                ok!(None)
+                ok!(())
             })
         } else {
             starlark_err!(

--- a/starlark/src/stdlib/macros.rs
+++ b/starlark/src/stdlib/macros.rs
@@ -296,7 +296,7 @@ macro_rules! starlark_signatures {
 ///            if let Some(x) = environ.get_parent() { x.name() } else { "<root>".to_owned() },
 ///            cs.iter().skip(1).fold(String::new(), |a, x| format!("{}\n{}", a, x.1))
 ///        );
-///        Ok(Value::from(None))
+///        Ok(Value::from(()))
 ///     }
 /// }
 /// #

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -348,7 +348,7 @@ starlark_module! {global_functions =>
     /// getattr("banana", "split")("a") == ["b", "n", "n", ""] # equivalent to "banana".split("a")
     /// # "#).unwrap());
     /// ```
-    getattr(env env, #a, #attr, #default=None) {
+    getattr(env env, #a, #attr, #default = ()) {
         if attr.get_type() != "string" {
             starlark_err!(
                 ATTR_NAME_NOT_STRING_ERROR_CODE,
@@ -966,7 +966,7 @@ starlark_module! {global_functions =>
 /// of this global environment that have been frozen.
 pub fn global_environment() -> Environment {
     let env = add_set(Environment::new("global"));
-    env.set("None", Value::new(None)).unwrap();
+    env.set("None", Value::new(())).unwrap();
     env.set("True", Value::new(true)).unwrap();
     env.set("False", Value::new(false)).unwrap();
     dict::global(list::global(string::global(global_functions(env))))

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -298,7 +298,7 @@ starlark_module! {global =>
     /// "hello, world!".count("o", 7, 12) == 1  # in "world"
     /// # )"#).unwrap());
     /// ```
-    string.count(this, #needle, #start = 0, #end = None) {
+    string.count(this, #needle, #start = 0, #end = ()) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -362,7 +362,7 @@ starlark_module! {global =>
     /// "bonbon".find("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.find(this, #needle, #start = 0, #end = None) {
+    string.find(this, #needle, #start = 0, #end = ()) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -517,7 +517,7 @@ starlark_module! {global =>
     /// "bonbon".index("on", 2, 5) # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.index(this, #needle, #start = 0, #end = None) {
+    string.index(this, #needle, #start = 0, #end = ()) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -948,7 +948,7 @@ starlark_module! {global =>
     /// "bonbon".rfind("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.rfind(this, #needle, #start = 0, #end = None) {
+    string.rfind(this, #needle, #start = 0, #end = ()) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -983,7 +983,7 @@ starlark_module! {global =>
     /// "bonbon".rindex("on", 2, 5)   # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.rindex(this, #needle, #start = 0, #end = None) {
+    string.rindex(this, #needle, #start = 0, #end = ()) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let this = this.to_str();
@@ -1059,7 +1059,7 @@ starlark_module! {global =>
     /// "one two  three".rsplit(None, 1) == ["one two", "three"]
     /// # )"#).unwrap());
     /// ```
-    string.rsplit(this, #sep = None, #maxsplit = None) {
+    string.rsplit(this, #sep = (), #maxsplit = ()) {
         let this = this.to_str();
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
@@ -1151,7 +1151,7 @@ starlark_module! {global =>
     /// "banana".split("n", 1) == ["ba", "ana"]
     /// # )"#).unwrap());
     /// ```
-    string.split(this, #sep = None, #maxsplit = None) {
+    string.split(this, #sep = (), #maxsplit = ()) {
         let this = this.to_str();
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -86,7 +86,7 @@ impl From<FunctionArg> for Value {
             FunctionArg::ArgsArray(v) => v.into(),
             FunctionArg::Optional(v) => match v {
                 Some(v) => v,
-                None => Value::new(None),
+                None => Value::new(()),
             },
             FunctionArg::KWArgsDict(v) => {
                 // `unwrap` does not panic, because key is a string which hashable

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -36,31 +36,27 @@
 //!
 //! ```rust,ignore
 //! /// Define the NoneType type
-//! impl TypedValue for Option<()> {
-//!     immutable!();
-//!     any!();  // Generally you don't want to implement as_any() and as_any_mut() yourself.
-//!     fn to_str(&self) -> String {
-//!         "None".to_owned()
-//!     }
-//!     fn to_repr(&self) -> String {
-//!         self.to_str()
-//!     }
-//!     not_supported!(to_int);
-//!     fn get_type(&self) -> &'static str {
-//!         "NoneType"
-//!     }
-//!     fn to_bool(&self) -> bool {
-//!         false
-//!     }
-//!     // just took the result of hash(None) in macos python 2.7.10 interpreter.
-//!     fn get_hash(&self) -> Result<u64, ValueError> {
-//!         Ok(9223380832852120682)
-//!     }
-//!     fn compare(&self, other: &Value) -> Ordering { default_compare(self, other) }
-//!     not_supported!(binop);
-//!     not_supported!(container);
-//!     not_supported!(function);
-//! }
+//! impl TypedValue for () {
+//!    immutable!();
+//!    any!();
+//!    default_compare!();
+//!    fn to_repr(&self) -> String {
+//!        "None".to_owned()
+//!    }
+//!    fn get_type(&self) -> &'static str {
+//!        "NoneType"
+//!    }
+//!    fn to_bool(&self) -> bool {
+//!        false
+//!    }
+//!    // just took the result of hash(None) in macos python 2.7.10 interpreter.
+//!    fn get_hash(&self) -> Result<u64, ValueError> {
+//!        Ok(9_223_380_832_852_120_682)
+//!    }
+//!    fn is_descendant(&self, _other: &TypedValue) -> bool {
+//!        false
+//!    }
+//!}
 //! ```
 //!
 //! In addition to the `TypedValue` trait, it is recommended to implement the `From` trait

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -17,7 +17,7 @@
 use crate::values::*;
 
 /// Define the NoneType type
-impl TypedValue for Option<()> {
+impl TypedValue for () {
     immutable!();
     any!();
     default_compare!();
@@ -39,8 +39,8 @@ impl TypedValue for Option<()> {
     }
 }
 
-impl From<Option<()>> for Value {
-    fn from(_a: Option<()>) -> Value {
-        Value::new(None)
+impl From<()> for Value {
+    fn from((): ()) -> Self {
+        Value::new(())
     }
 }

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -433,12 +433,6 @@ impl TypedValue for Tuple {
     }
 }
 
-impl From<()> for Value {
-    fn from(_a: ()) -> Value {
-        Value::new(Tuple::from(()))
-    }
-}
-
 macro_rules! from_tuple {
     ($x: ty) => {
         impl From<$x> for Value {
@@ -492,7 +486,9 @@ mod tests {
         assert_eq!("(1, 2, 3)", Value::from((1, 2, 3)).to_str());
         assert_eq!("(1, (2, 3))", Value::from((1, (2, 3))).to_str());
         assert_eq!("(1,)", Value::from((1,)).to_str());
-        assert_eq!("()", Value::from(()).to_str());
+        assert_eq!("()", Tuple::new(&[]).to_str());
+        // Empty tuple (unit) represents `None` in Starlark
+        assert_eq!("None", Value::from(()).to_str());
     }
 
     #[test]


### PR DESCRIPTION
Three reasons for this:

* First, "no return value" in Rust is `()` and `None` in Starlark,
  so it seems logical to represent them using the same Rust type.
* `Option<()>` occupies one byte. Although it is not performance critial,
  it is a bit misleading: if Rust `None` is Starlark `None`, then
  what is `Some(())`?
* `From<()>` to make a `()` was never used in starlark-rust and
  probably never needed by anyone.