### PR TITLE
Fix arithmetic operations grammar

### DIFF
--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -174,9 +174,9 @@ ExprList: AstExpr = L<Expr>;
 TestList: AstExpr = L<Test>;
 
 PipedExpr: AstExpr = {
-    <l:@L> <e1:AddExpr> "|" <e2:PipedExpr> <r:@R>
+    <l:@L> <e1:ArithExpr> "|" <e2:PipedExpr> <r:@R>
       => Expr::Op(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
-    AddExpr
+    ArithExpr
 };
 
 PrimaryExpr: AstExpr = {
@@ -311,22 +311,17 @@ CompTest: AstExpr = {
 };
 
 Expr: AstExpr = {
-    <l:@L> <e1:AddExpr> "|" <e2:Expr> <r:@R>
+    <l:@L> <e1:ArithExpr> "|" <e2:Expr> <r:@R>
         => Expr::Op(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
-    AddExpr,
+    ArithExpr,
 };
 
-AddExpr: AstExpr = {
-    <l:@L> <e1:SubExpr> "+" <e2:AddExpr> <r:@R>
+ArithExpr: AstExpr = {
+    <l:@L> <e1:ArithExpr> "+" <e2:ProductExpr> <r:@R>
         => Expr::Op(BinOp::Addition, e1, e2).to_ast(file_span.subspan(l, r)),
-    SubExpr,
-};
-
-SubExpr: AstExpr = {
-    <l:@L> <e1:ProductExpr> "-" <e2:SubExpr> <r:@R>
-        => Expr::Op(BinOp::Substraction, e1, e2)
-              .to_ast(file_span.subspan(l, r)),
-    ProductExpr
+    <l:@L> <e1:ArithExpr> "-" <e2:ProductExpr> <r:@R>
+        => Expr::Op(BinOp::Substraction, e1, e2).to_ast(file_span.subspan(l, r)),
+    ProductExpr,
 };
 
 ProductExpr: AstExpr = {

--- a/starlark/tests/rust-testcases/int.sky
+++ b/starlark/tests/rust-testcases/int.sky
@@ -17,3 +17,7 @@ assert_eq(0, int_min % -1)
 assert_eq(0, int_min % int_min)
 assert_eq(9223372036854775806, int_min % 9223372036854775807)
 assert_eq(-1, 9223372036854775807 % int_min)
+
+
+# Issue #98
+assert_eq(4, 7 - 2 - 1)


### PR DESCRIPTION
Fixes issue #98

```
>>> 7 - 2 - 1
4
```

Before this patch it evaluates to `6`.