### PR TITLE
Compare implementation cleanup/improvements

### DIFF
--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -131,30 +131,26 @@ impl TypedValue for Set {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
-        if other.get_type() == "set" {
-            let other = other.as_any().downcast_ref::<Self>().unwrap();
-            if self
-                .content
-                .symmetric_difference(&other.content)
-                .next()
-                .is_none()
-            {
-                return Ok(Ordering::Equal);
-            }
-            // Comparing based on hash value isn't particularly meaningful to users, who may expect
-            // sets to compare based on, say, their size, or comparing their elements.
-            // We do this because it's guaranteed to provide a consistent ordering for any pair of
-            // sets. We should consider better defining the sort order of sets if users complain.
-            let l = self.get_hash().unwrap();
-            let r = other.get_hash().unwrap();
-            if l <= r {
-                Ok(Ordering::Less)
-            } else {
-                Ok(Ordering::Greater)
-            }
+    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+        let other = other.downcast_ref::<Self>().unwrap();
+        if self
+            .content
+            .symmetric_difference(&other.content)
+            .next()
+            .is_none()
+        {
+            return Ok(Ordering::Equal);
+        }
+        // Comparing based on hash value isn't particularly meaningful to users, who may expect
+        // sets to compare based on, say, their size, or comparing their elements.
+        // We do this because it's guaranteed to provide a consistent ordering for any pair of
+        // sets. We should consider better defining the sort order of sets if users complain.
+        let l = self.get_hash().unwrap();
+        let r = other.get_hash().unwrap();
+        if l <= r {
+            Ok(Ordering::Less)
         } else {
-            default_compare(self, other)
+            Ok(Ordering::Greater)
         }
     }
 

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -14,7 +14,9 @@
 
 //! Define the bool type for Starlark.
 
+use crate::values::error::ValueError;
 use crate::values::*;
+use std::cmp::Ordering;
 
 impl From<bool> for Value {
     fn from(b: bool) -> Self {
@@ -26,7 +28,9 @@ impl From<bool> for Value {
 impl TypedValue for bool {
     immutable!();
     any!();
-    default_compare!();
+    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+        Ok(self.cmp(&*other.downcast_ref::<bool>().unwrap()))
+    }
     fn to_repr(&self) -> String {
         if *self {
             "True".to_owned()

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -363,14 +363,6 @@ impl TypedValue for Function {
         "function"
     }
 
-    fn compare(&self, other: &dyn TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
-        if other.get_type() == "function" {
-            Ok(self.to_repr().cmp(&other.to_repr()))
-        } else {
-            default_compare(self, other)
-        }
-    }
-
     fn call(
         &self,
         call_stack: &[(String, String)],
@@ -485,9 +477,6 @@ impl TypedValue for WrappedMethod {
     }
     fn get_type(&self) -> &'static str {
         "function"
-    }
-    fn compare(&self, other: &dyn TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
-        self.method.compare_underlying(other, recursion)
     }
 
     fn call(

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -15,6 +15,7 @@
 //! Define the int type for Starlark.
 
 use crate::values::*;
+use std::cmp::Ordering;
 
 // A convenient macro for testing and documentation.
 #[macro_export]
@@ -80,7 +81,9 @@ where
 impl TypedValue for i64 {
     immutable!();
     any!();
-    default_compare!();
+    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+        Ok(self.cmp(&*other.downcast_ref::<i64>().unwrap()))
+    }
     fn to_str(&self) -> String {
         format!("{}", self)
     }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -100,25 +100,23 @@ impl TypedValue for List {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &dyn TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
-        if other.get_type() == "list" {
-            let mut iter1 = self.iter()?;
-            let mut iter2 = other.iter()?;
-            loop {
-                match (iter1.next(), iter2.next()) {
-                    (None, None) => return Ok(Ordering::Equal),
-                    (None, Some(..)) => return Ok(Ordering::Less),
-                    (Some(..), None) => return Ok(Ordering::Greater),
-                    (Some(v1), Some(v2)) => {
-                        let r = v1.compare(&v2, recursion + 1)?;
-                        if r != Ordering::Equal {
-                            return Ok(r);
-                        }
+    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+        // assert type
+        other.downcast_ref::<List>().unwrap();
+        let mut iter1 = self.iter()?;
+        let mut iter2 = other.iter()?;
+        loop {
+            match (iter1.next(), iter2.next()) {
+                (None, None) => return Ok(Ordering::Equal),
+                (None, Some(..)) => return Ok(Ordering::Less),
+                (Some(..), None) => return Ok(Ordering::Greater),
+                (Some(v1), Some(v2)) => {
+                    let r = v1.compare(&v2, recursion + 1)?;
+                    if r != Ordering::Equal {
+                        return Ok(r);
                     }
                 }
             }
-        } else {
-            default_compare(self, other)
         }
     }
 

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -15,6 +15,7 @@
 //! Define the None type for Starlark.
 
 use crate::values::*;
+use std::cmp::Ordering;
 
 /// Define the NoneType type
 pub enum NoneType {
@@ -24,7 +25,11 @@ pub enum NoneType {
 impl TypedValue for NoneType {
     immutable!();
     any!();
-    default_compare!();
+    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+        // assert type
+        other.downcast_ref::<NoneType>().unwrap();
+        Ok(Ordering::Equal)
+    }
     fn to_repr(&self) -> String {
         "None".to_owned()
     }

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -52,12 +52,8 @@ impl TypedValue for String {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &dyn TypedValue, _recursion: u32) -> Result<Ordering, ValueError> {
-        if other.get_type() == "string" {
-            Ok(self.cmp(&other.to_str()))
-        } else {
-            default_compare(self, other)
-        }
+    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+        Ok(self.cmp(other.downcast_ref::<String>().unwrap().deref()))
     }
 
     fn at(&self, index: Value) -> ValueResult {

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -305,25 +305,23 @@ impl TypedValue for Tuple {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &dyn TypedValue, recursion: u32) -> Result<Ordering, ValueError> {
-        if other.get_type() == "tuple" {
-            let mut iter1 = self.iter()?;
-            let mut iter2 = other.iter()?;
-            loop {
-                match (iter1.next(), iter2.next()) {
-                    (None, None) => return Ok(Ordering::Equal),
-                    (None, Some(..)) => return Ok(Ordering::Less),
-                    (Some(..), None) => return Ok(Ordering::Greater),
-                    (Some(v1), Some(v2)) => {
-                        let r = v1.compare(&v2, recursion + 1)?;
-                        if r != Ordering::Equal {
-                            return Ok(r);
-                        }
+    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+        // assert type
+        other.downcast_ref::<Tuple>().unwrap();
+        let mut iter1 = self.iter()?;
+        let mut iter2 = other.iter()?;
+        loop {
+            match (iter1.next(), iter2.next()) {
+                (None, None) => return Ok(Ordering::Equal),
+                (None, Some(..)) => return Ok(Ordering::Less),
+                (Some(..), None) => return Ok(Ordering::Greater),
+                (Some(v1), Some(v2)) => {
+                    let r = v1.compare(&v2, recursion + 1)?;
+                    if r != Ordering::Equal {
+                        return Ok(r);
                     }
                 }
             }
-        } else {
-            default_compare(self, other)
         }
     }
 


### PR DESCRIPTION
* `Value::compare` now delegates to `TypedValue::compare` only if
  type ids are the same
* `TypedValue` now has default `compare` implementation which does
  pointer comparison
* `default_compare!` macro and `default_compare` functions are
  removed
* `Function` and `WrappedMethod` now do default (pointer) comparison
* `compare_underlying` function is removed