### PR TITLE
Change `None` representation from `Option<()>` to `NoneType`

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -49,6 +49,7 @@ use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
 use starlark::syntax::parser::parse_lexer;
+use starlark::values::none::NoneType;
 use starlark::values::Value;
 use std::env;
 use std::path::PathBuf;
@@ -108,7 +109,7 @@ starlark_module! {print_function =>
             r.push_str(&arg.to_str());
         }
         eprintln!("{}", r);
-        Ok(Value::new(None))
+        Ok(Value::new(NoneType::None))
     }
 }
 

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -28,6 +28,7 @@ use crate::syntax::parser::{parse, parse_file, parse_lexer};
 use crate::values::dict::Dictionary;
 use crate::values::error::ValueError;
 use crate::values::function::{FunctionArg, FunctionParameter};
+use crate::values::none::NoneType;
 use crate::values::*;
 use codemap::{CodeMap, Span, Spanned};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
@@ -470,7 +471,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for TransformedExpr<T> {
     }
 
     fn set(&self, context: &mut EvaluationContext<T>, new_value: Value) -> EvalResult {
-        let ok = Ok(Value::new(None));
+        let ok = Ok(Value::new(NoneType::None));
         match self {
             TransformedExpr::List(ref v, ref span) | &TransformedExpr::Tuple(ref v, ref span) => {
                 let l = v.len() as i64;
@@ -696,7 +697,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstExpr {
     }
 
     fn set(&self, context: &mut EvaluationContext<T>, new_value: Value) -> EvalResult {
-        let ok = Ok(Value::new(None));
+        let ok = Ok(Value::new(NoneType::None));
         match self.node {
             Expr::Tuple(ref v) | Expr::List(ref v) => {
                 let l = v.len() as i64;
@@ -738,11 +739,13 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
         match self.node {
             Statement::Break => Err(EvalException::Break(self.span)),
             Statement::Continue => Err(EvalException::Continue(self.span)),
-            Statement::Pass => Ok(Value::new(None)),
+            Statement::Pass => Ok(Value::new(NoneType::None)),
             Statement::Return(Some(ref e)) => {
                 Err(EvalException::Return(self.span, e.eval(context)?))
             }
-            Statement::Return(None) => Err(EvalException::Return(self.span, Value::new(None))),
+            Statement::Return(None) => {
+                Err(EvalException::Return(self.span, Value::new(NoneType::None)))
+            }
             Statement::Expression(ref e) => e.eval(context),
             Statement::Assign(ref lhs, AssignOp::Assign, ref rhs) => {
                 let rhs = rhs.eval(context)?;
@@ -788,7 +791,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                 if cond.eval(context)?.to_bool() {
                     st.eval(context)
                 } else {
-                    Ok(Value::new(None))
+                    Ok(Value::new(NoneType::None))
                 }
             }
             Statement::IfElse(ref cond, ref st1, ref st2) => {
@@ -806,7 +809,7 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                 ref st,
             ) => {
                 let mut iterable = e2.eval(context)?;
-                let mut result = Ok(Value::new(None));
+                let mut result = Ok(Value::new(NoneType::None));
                 iterable.freeze_for_iteration();
                 for v in t!(iterable.iter(), span * span)? {
                     e1.set(context, v)?;
@@ -858,12 +861,12 @@ impl<T: FileLoader + 'static> Evaluate<T> for AstStatement {
                     t!(context.env.import_symbol(&loadenv, &orig_name.node, &new_name.node),
                         span new_name.span.merge(orig_name.span))?
                 }
-                Ok(Value::new(None))
+                Ok(Value::new(NoneType::None))
             }
             Statement::Statements(ref v) => {
                 let r = eval_vector!(v, context);
                 match r.len() {
-                    0 => Ok(Value::new(None)),
+                    0 => Ok(Value::new(NoneType::None)),
                     _ => Ok(r.last().unwrap().clone()),
                 }
             }
@@ -918,7 +921,7 @@ pub fn eval_def(
     match stmts.eval(&mut ctx) {
         Err(EvalException::Return(_s, ret)) => Ok(ret),
         Err(x) => Err(ValueError::DiagnosedError(x.into())),
-        Ok(..) => Ok(Value::new(None)),
+        Ok(..) => Ok(Value::new(NoneType::None)),
     }
 }
 

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -16,6 +16,7 @@
 
 use crate::values::error::*;
 use crate::values::hashed_value::HashedValue;
+use crate::values::none::NoneType;
 use crate::values::*;
 
 use crate::linked_hash_set::value::Set;
@@ -72,7 +73,7 @@ starlark_module! {global =>
     /// ```
     set.add(this, #el) {
         Set::insert_if_absent(&this, el)?;
-        ok!(None)
+        Ok(Value::new(NoneType::None))
     }
 
     /// set.clear: clear a set
@@ -96,7 +97,7 @@ starlark_module! {global =>
     set.clear(this) {
         Set::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -199,7 +200,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -226,7 +227,7 @@ starlark_module! {global =>
     set.discard(this, #needle) {
         Set::mutate(&this, &|x| {
             x.remove(&HashedValue::new(needle.clone())?);
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -305,7 +306,7 @@ starlark_module! {global =>
             for value in values.into_iter() {
                 x.insert(value);
             }
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -405,7 +406,7 @@ starlark_module! {global =>
     /// x == set([3])
     /// # )"#).unwrap());
     /// ```
-    set.pop(this, #index = None) {
+    set.pop(this, #index = NoneType::None) {
         let length = this.length()?;
         let index = if index.get_type() == "NoneType" {
             length - 1
@@ -460,7 +461,7 @@ starlark_module! {global =>
             ok!(x.remove(&HashedValue::new(needle.clone())?))
         });
         if did_remove?.to_bool() {
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         } else {
             starlark_err!(
                 SET_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE,
@@ -540,7 +541,7 @@ starlark_module! {global =>
             for item in symmetric_difference.iter()? {
                 s.insert(HashedValue::new(item)?);
             }
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -610,6 +611,6 @@ starlark_module! {global =>
                 Set::insert_if_absent(&this, el)?;
             }
         }
-        ok!(None)
+        Ok(Value::new(NoneType::None))
     }
 }

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -16,6 +16,7 @@
 use crate::linked_hash_set::set_impl::LinkedHashSet;
 use crate::values::error::ValueError;
 use crate::values::hashed_value::HashedValue;
+use crate::values::none::NoneType;
 use crate::values::*;
 use std::cmp::Ordering;
 use std::num::Wrapping;
@@ -51,7 +52,7 @@ impl Set {
         let v = v.clone_for_container_value(set)?;
         Self::mutate(set, &|hashset| {
             hashset.insert_if_absent(HashedValue::new(v.clone())?);
-            Ok(Value::from(None))
+            Ok(Value::new(NoneType::None))
         })
     }
 

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -16,6 +16,7 @@
 
 use crate::values::error::*;
 use crate::values::hashed_value::HashedValue;
+use crate::values::none::NoneType;
 use crate::values::*;
 use linked_hash_map::LinkedHashMap;
 
@@ -53,7 +54,7 @@ starlark_module! {global =>
             &this,
             &|x: &mut LinkedHashMap<HashedValue, Value>| -> ValueResult {
                 x.clear();
-                ok!(None)
+                Ok(Value::new(NoneType::None))
             }
         )
     }
@@ -82,7 +83,7 @@ starlark_module! {global =>
     /// x.get("three", 0) == 0
     /// # )"#).unwrap());
     /// ```
-    dict.get(this, #key, #default = None) {
+    dict.get(this, #key, #default = NoneType::None) {
         match this.at(key) {
             Err(ValueError::KeyNotFound(..)) => Ok(default),
             x => x
@@ -170,7 +171,7 @@ starlark_module! {global =>
     /// ```python
     /// x.pop("four")  # error: missing key
     /// ```
-    dict.pop(this, #key, #default = None) {
+    dict.pop(this, #key, #default = NoneType::None) {
         let key = HashedValue::new(key)?;
         let key_error = format!("Key '{}' not found in '{}'", key.get_value().to_repr(), this.to_repr());
         dict::Dictionary::mutate(
@@ -263,7 +264,7 @@ starlark_module! {global =>
     /// x == {"one": 1, "two": 2, "three": 0, "four": None}
     /// # )"#).unwrap());
     /// ```
-    dict.setdefault(this, #key, #default = None) {
+    dict.setdefault(this, #key, #default = NoneType::None) {
         let key = HashedValue::new(key)?;
         let cloned_default = default.clone_for_container_value(&this);
         dict::Dictionary::mutate(
@@ -346,7 +347,7 @@ starlark_module! {global =>
         for (k, v) in kwargs {
             this.set_at(k.into(), v)?;
         }
-        ok!(None)
+        Ok(Value::new(NoneType::None))
     }
 
     /// [dict.values](

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -15,17 +15,12 @@
 //! Methods for the `list` type.
 
 use crate::values::error::*;
+use crate::values::none::NoneType;
 use crate::values::*;
 
 // Errors -- UF = User Failure -- Failure that should be expected by the user (e.g. from a fail()).
 pub const LIST_INDEX_FAILED_ERROR_CODE: &str = "UF10";
 pub const LIST_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE: &str = "UF11";
-
-macro_rules! ok {
-    ($e:expr) => {
-        return Ok(Value::from($e));
-    };
-}
 
 starlark_module! {global =>
     /// [list.append](
@@ -56,7 +51,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &|x| {
             x.push(el.clone()?);
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -81,7 +76,7 @@ starlark_module! {global =>
     list.clear(this) {
         list::List::mutate(&this, &|x| {
             x.clear();
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -113,7 +108,7 @@ starlark_module! {global =>
         let other_cloned: Result<Vec<_>, _>  = other.iter()?.map(|v| v.clone_for_container_value(&this_cloned)).collect();
         list::List::mutate(&this, &|x| {
             x.extend(other_cloned.clone()?);
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -146,11 +141,11 @@ starlark_module! {global =>
     /// x.index("a", -2) == 5  # bananA
     /// # )"#).unwrap());
     /// ```
-    list.index(this, #needle, #start = 0, #end = None) {
+    list.index(this, #needle, #start = 0, #end = NoneType::None) {
         convert_indices!(this, start, end);
         let mut it = this.iter()?.skip(start).take(end - start);
         if let Some(offset) = it.position(|x| x == needle) {
-            ok!((offset + start) as i64)
+            Ok(Value::new((offset + start) as i64))
         } else {
             starlark_err!(
                 LIST_INDEX_FAILED_ERROR_CODE,
@@ -190,7 +185,7 @@ starlark_module! {global =>
         let el = el.clone_for_container_value(&this);
         list::List::mutate(&this, &move |x| {
             x.insert(index, el.clone()?);
-            ok!(None)
+            Ok(Value::new(NoneType::None))
         })
     }
 
@@ -227,7 +222,7 @@ starlark_module! {global =>
             return Err(ValueError::IndexOutOfBound(index));
         }
         list::List::mutate(&this, &|x| {
-            ok!(x.remove(index as usize));
+            Ok(x.remove(index as usize))
         })
     }
 
@@ -264,7 +259,7 @@ starlark_module! {global =>
         if let Some(offset) = it.position(|x| x == needle) {
             list::List::mutate(&this, &|x| {
                 x.remove(offset);
-                ok!(None)
+                Ok(Value::new(NoneType::None))
             })
         } else {
             starlark_err!(

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -263,6 +263,7 @@ macro_rules! starlark_signatures {
 /// ```rust
 /// # #[macro_use] extern crate starlark;
 /// # use starlark::values::*;
+/// # use starlark::values::none::NoneType;
 /// # use starlark::environment::Environment;
 /// starlark_module!{ my_starlark_module =>
 ///     // Declare a 'str' function (_ are trimmed away and just here to avoid collision with
@@ -299,7 +300,7 @@ macro_rules! starlark_signatures {
 ///            if let Some(x) = environ.get_parent() { x.name() } else { "<root>".to_owned() },
 ///            cs.iter().skip(1).fold(String::new(), |a, x| format!("{}\n{}", a, x.1))
 ///        );
-///        Ok(Value::from(None))
+///        Ok(Value::from(NoneType::None))
 ///     }
 /// }
 /// #

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -24,6 +24,7 @@ use std::sync;
 use crate::environment::Environment;
 use crate::syntax::dialect::Dialect;
 use crate::values::dict::Dictionary;
+use crate::values::none::NoneType;
 use crate::values::*;
 
 // Errors -- CR = Critical Runtime
@@ -346,7 +347,7 @@ starlark_module! {global_functions =>
     /// getattr("banana", "split")("a") == ["b", "n", "n", ""] # equivalent to "banana".split("a")
     /// # "#).unwrap());
     /// ```
-    getattr(env env, #a, #attr: String, #default=None) {
+    getattr(env env, #a, #attr: String, #default = NoneType::None) {
         match a.get_attr(&attr) {
             Ok(v) => Ok(v),
             x => match env.get_type_value(&a, &attr) {
@@ -940,7 +941,7 @@ starlark_module! {global_functions =>
 /// of this global environment that have been frozen.
 pub fn global_environment() -> Environment {
     let env = Environment::new("global");
-    env.set("None", Value::new(None)).unwrap();
+    env.set("None", Value::new(NoneType::None)).unwrap();
     env.set("True", Value::new(true)).unwrap();
     env.set("False", Value::new(false)).unwrap();
     dict::global(list::global(string::global(global_functions(env))))

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -15,6 +15,7 @@
 //! Methods for the `string` type.
 
 use crate::values::error::*;
+use crate::values::none::NoneType;
 use crate::values::*;
 use std::convert::TryFrom;
 use std::str::FromStr;
@@ -298,7 +299,7 @@ starlark_module! {global =>
     /// "hello, world!".count("o", 7, 12) == 1  # in "world"
     /// # )"#).unwrap());
     /// ```
-    string.count(this: String, #needle: String, #start = 0, #end = None) {
+    string.count(this: String, #needle: String, #start = 0, #end = NoneType::None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         let n = needle.as_str();
@@ -360,7 +361,7 @@ starlark_module! {global =>
     /// "bonbon".find("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.find(this: String, #needle: String, #start = 0, #end = None) {
+    string.find(this: String, #needle: String, #start = 0, #end = NoneType::None) {
         convert_indices!(this, start, end);
         let needle = needle.to_str();
         if let Some(substring) = this.as_str().get(start..end) {
@@ -512,7 +513,7 @@ starlark_module! {global =>
     /// "bonbon".index("on", 2, 5) # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.index(this: String, #needle: String, #start = 0, #end = None) {
+    string.index(this: String, #needle: String, #start = 0, #end = NoneType::None) {
         check_string!(needle, count);
         convert_indices!(this, start, end);
         if let Some(substring) = this.as_str().get(start..end) {
@@ -934,7 +935,7 @@ starlark_module! {global =>
     /// "bonbon".rfind("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.rfind(this: String, #needle: String, #start = 0, #end = None) {
+    string.rfind(this: String, #needle: String, #start = 0, #end = NoneType::None) {
         convert_indices!(this, start, end);
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
@@ -966,7 +967,7 @@ starlark_module! {global =>
     /// "bonbon".rindex("on", 2, 5)   # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.rindex(this: String, #needle: String, #start = 0, #end = None) {
+    string.rindex(this: String, #needle: String, #start = 0, #end = NoneType::None) {
         convert_indices!(this, start, end);
         if let Some(substring) = this.get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
@@ -1037,7 +1038,7 @@ starlark_module! {global =>
     /// "one two  three".rsplit(None, 1) == ["one two", "three"]
     /// # )"#).unwrap());
     /// ```
-    string.rsplit(this: String, #sep = None, #maxsplit = None) {
+    string.rsplit(this: String, #sep = NoneType::None, #maxsplit = NoneType::None) {
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
         } else {
@@ -1128,7 +1129,7 @@ starlark_module! {global =>
     /// "banana".split("n", 1) == ["ba", "ana"]
     /// # )"#).unwrap());
     /// ```
-    string.split(this: String, #sep = None, #maxsplit = None) {
+    string.split(this: String, #sep = NoneType::None, #maxsplit = NoneType::None) {
         let this = this.to_str();
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -19,6 +19,7 @@ use crate::eval::eval_def;
 use crate::stdlib::macros::param::TryParamConvertFromValue;
 use crate::syntax::ast::AstStatement;
 use crate::values::error::RuntimeError;
+use crate::values::none::NoneType;
 use codemap::CodeMap;
 use std::convert::TryInto;
 use std::mem;
@@ -120,7 +121,7 @@ impl From<FunctionArg> for Value {
             FunctionArg::ArgsArray(v) => v.into(),
             FunctionArg::Optional(v) => match v {
                 Some(v) => v,
-                None => Value::new(None),
+                None => Value::new(NoneType::None),
             },
             FunctionArg::KWArgsDict(v) => {
                 // `unwrap` does not panic, because key is a string which hashable

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -34,18 +34,23 @@
 //!
 //! For example the `NoneType` trait implementation is the following:
 //!
-//! ```rust,ignore
+//! ```rust
+//! # use starlark::{default_compare, any, immutable};
+//! # use starlark::values::TypedValue;
+//! # use starlark::values::error::ValueError;
+//!
 //! /// Define the NoneType type
-//! impl TypedValue for Option<()> {
+//! pub enum NoneType {
+//!     None
+//! }
+//!
+//! impl TypedValue for NoneType {
 //!     immutable!();
-//!     any!();  // Generally you don't want to implement as_any() and as_any_mut() yourself.
-//!     fn to_str(&self) -> String {
+//!     any!();
+//!     default_compare!();
+//!     fn to_repr(&self) -> String {
 //!         "None".to_owned()
 //!     }
-//!     fn to_repr(&self) -> String {
-//!         self.to_str()
-//!     }
-//!     not_supported!(to_int);
 //!     fn get_type(&self) -> &'static str {
 //!         "NoneType"
 //!     }
@@ -54,12 +59,11 @@
 //!     }
 //!     // just took the result of hash(None) in macos python 2.7.10 interpreter.
 //!     fn get_hash(&self) -> Result<u64, ValueError> {
-//!         Ok(9223380832852120682)
+//!         Ok(9_223_380_832_852_120_682)
 //!     }
-//!     fn compare(&self, other: &Value) -> Ordering { default_compare(self, other) }
-//!     not_supported!(binop);
-//!     not_supported!(container);
-//!     not_supported!(function);
+//!     fn is_descendant(&self, _other: &TypedValue) -> bool {
+//!         false
+//!     }
 //! }
 //! ```
 //!
@@ -618,9 +622,12 @@ pub fn default_compare(v1: &dyn TypedValue, v2: &dyn TypedValue) -> Result<Order
     })
 }
 
+#[macro_export]
 macro_rules! default_compare {
     () => {
-        fn compare(&self, other: &dyn TypedValue, _recursion: u32) -> Result<Ordering, ValueError> { default_compare(self, other) }
+        fn compare(&self, other: &dyn TypedValue, _recursion: u32) -> Result<::std::cmp::Ordering, ValueError> {
+            $crate::values::default_compare(self, other)
+        }
     }
 }
 

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -17,7 +17,11 @@
 use crate::values::*;
 
 /// Define the NoneType type
-impl TypedValue for Option<()> {
+pub enum NoneType {
+    None,
+}
+
+impl TypedValue for NoneType {
     immutable!();
     any!();
     default_compare!();
@@ -39,8 +43,8 @@ impl TypedValue for Option<()> {
     }
 }
 
-impl From<Option<()>> for Value {
-    fn from(_a: Option<()>) -> Value {
-        Value::new(None)
+impl From<NoneType> for Value {
+    fn from(NoneType::None: NoneType) -> Self {
+        Value::new(NoneType::None)
     }
 }


### PR DESCRIPTION
```
enum NoneType { None }
```

`Option<()>` occupies one byte. Although it is not performance
critial, it is a bit misleading: if Rust `None` is Starlark `None`,
then what is `Some(())`?