### PR TITLE
CallerEnvironment type

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -43,7 +43,7 @@ extern crate starlark;
 
 use codemap_diagnostic::{ColorConfig, Emitter};
 use linefeed::{Interface, ReadResult};
-use starlark::environment::Environment;
+use starlark::environment::{Environment, TypeValues};
 use starlark::eval::eval_lexer;
 use starlark::eval::simple::SimpleFileLoader;
 use starlark::syntax::dialect::Dialect;
@@ -81,7 +81,7 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             dialect,
             lexer,
             env,
-            file_loader_env.clone(),
+            TypeValues::new(file_loader_env.clone()),
             SimpleFileLoader::new(&map.clone(), file_loader_env),
         ) {
             Ok(v) => {

--- a/starlark/benches/benchutil/mod.rs
+++ b/starlark/benches/benchutil/mod.rs
@@ -15,6 +15,7 @@
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Emitter};
 use linked_hash_map::LinkedHashMap;
+use starlark::environment::TypeValues;
 use starlark::eval::call_stack::CallStack;
 use starlark::eval::simple::eval;
 use starlark::stdlib::global_environment_with_extensions;
@@ -71,7 +72,7 @@ def assert_(cond, msg="assertion failed"):
         let env = env.child("bench");
         match bench_func.call(
             &CallStack::default(),
-            env,
+            TypeValues::new(env),
             Vec::new(),
             LinkedHashMap::new(),
             None,

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -136,12 +136,12 @@ impl Environment {
     }
 
     /// Get a type value if it exists (e.g. list.index).
-    pub fn get_type_value(&self, obj: &Value, id: &str) -> Option<Value> {
+    fn get_type_value(&self, obj: &Value, id: &str) -> Option<Value> {
         self.env.borrow().get_type_value(obj, id)
     }
 
     /// List the attribute of a type
-    pub fn list_type_value(&self, obj: &Value) -> Vec<String> {
+    fn list_type_value(&self, obj: &Value) -> Vec<String> {
         self.env.borrow().list_type_value(obj)
     }
 
@@ -279,7 +279,7 @@ impl EnvironmentContent {
     }
 
     /// Get a type value if it exists (e.g. list.index).
-    pub fn get_type_value(&self, obj: &Value, id: &str) -> Option<Value> {
+    fn get_type_value(&self, obj: &Value, id: &str) -> Option<Value> {
         match self.type_objs.get(obj.get_type()) {
             Some(ref d) => match d.get(id) {
                 Some(v) => Some(v.clone()),
@@ -313,5 +313,37 @@ impl EnvironmentContent {
     /// Return the parent environment (or `None` if there is no parent).
     pub fn get_parent(&self) -> Option<Environment> {
         self.parent.clone()
+    }
+}
+
+/// Environment passed to `call` calls.
+///
+/// Function implementations are only allowed to access
+/// type values from "type values" from the caller context,
+/// so this struct is passed instead of full `Environment`.
+#[derive(Clone)]
+pub struct TypeValues {
+    env: Environment,
+}
+
+impl TypeValues {
+    /// Wrap environment.
+    pub fn new(env: Environment) -> TypeValues {
+        TypeValues { env }
+    }
+
+    /// Return the underlying `Environment` name.
+    pub fn name(&self) -> String {
+        self.env.name()
+    }
+
+    /// Get a type value if it exists (e.g. list.index).
+    pub fn get_type_value(&self, obj: &Value, id: &str) -> Option<Value> {
+        self.env.get_type_value(obj, id)
+    }
+
+    /// List the attribute of a type
+    pub fn list_type_value(&self, obj: &Value) -> Vec<String> {
+        self.env.list_type_value(obj)
     }
 }

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -15,7 +15,7 @@
 //! Define simpler version of the evaluation function,
 //! which does not support `load(...)` statement.
 
-use crate::environment::{Environment, LOAD_NOT_SUPPORTED_ERROR_CODE};
+use crate::environment::{Environment, TypeValues, LOAD_NOT_SUPPORTED_ERROR_CODE};
 use crate::eval::{EvalException, FileLoader};
 use crate::syntax::dialect::Dialect;
 use crate::values::Value;
@@ -56,7 +56,15 @@ pub fn eval(
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
-    globals: Environment,
+    type_values: TypeValues,
 ) -> Result<Value, Diagnostic> {
-    super::eval(map, path, content, dialect, env, globals, NoLoadFileLoader)
+    super::eval(
+        map,
+        path,
+        content,
+        dialect,
+        env,
+        type_values,
+        NoLoadFileLoader,
+    )
 }

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -15,7 +15,7 @@
 //! Define simpler version of the evaluation function
 use super::Dialect;
 use super::{EvalException, FileLoader};
-use crate::environment::Environment;
+use crate::environment::{Environment, TypeValues};
 use crate::values::*;
 use codemap::CodeMap;
 use codemap_diagnostic::Diagnostic;
@@ -54,7 +54,7 @@ impl FileLoader for SimpleFileLoader {
             path,
             Dialect::Bzl,
             &mut env,
-            self.parent_env.clone(),
+            TypeValues::new(self.parent_env.clone()),
             self.clone(),
         ) {
             return Err(EvalException::DiagnosedError(d));
@@ -94,7 +94,7 @@ pub fn eval(
         content,
         dialect,
         env,
-        file_loader_env.clone(),
+        TypeValues::new(file_loader_env.clone()),
         SimpleFileLoader::new(map, file_loader_env),
     )
 }
@@ -122,7 +122,7 @@ pub fn eval_file(
         path,
         build,
         env,
-        file_loader_env.clone(),
+        TypeValues::new(file_loader_env.clone()),
         SimpleFileLoader::new(map, file_loader_env),
     )
 }

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -31,7 +31,7 @@ pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
         snippet,
         Dialect::Bzl,
         &mut env,
-        environment::Environment::new("empty"),
+        environment::TypeValues::new(environment::Environment::new("empty")),
     ) {
         Ok(v) => Ok(v.to_bool()),
         Err(d) => {

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -165,7 +165,7 @@ macro_rules! starlark_fun {
         $(#[$attr])*
         fn $fn(
             __call_stack: &$crate::eval::call_stack::CallStack,
-            __env: $crate::environment::Environment,
+            __env: $crate::environment::TypeValues,
             args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
             let mut __args = args.into_iter();
@@ -181,7 +181,7 @@ macro_rules! starlark_fun {
         $(#[$attr])*
         fn $fn(
             __call_stack: &$crate::eval::call_stack::CallStack,
-            __env: $crate::environment::Environment,
+            __env: $crate::environment::TypeValues,
             args: Vec<$crate::values::function::FunctionArg>
         ) -> $crate::values::ValueResult {
             let mut __args = args.into_iter();
@@ -267,14 +267,12 @@ macro_rules! starlark_signatures {
 ///         Ok(Value::new(x * x))
 ///     }
 ///
-///     // It is also possible to capture the calling environment with `env name`
-///     // (type `starlark::enviroment::Environment`) and the call stack with
+///     // It is also possible to capture the call stack with
 ///     // `call_stack name` (type `Vec<String>`). For example a `dbg` function that print the
-///     // environment and the call stack of the caller:
-///     dbg(call_stack cs, env environ) {
+///     // the call stack:
+///     dbg(call_stack cs) {
 ///        println!(
-///            "In {}:{}",
-///            if let Some(x) = environ.get_parent() { x.name() } else { "<root>".to_owned() },
+///            "In:{}",
 ///            cs.print_with_newline_before()
 ///        );
 ///        Ok(Value::from(NoneType::None))
@@ -315,7 +313,7 @@ macro_rules! starlark_signatures {
 /// ```rust
 /// # #[macro_use] extern crate starlark;
 /// # use starlark::values::*;
-/// # use starlark::environment::Environment;
+/// # use starlark::environment::{Environment, TypeValues};
 /// starlark_module!{ my_starlark_module =>
 ///     // The first argument is always self in that module but we use "this" because "self" is a
 ///     // a rust keyword.
@@ -327,7 +325,7 @@ macro_rules! starlark_signatures {
 /// }
 /// #
 /// # fn main() {
-/// #    let env = my_starlark_module(Environment::new("test"));
+/// #    let env = TypeValues::new(my_starlark_module(Environment::new("test")));
 /// #    assert_eq!(env.get_type_value(&Value::from(""), "hello").unwrap().get_type(), "function");
 /// # }
 /// ```

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -131,6 +131,7 @@ mod test {
     use crate::starlark_signature_extraction;
     use crate::starlark_signatures;
 
+    use crate::environment::TypeValues;
     use crate::eval::noload::eval;
     use crate::stdlib::global_environment;
     use crate::syntax::dialect::Dialect;
@@ -159,7 +160,7 @@ mod test {
             "cc_binary(name='star', srcs=['a.cc', 'b.cc'])",
             Dialect::Build,
             &mut child,
-            env,
+            TypeValues::new(env),
         )
         .unwrap();
 

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -81,7 +81,7 @@
 //!     }
 //! }
 //! ```
-use crate::environment::Environment;
+use crate::environment::TypeValues;
 use crate::eval::call_stack;
 use crate::eval::call_stack::CallStack;
 use crate::values::error::ValueError;
@@ -313,7 +313,7 @@ impl<T: TypedValue> ValueHolderDyn for ValueHolder<T> {
     fn call(
         &self,
         call_stack: &CallStack,
-        env: Environment,
+        type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
@@ -321,7 +321,7 @@ impl<T: TypedValue> ValueHolderDyn for ValueHolder<T> {
     ) -> ValueResult {
         self.content
             .borrow()
-            .call(call_stack, env, positional, named, args, kwargs)
+            .call(call_stack, type_values, positional, named, args, kwargs)
     }
 
     fn at(&self, index: Value) -> Result<Value, ValueError> {
@@ -481,7 +481,7 @@ trait ValueHolderDyn {
     fn call(
         &self,
         call_stack: &CallStack,
-        env: Environment,
+        type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
@@ -639,7 +639,7 @@ pub trait TypedValue: Sized + 'static {
     /// # Parameters
     ///
     /// * call_stack: the calling stack, to detect recursion
-    /// * globals: global environment of the caller.
+    /// * type_values: environment used to resolve type fields.
     /// * positional: the list of arguments passed positionally.
     /// * named: the list of argument that were named.
     /// * args: if provided, the `*args` argument.
@@ -647,7 +647,7 @@ pub trait TypedValue: Sized + 'static {
     fn call(
         &self,
         _call_stack: &CallStack,
-        _globals: Environment,
+        _type_values: TypeValues,
         _positional: Vec<Value>,
         _named: LinkedHashMap<String, Value>,
         _args: Option<Value>,
@@ -1044,14 +1044,14 @@ impl Value {
     pub fn call(
         &self,
         call_stack: &CallStack,
-        globals: Environment,
+        type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
         kwargs: Option<Value>,
     ) -> ValueResult {
         self.0
-            .call(call_stack, globals, positional, named, args, kwargs)
+            .call(call_stack, type_values, positional, named, args, kwargs)
     }
 
     pub fn at(&self, index: Value) -> ValueResult {


### PR DESCRIPTION
Caller environment can only be used to revolve "type values" and
nothing more.

It might be convenient to access true caller environment, but it leads
to certain problems. Consider this situation. Module `a.bzl`
defines a function `foo` which calls function `bar`.

```
def bar(): ...

def foo(): bar()
```

and `BUILD` file imports `a.bzl` and calls `foo`:

```
foo()
```

`foo` function captures the context of `a.bzl` and inherits it in
locals (since #113).

However, when `foo` resolves type values, it must use type values
defined in the root caller (`BUILD` context, not captured).

Now function `foo` calls `bar`. Function `bar` also needs to resolve
type values.  These type values must again come from `BUILD` (because
captured context might not contain proper type values).

This environment passed to `bar` must be `BUILD` environment, but
not the local environment of `foo`.

Why the environment passed to `bar` must be `BUILD` environment?
Consider this scenario, `baz` is defined in `baz.bzl`:

```
def baz(unknown): unknown.append(10)
```

When `baz` is called from `BUILD` with object `foo` defined elsewhere,
`baz` should use the caller context, not local or captured context
to resolve `unknown.bar`. Because local (and captured) context might
not contain type values for `unknown`. But the function definition
is perfectly valid.

In theory in `foo` when calling `bar` we could merge the local
environment with the environment from `BUILD`, but:

* it is not practically needed for anything
* it complicates everything beyond the limit of understanding by human

`CallerEnvironment` type is introduced which wraps `Environment`
but only provides access to type values. And `Environment` no longer
provides readable access to type values.

The good side is that change forced me to fix a couple of issues
with using an incorrect environment to find type values.

The bad side is that `dbg` function is no longer able to print
caller locals.

But the good side is that `dbg` was broken anyway after fix #113.