### PR TITLE
starlark-repl --ast to print AST instead of evaluating

### DIFF
--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -14,14 +14,19 @@
 
 //! A command line interpreter for Starlark, provide a REPL.
 
+use codemap::CodeMap;
+use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use getopts::Options;
 use starlark::eval::interactive::{eval, eval_file, EvalError};
 use starlark::stdlib::{global_environment, structs};
+use starlark::syntax::ast::AstStatement;
 use starlark::syntax::dialect::Dialect;
+use starlark::syntax::parser::{parse, parse_file};
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
 use std::env;
 use std::process::exit;
+use std::sync::{Arc, Mutex};
 
 const EXIT_CODE_USAGE: i32 = 1;
 const EXIT_CODE_FAILURE: i32 = 2;
@@ -60,6 +65,7 @@ fn main() {
     );
     opts.optflag("h", "help", "Show the usage of this program.");
     opts.optflag("r", "repl", "Run a REPL after files have been parsed.");
+    opts.optflag("a", "ast", "Parse and print AST instead of evaluating");
     opts.optopt(
         "c",
         "command",
@@ -77,6 +83,7 @@ fn main() {
                 let build_file = matches.opt_present("b");
                 let opt_repl = matches.opt_present("r");
                 let command = matches.opt_str("c");
+                let ast = matches.opt_present("a");
 
                 if opt_repl && command.is_some() {
                     eprintln!("Cannot pass both -r and -c");
@@ -95,21 +102,42 @@ fn main() {
                 };
                 let free_args_empty = matches.free.is_empty();
                 for i in matches.free.into_iter() {
-                    maybe_print_or_exit(eval_file(&i, dialect, &mut global.child(&i)));
+                    if ast {
+                        let codemap = Arc::new(Mutex::new(CodeMap::new()));
+                        maybe_print_ast_or_exit(parse_file(&codemap, &i, dialect), &codemap);
+                    } else {
+                        maybe_print_or_exit(eval_file(&i, dialect, &mut global.child(&i)));
+                    }
                 }
                 if opt_repl || (free_args_empty && command.is_none()) {
                     println!("Welcome to Starlark REPL, press Ctrl+D to exit.");
-                    repl(&global, dialect);
+                    repl(&global, dialect, ast);
                 }
                 if let Some(command) = command {
-                    maybe_print_or_exit(eval(
-                        "[command flag]",
-                        &command,
-                        dialect,
-                        &mut global.child("[command flag]"),
-                    ));
+                    let path = "[command flag]";
+                    if ast {
+                        let codemap = Arc::new(Mutex::new(CodeMap::new()));
+                        maybe_print_ast_or_exit(parse(&codemap, path, &command, dialect), &codemap);
+                    } else {
+                        maybe_print_or_exit(eval(path, &command, dialect, &mut global.child(path)));
+                    }
                 }
             }
+        }
+    }
+}
+
+fn maybe_print_ast_or_exit(
+    result: Result<AstStatement, Diagnostic>,
+    codemap: &Arc<Mutex<CodeMap>>,
+) {
+    match result {
+        Ok(ast) => {
+            println!("{:#?}", ast);
+        }
+        Err(diagnostic) => {
+            Emitter::stderr(ColorConfig::Auto, Some(&*codemap.lock().unwrap())).emit(&[diagnostic]);
+            exit(EXIT_CODE_FAILURE);
         }
     }
 }


### PR DESCRIPTION
Could be useful to debug parser.

```
% cargo run -- -a -c 'def x(): pass'
   Compiling starlark-repl v0.3.0-pre (/Users/nga/devel/left/starlark-rust/starlark-repl)
    Finished dev [unoptimized + debuginfo] target(s) in 3.68s
     Running `target/debug/starlark-repl -a -c 'def x(): pass'`
Spanned {
    node: Statements(
        [
            Spanned {
                node: Def(
                    Spanned {
                        node: "x",
                        span: Span {
                            low: Pos(
                                5,
                            ),
                            high: Pos(
                                6,
                            ),
                        },
                    },
                    [],
...
```