### PR TITLE
Add a type for call stack

### DIFF
--- a/starlark/src/eval/call_stack.rs
+++ b/starlark/src/eval/call_stack.rs
@@ -1,0 +1,61 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Starlark call stack.
+
+use std::fmt;
+
+/// Starlark call stack.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct CallStack {
+    stack: Vec<(String, String)>,
+}
+
+impl CallStack {
+    /// Push an element to the stack
+    pub fn push(&mut self, function_id: &str, call_descr: &str, file_name: &str, line: u32) {
+        self.stack.push((
+            function_id.to_owned(),
+            format!(
+                "call to {} at {}:{}",
+                call_descr,
+                file_name,
+                line + 1, // line 1 is 0, so add 1 for human readable.
+            ),
+        ));
+    }
+
+    /// Test if call stack contains a function with given id.
+    pub fn contains(&self, function_id: &str) -> bool {
+        self.stack.iter().any(|(n, _)| n == function_id)
+    }
+
+    /// Print call stack as multiline string
+    /// with each line beginning with newline.
+    pub fn print_with_newline_before<'a>(&'a self) -> impl fmt::Display + 'a {
+        DisplayWithNewlineBefore { call_stack: self }
+    }
+}
+
+struct DisplayWithNewlineBefore<'a> {
+    call_stack: &'a CallStack,
+}
+
+impl<'a> fmt::Display for DisplayWithNewlineBefore<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (_fname, descr) in self.call_stack.stack.iter().rev() {
+            write!(f, "\n    {}", descr)?;
+        }
+        Ok(())
+    }
+}

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -169,7 +169,7 @@ macro_rules! starlark_fun {
     ($(#[$attr:meta])* $fn:ident ( $($signature:tt)* ) { $($content:tt)* } $($($rest:tt)+)?) => {
         $(#[$attr])*
         fn $fn(
-            __call_stack: &[(String, String)],
+            __call_stack: &$crate::eval::call_stack::CallStack,
             __env: $crate::environment::Environment,
             args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
@@ -185,7 +185,7 @@ macro_rules! starlark_fun {
             $($($rest:tt)+)?) => {
         $(#[$attr])*
         fn $fn(
-            __call_stack: &[(String, String)],
+            __call_stack: &$crate::eval::call_stack::CallStack,
             __env: $crate::environment::Environment,
             args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
@@ -280,7 +280,7 @@ macro_rules! starlark_signatures {
 ///        println!(
 ///            "In {}:{}",
 ///            if let Some(x) = environ.get_parent() { x.name() } else { "<root>".to_owned() },
-///            cs.iter().skip(1).fold(String::new(), |a, x| format!("{}\n{}", a, x.1))
+///            cs.print_with_newline_before()
 ///        );
 ///        Ok(Value::from(NoneType::None))
 ///     }

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -56,7 +56,7 @@ starlark_module! {global_functions =>
             format!(
                 "fail(): {}{}",
                 msg.to_str(),
-                st.iter().rev().fold(String::new(), |a,s| format!("{}\n    {}", a, s.1))
+                st.print_with_newline_before(),
             ),
             msg.to_str()
         )

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -132,7 +132,7 @@ impl From<FunctionArg> for Value {
 }
 
 pub type StarlarkFunctionPrototype =
-    dyn Fn(&[(String, String)], Environment, Vec<FunctionArg>) -> ValueResult;
+    dyn Fn(&CallStack, Environment, Vec<FunctionArg>) -> ValueResult;
 
 pub struct Function {
     function: Box<StarlarkFunctionPrototype>,
@@ -224,7 +224,7 @@ impl Function {
     #[allow(clippy::new_ret_no_self)]
     pub fn new<F>(name: String, f: F, signature: Vec<FunctionParameter>) -> Value
     where
-        F: Fn(&[(String, String)], Environment, Vec<FunctionArg>) -> ValueResult + 'static,
+        F: Fn(&CallStack, Environment, Vec<FunctionArg>) -> ValueResult + 'static,
     {
         Value::new(Function {
             function: Box::new(f),
@@ -240,7 +240,7 @@ impl Function {
         signature: Vec<FunctionParameter>,
     ) -> Value
     where
-        F: Fn(&[(String, String)], Environment, Vec<FunctionArg>) -> ValueResult + 'static,
+        F: Fn(&CallStack, Environment, Vec<FunctionArg>) -> ValueResult + 'static,
     {
         Value::new(Function {
             function: Box::new(f),
@@ -365,7 +365,7 @@ impl TypedValue for Function {
 
     fn call(
         &self,
-        call_stack: &[(String, String)],
+        call_stack: &CallStack,
         globals: Environment,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
@@ -481,7 +481,7 @@ impl TypedValue for WrappedMethod {
 
     fn call(
         &self,
-        call_stack: &[(String, String)],
+        call_stack: &CallStack,
         env: Environment,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -84,6 +84,7 @@
 //! }
 //! ```
 use crate::environment::Environment;
+use crate::eval::call_stack::CallStack;
 use crate::values::error::ValueError;
 use codemap_diagnostic::Level;
 use linked_hash_map::LinkedHashMap;
@@ -249,7 +250,7 @@ pub trait TypedValue: 'static {
     /// * kwargs: if provided, the `**kwargs` argument.
     fn call(
         &self,
-        _call_stack: &[(String, String)],
+        _call_stack: &CallStack,
         _globals: Environment,
         _positional: Vec<Value>,
         _named: LinkedHashMap<String, Value>,
@@ -795,7 +796,7 @@ impl Value {
 
     pub fn call(
         &self,
-        call_stack: &[(String, String)],
+        call_stack: &CallStack,
         globals: Environment,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,


### PR DESCRIPTION
It's easier to read and maintain code with some entities represented
as types.

Test plan:

```
% cargo run -- ~/folder/a.x
   Compiling starlark v0.3.0-pre (/Users/me/devel/left/starlark-rust/starlark)
   Compiling starlark-repl v0.3.0-pre (/Users/me/devel/left/starlark-rust/starlark-repl)
    Finished dev [unoptimized + debuginfo] target(s) in 7.17s
     Running `target/debug/starlark-repl /Users/me/folder/a.x`
error[CR99]: fail(): a
    call to fail(msg) at /Users/me/folder/a.x:2
    call to h() at /Users/me/folder/a.x:6
    call to g() at /Users/me/folder/a.x:9
    call to f() at /Users/me/folder/a.x:11
 --> /Users/me/folder/a.x:2:5
  |
2 |     fail("a")
  |     ^^^^^^^^^ a

```