### PR TITLE
Check for mutability in Value::downcast_mut

### DIFF
--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -59,11 +59,8 @@ impl Set {
         v: &Value,
         f: &Fn(&mut LinkedHashSet<HashedValue>) -> ValueResult,
     ) -> ValueResult {
-        match v.downcast_mut::<Set>() {
-            Some(mut x) => {
-                x.mutability.test()?;
-                f(&mut x.content)
-            }
+        match v.downcast_mut::<Set>()? {
+            Some(mut x) => f(&mut x.content),
             None => Err(ValueError::IncorrectParameterType),
         }
     }

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -27,8 +27,8 @@ pub struct StarlarkStruct {
 impl TypedValue for StarlarkStruct {
     any!();
 
-    fn immutable(&self) -> bool {
-        true
+    fn mutability(&self) -> IterableMutability {
+        IterableMutability::Immutable
     }
 
     fn freeze(&mut self) {

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -59,11 +59,8 @@ impl Dictionary {
         v: &Value,
         f: &dyn Fn(&mut LinkedHashMap<HashedValue, Value>) -> ValueResult,
     ) -> ValueResult {
-        match v.downcast_mut::<Dictionary>() {
-            Some(mut x) => {
-                x.mutability.test()?;
-                f(&mut x.content)
-            }
+        match v.downcast_mut::<Dictionary>()? {
+            Some(mut x) => f(&mut x.content),
             None => Err(ValueError::IncorrectParameterType),
         }
     }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -47,11 +47,8 @@ impl List {
     }
 
     pub fn mutate(v: &Value, f: &dyn Fn(&mut Vec<Value>) -> ValueResult) -> ValueResult {
-        match v.downcast_mut::<List>() {
-            Some(mut x) => {
-                x.mutability.test()?;
-                f(&mut x.content)
-            }
+        match v.downcast_mut::<List>()? {
+            Some(mut x) => f(&mut x.content),
             None => Err(ValueError::IncorrectParameterType),
         }
     }

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! Define the tuple type for Starlark.
+use crate::values::error::ValueError;
 use crate::values::*;
 use std::borrow::BorrowMut;
 use std::cmp::Ordering;
@@ -260,9 +261,10 @@ impl<
 impl TypedValue for Tuple {
     any!();
 
-    fn immutable(&self) -> bool {
-        true
+    fn mutability(&self) -> IterableMutability {
+        IterableMutability::Immutable
     }
+
     fn freeze(&mut self) {
         // Tuple are weird, immutable but with potentially mutable
         for x in self.content.iter_mut() {


### PR DESCRIPTION
It makes code a bit safer (caller does not need to remember to do
mutability test).