### PR TITLE
Fix caller context capture in Starlark

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -55,6 +55,7 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+#[allow(clippy::too_many_arguments)]
 fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: Arc<Mutex<codemap::CodeMap>>,
     filename: &str,
@@ -62,6 +63,7 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     lexer: T2,
     dialect: Dialect,
     env: &mut Environment,
+    file_loader_env: Environment,
     ast: bool,
 ) {
     if ast {
@@ -79,7 +81,8 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             dialect,
             lexer,
             env,
-            SimpleFileLoader::new(&map.clone()),
+            file_loader_env.clone(),
+            SimpleFileLoader::new(&map.clone(), file_loader_env),
         ) {
             Ok(v) => {
                 if v.get_type() != "NoneType" {
@@ -171,6 +174,7 @@ pub fn repl(global_environment: &Environment, dialect: Dialect, ast: bool) {
                 lexer,
                 dialect,
                 &mut env,
+                global_environment.clone(),
                 ast,
             )
         }

--- a/starlark-repl/src/main.rs
+++ b/starlark-repl/src/main.rs
@@ -104,7 +104,12 @@ fn main() {
                         let codemap = Arc::new(Mutex::new(CodeMap::new()));
                         maybe_print_ast_or_exit(parse_file(&codemap, &i, dialect), &codemap);
                     } else {
-                        maybe_print_or_exit(eval_file(&i, dialect, &mut global.child(&i)));
+                        maybe_print_or_exit(eval_file(
+                            &i,
+                            dialect,
+                            &mut global.child(&i),
+                            global.clone(),
+                        ));
                     }
                 }
                 if opt_repl || (free_args_empty && command.is_none()) {
@@ -117,7 +122,13 @@ fn main() {
                         let codemap = Arc::new(Mutex::new(CodeMap::new()));
                         maybe_print_ast_or_exit(parse(&codemap, path, &command, dialect), &codemap);
                     } else {
-                        maybe_print_or_exit(eval(path, &command, dialect, &mut global.child(path)));
+                        maybe_print_or_exit(eval(
+                            "[command flag]",
+                            &command,
+                            dialect,
+                            &mut global.child("[command flag]"),
+                            global.clone(),
+                        ));
                     }
                 }
             }

--- a/starlark/benches/benchutil/mod.rs
+++ b/starlark/benches/benchutil/mod.rs
@@ -48,12 +48,13 @@ def assert_(cond, msg="assertion failed"):
 "#,
         starlark::syntax::dialect::Dialect::Bzl,
         &mut prelude,
+        global.clone(),
     )
     .unwrap();
     prelude.freeze();
 
     let mut env = prelude.child("run");
-    match eval(&map, path, &content, Dialect::Bzl, &mut env) {
+    match eval(&map, path, &content, Dialect::Bzl, &mut env, global) {
         Ok(_) => (),
         Err(p) => {
             Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[p]);

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -50,9 +50,13 @@ pub fn eval(
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
+    file_loader_env: Environment,
 ) -> Result<Option<Value>, EvalError> {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    transform_result(super::simple::eval(&map, path, content, dialect, env), map)
+    transform_result(
+        super::simple::eval(&map, path, content, dialect, env, file_loader_env),
+        map,
+    )
 }
 
 /// Evaluate a file, mutate the environment accordingly, and return the value of the last
@@ -70,9 +74,13 @@ pub fn eval_file(
     path: &str,
     dialect: Dialect,
     env: &mut Environment,
+    file_loader_env: Environment,
 ) -> Result<Option<Value>, EvalError> {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    transform_result(super::simple::eval_file(&map, path, dialect, env), map)
+    transform_result(
+        super::simple::eval_file(&map, path, dialect, env, file_loader_env),
+        map,
+    )
 }
 
 fn transform_result(

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -147,14 +147,15 @@ mod test {
         let env = global(env);
         env.freeze();
 
-        let mut env = env.child("my");
+        let mut child = env.child("my");
 
         let r = eval(
             &Arc::new(Mutex::new(CodeMap::new())),
             "test_simple.star",
             "cc_binary(name='star', srcs=['a.cc', 'b.cc'])",
             Dialect::Build,
-            &mut env,
+            &mut child,
+            env,
         )
         .unwrap();
 

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -232,7 +232,7 @@ pub trait TypedValue: 'static {
     /// # Parameters
     ///
     /// * call_stack: the calling stack, to detect recursion
-    /// * env: the environment for the call.
+    /// * globals: global environment of the caller.
     /// * positional: the list of arguments passed positionally.
     /// * named: the list of argument that were named.
     /// * args: if provided, the `*args` argument.
@@ -240,7 +240,7 @@ pub trait TypedValue: 'static {
     fn call(
         &self,
         _call_stack: &[(String, String)],
-        _env: Environment,
+        _globals: Environment,
         _positional: Vec<Value>,
         _named: LinkedHashMap<String, Value>,
         _args: Option<Value>,
@@ -808,14 +808,14 @@ impl Value {
     pub fn call(
         &self,
         call_stack: &[(String, String)],
-        env: Environment,
+        globals: Environment,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
         kwargs: Option<Value>,
     ) -> ValueResult {
         let borrowed = self.0.borrow();
-        borrowed.call(call_stack, env, positional, named, args, kwargs)
+        borrowed.call(call_stack, globals, positional, named, args, kwargs)
     }
     pub fn at(&self, index: Value) -> ValueResult {
         let borrowed = self.0.borrow();

--- a/starlark/tests/testutil/mod.rs
+++ b/starlark/tests/testutil/mod.rs
@@ -92,6 +92,7 @@ def assert_(cond, msg="assertion failed"):
 "#,
         starlark::syntax::dialect::Dialect::Bzl,
         &mut prelude,
+        global.clone(),
     )
     .unwrap();
     prelude.freeze();
@@ -110,6 +111,7 @@ def assert_(cond, msg="assertion failed"):
             &content,
             starlark::syntax::dialect::Dialect::Bzl,
             &mut prelude.child(&path),
+            global.clone(),
         ) {
             Err(p) => {
                 if err.is_empty() {


### PR DESCRIPTION
TL;DR: this works properly now:

bb.star
```
x = 1

def f():
    print(x)
```

aa.star
```
load("bb.star", "f")

f()
```

```
% cargo run -- ./aa.star
    Finished dev [unoptimized + debuginfo] target(s) in 4.73s
     Running `target/debug/starlark-repl ./aa.star`
1
```

```
% starlark ./aa.star
1
```

More details:

`def` functions now capture evaluation context during function creation
intead of evaluation.

`Environment` is still passed to `TypedValue::call`, but it is
"global" environment now which is used to resolve types (i. e. only
in implementations of functions like `getattr`).

Fixes issue #108