### PR TITLE
Replace `linked_hash_set` feature with runtime conf option

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,6 @@ case "$1" in
   build)
     cargo build --all
     cargo test --all
-    (cd starlark && cargo test --all --features=linked_hash_set)
     ;;
   doc)
     cargo doc --all

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ https://github.com/google/skylark/blob/a0e5de7e63b47e716cca7226662a4c95d47bf873/
 and the Python 3 documentation when things were unclear.
 
 This interpreter does not support most of the go extensions (e.g. bitwise
-operator or floating point). It optionally includes a `set` type (by enabling the `linked_hash_set` feature),
+operator or floating point). It optionally includes a `set` type
+(by explicitly including `starlark::linked_hash_set::global()` environment),
 as an extension which is not specified in [the
 official Starlark specification](https://github.com/bazelbuild/starlark/blob/master/spec.md), but note that this
 is just an insertion-order-preserving set, and does not have optimisations for nesting as can be found in the

--- a/starlark-repl/Cargo.toml
+++ b/starlark-repl/Cargo.toml
@@ -36,7 +36,3 @@ bench = false
 [[bin]]
 name = "starlark-repl"
 bench = false
-
-[features]
-default = ["linked_hash_set"]
-linked_hash_set = ["starlark/linked_hash_set"]

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -18,7 +18,7 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use getopts::Options;
 use starlark::eval::interactive::{eval, eval_file, EvalError};
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use starlark::syntax::ast::AstStatement;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::parser::{parse, parse_file};
@@ -90,9 +90,7 @@ fn main() {
                     exit(EXIT_CODE_USAGE);
                 }
 
-                let global = print_function(global_environment());
-                // `struct` is not a part of the Starlark spec, but may be useful in REPL.
-                let global = structs::global(global);
+                let global = print_function(global_environment_with_extensions());
                 global.freeze();
 
                 let dialect = if build_file {

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -26,7 +26,6 @@ codemap = "0.1.1"
 codemap-diagnostic = "0.1.1"
 lalrpop-util = "0.16.0"
 linked-hash-map = "0.5.1"
-linked_hash_set = { version = "0.1.3", optional = true }
 
 [lib]
 bench = false

--- a/starlark/benches/benchutil/mod.rs
+++ b/starlark/benches/benchutil/mod.rs
@@ -16,7 +16,7 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Emitter};
 use linked_hash_map::LinkedHashMap;
 use starlark::eval::simple::eval;
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::error::ValueError;
 use std::fs::File;
@@ -31,8 +31,7 @@ pub fn do_bench(bencher: &mut Bencher, path: &str) {
     drop(file);
 
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let global = global_environment();
-    let global = structs::global(global);
+    let global = global_environment_with_extensions();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     eval(

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -79,5 +79,4 @@ pub mod values;
 pub mod eval;
 #[macro_use]
 pub mod stdlib;
-#[cfg(feature = "linked_hash_set")]
 pub mod linked_hash_set;

--- a/starlark/src/linked_hash_set/mod.rs
+++ b/starlark/src/linked_hash_set/mod.rs
@@ -1,2 +1,12 @@
-pub mod stdlib;
-pub mod value;
+use crate::environment::Environment;
+
+pub(crate) mod set_impl;
+mod stdlib;
+pub(crate) mod value;
+
+/// Include `set` constructor and set functions in environment.
+pub fn global(env: Environment) -> Environment {
+    let env = stdlib::global(env);
+    env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
+    env
+}

--- a/starlark/src/linked_hash_set/set_impl.rs
+++ b/starlark/src/linked_hash_set/set_impl.rs
@@ -1,0 +1,109 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simple implementation of `LinkedHashSet`.
+
+use linked_hash_map::{Entry, LinkedHashMap};
+use std::hash::Hash;
+
+/// `LinkedHashSet` is a tiny wrapper around `LinkedHashMap`.
+///
+/// Using `LinkedHashMap` directly to avoid adding extra dependency.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub(crate) struct LinkedHashSet<K: Eq + Hash> {
+    map: LinkedHashMap<K, ()>,
+}
+
+impl<K: Eq + Hash> LinkedHashSet<K> {
+    pub fn new() -> Self {
+        LinkedHashSet {
+            map: LinkedHashMap::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        LinkedHashSet {
+            map: LinkedHashMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &K> {
+        self.map.keys()
+    }
+
+    pub fn contains(&self, value: &K) -> bool {
+        self.map.get(value).is_some()
+    }
+
+    pub fn insert(&mut self, value: K) {
+        self.map.insert(value, ());
+    }
+
+    pub fn insert_if_absent(&mut self, value: K) {
+        if let Entry::Vacant(e) = self.map.entry(value) {
+            e.insert(());
+        }
+    }
+
+    pub fn remove(&mut self, value: &K) -> bool {
+        self.map.remove(value).is_some()
+    }
+
+    /// Items in both sets
+    pub fn intersection<'a>(&'a self, other: &'a LinkedHashSet<K>) -> impl Iterator<Item = &'a K> {
+        let (a, b) = if self.len() <= other.len() {
+            (self, other)
+        } else {
+            (other, self)
+        };
+        a.iter().filter(move |k| b.contains(k))
+    }
+
+    /// Items which are in `self`, but not in `other`.
+    pub fn difference<'a>(&'a self, other: &'a LinkedHashSet<K>) -> impl Iterator<Item = &'a K> {
+        self.iter().filter(move |k| !other.contains(k))
+    }
+
+    /// Items which are in `self` or in `other` but not in `both`
+    pub fn symmetric_difference<'a>(
+        &'a self,
+        other: &'a LinkedHashSet<K>,
+    ) -> impl Iterator<Item = &'a K> {
+        self.difference(other).chain(other.difference(self))
+    }
+
+    pub fn is_subset(&self, other: &LinkedHashSet<K>) -> bool {
+        self.len() <= other.len() && self.iter().all(|k| other.contains(k))
+    }
+
+    pub fn pop_front(&mut self) -> Option<K> {
+        self.map.pop_front().map(|(k, ())| k)
+    }
+
+    pub fn pop_back(&mut self) -> Option<K> {
+        self.map.pop_back().map(|(k, ())| k)
+    }
+}

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 //! Define the set type of Starlark
+use crate::linked_hash_set::set_impl::LinkedHashSet;
 use crate::values::error::ValueError;
 use crate::values::hashed_value::HashedValue;
 use crate::values::*;
-use linked_hash_set::LinkedHashSet;
 use std::cmp::Ordering;
 use std::num::Wrapping;
 
-pub struct Set {
+pub(crate) struct Set {
     mutability: IterableMutability,
     content: LinkedHashSet<HashedValue>,
 }

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -17,7 +17,7 @@
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::simple::eval;
-use starlark::stdlib::{global_environment, structs};
+use starlark::stdlib::global_environment_with_extensions;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, Write};
@@ -75,8 +75,7 @@ fn assert_diagnostic(
 
 fn run_conformance_test(path: &str) -> bool {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let global = global_environment();
-    let global = structs::global(global);
+    let global = global_environment_with_extensions();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     eval(


### PR DESCRIPTION
`LinkedHashSet` is reimplemented as tiny `LinkedHashMap` wrapper
to keep the number of dependencies small.

Now to enable sets client must explicitly call

```
starlark::linked_hash_set::global(env)
```

If that function is not called, `set` function and `Set` type are
unavailable, and technically user can provide custom set implementation.

`linked_hash_set` as feature is somewhat inconvenient:

* `{1, 2}` could work or not work depending on compilation options,
  and client Rust code has no easy way to ensure `set` is present
* each additional feature increases increases maintenance cost
  and produces problems like one fixed in #103

`global_environment_with_extensions` is a convenient shortcut to
enable both `set` and `struct` extensions.

REPL enables both `set` and `struct` (as before this diff when
feature is enabled).