### PR TITLE
Replace `linked_hash_set` feature with runtime conf option

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,6 @@ case "$1" in
   build)
     cargo build --all
     cargo test --all
-    (cd starlark && cargo test --all --features=linked_hash_set)
     ;;
   doc)
     cargo doc --all

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ https://github.com/google/skylark/blob/a0e5de7e63b47e716cca7226662a4c95d47bf873/
 and the Python 3 documentation when things were unclear.
 
 This interpreter does not support most of the go extensions (e.g. bitwise
-operator or floating point). It optionally includes a `set` type (by enabling the `linked_hash_set` feature),
+operator or floating point). It optionally includes a `set` type
+(by explicitly including `starlark::linked_hash_set::global()` environment),
 as an extension which is not specified in [the
 official Starlark specification](https://github.com/bazelbuild/starlark/blob/master/spec.md), but note that this
 is just an insertion-order-preserving set, and does not have optimisations for nesting as can be found in the

--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -36,7 +36,3 @@ bench = false
 [[bin]]
 name = "starlark-repl"
 bench = false
-
-[features]
-default = ["linked_hash_set"]
-linked_hash_set = ["starlark/linked_hash_set"]

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -16,7 +16,7 @@
 
 use getopts::Options;
 use starlark::eval::interactive::{eval, eval_file, EvalError};
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
@@ -83,9 +83,7 @@ fn main() {
                     exit(EXIT_CODE_USAGE);
                 }
 
-                let global = print_function(global_environment());
-                // `struct` is not a part of the Starlark spec, but may be useful in REPL.
-                let global = structs::global(global);
+                let global = print_function(global_environment_with_extensions());
                 global.freeze();
 
                 let dialect = if build_file {

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -26,7 +26,7 @@ codemap = "0.1.1"
 codemap-diagnostic = "0.1.1"
 lalrpop-util = "0.16.0"
 linked-hash-map = "0.5.1"
-linked_hash_set = { version = "0.1.3", optional = true }
+linked_hash_set = "0.1.3"
 
 [lib]
 bench = false

--- a/starlark/benches/benchutil/mod.rs
+++ b/starlark/benches/benchutil/mod.rs
@@ -16,7 +16,7 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Emitter};
 use linked_hash_map::LinkedHashMap;
 use starlark::eval::simple::eval;
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::error::ValueError;
 use std::fs::File;
@@ -31,8 +31,7 @@ pub fn do_bench(bencher: &mut Bencher, path: &str) {
     drop(file);
 
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let global = global_environment();
-    let global = structs::global(global);
+    let global = global_environment_with_extensions();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     eval(

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -79,5 +79,4 @@ pub mod values;
 pub mod eval;
 #[macro_use]
 pub mod stdlib;
-#[cfg(feature = "linked_hash_set")]
 pub mod linked_hash_set;

--- a/starlark/src/linked_hash_set/mod.rs
+++ b/starlark/src/linked_hash_set/mod.rs
@@ -1,2 +1,11 @@
-pub mod stdlib;
+use crate::environment::Environment;
+
+mod stdlib;
 pub mod value;
+
+/// Include `set` constructor and set functions in environment.
+pub fn global(env: Environment) -> Environment {
+    let env = stdlib::global(env);
+    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
+    env
+}

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -965,22 +965,18 @@ starlark_module! {global_functions =>
 /// For example `stdlib::global_environment().freeze().child("test")` create a child environment
 /// of this global environment that have been frozen.
 pub fn global_environment() -> Environment {
-    let env = add_set(Environment::new("global"));
+    let env = Environment::new("global");
     env.set("None", Value::new(None)).unwrap();
     env.set("True", Value::new(true)).unwrap();
     env.set("False", Value::new(false)).unwrap();
     dict::global(list::global(string::global(global_functions(env))))
 }
 
-#[cfg(feature = "linked_hash_set")]
-fn add_set(env: Environment) -> Environment {
-    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
-    crate::linked_hash_set::stdlib::global(env)
-}
-
-#[cfg(not(feature = "linked_hash_set"))]
-fn add_set(env: Environment) -> Environment {
-    env
+/// Default global environment with added non-standard `struct` and `set` extensions.
+pub fn global_environment_with_extensions() -> Environment {
+    let env = global_environment();
+    let env = structs::global(env);
+    crate::linked_hash_set::global(env)
 }
 
 /// Execute a starlark snippet with the default environment for test and return the truth value
@@ -988,8 +984,7 @@ fn add_set(env: Environment) -> Environment {
 #[doc(hidden)]
 pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    let env = global_environment();
-    let env = structs::global(env);
+    let env = global_environment_with_extensions();
     let mut env = env.freeze().child("test");
     match eval(&map, "<test>", snippet, Dialect::Bzl, &mut env) {
         Ok(v) => Ok(v.to_bool()),

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -17,7 +17,7 @@
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::simple::eval;
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, Write};
@@ -75,8 +75,7 @@ fn assert_diagnostic(
 
 fn run_conformance_test(path: &str) -> bool {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let global = global_environment();
-    let global = structs::global(global);
+    let global = global_environment_with_extensions();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     eval(


### PR DESCRIPTION
Now to enable sets client must explicitly call

```
starlark::linked_hash_set::global(env)
```

If that function is not called, `set` function and `Set` type are
unavailable , and technically user can provide custom set implementation.

`linked_hash_set` as feature is somewhat inconvenient:

* `{1, 2}` could work or not work depending on compilation options,
  and client Rust code has no easy way to ensure `set` is present
* each additional feature increases increases maintenance cost
  and produces problems like one fixed in #103

`global_environment_with_extensions` is a convenient shortcut to
enable both `set` and `struct` extensions.

REPL enables both `set` and `struct` (as before this diff when
feature is enabled).