### PR TITLE
Split equals and compare operations

### DIFF
--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -28,6 +28,9 @@ impl From<bool> for Value {
 impl TypedValue for bool {
     immutable!();
     any!();
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        Ok(*self == *other.downcast_ref::<bool>().unwrap())
+    }
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(&*other.downcast_ref::<bool>().unwrap()))
     }

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -14,6 +14,7 @@
 
 //! Define the int type for Starlark.
 
+use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
 
@@ -81,6 +82,9 @@ where
 impl TypedValue for i64 {
     immutable!();
     any!();
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        Ok(*self == *other.downcast_ref::<i64>().unwrap())
+    }
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(&*other.downcast_ref::<i64>().unwrap()))
     }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -143,6 +143,31 @@ impl TypedValue for List {
         !self.content.is_empty()
     }
 
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        let other = other.downcast_ref::<List>().unwrap();
+
+        if self.content.len() != other.content.len() {
+            return Ok(false);
+        }
+
+        let mut self_iter = self.content.iter();
+        let mut other_iter = other.content.iter();
+
+        loop {
+            match (self_iter.next(), other_iter.next()) {
+                (Some(a), Some(b)) => {
+                    if !a.equals(b)? {
+                        return Ok(false);
+                    }
+                }
+                (None, None) => {
+                    return Ok(true);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<List>().unwrap();
@@ -174,7 +199,7 @@ impl TypedValue for List {
 
     fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
         for x in self.content.iter() {
-            if x.compare(other)? == Ordering::Equal {
+            if x.equals(other)? {
                 return Ok(true);
             }
         }

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -14,6 +14,7 @@
 
 //! Define the None type for Starlark.
 
+use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
 
@@ -25,6 +26,11 @@ pub enum NoneType {
 impl TypedValue for NoneType {
     immutable!();
     any!();
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        // assert type
+        other.downcast_ref::<NoneType>().unwrap();
+        Ok(true)
+    }
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<NoneType>().unwrap();

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -52,6 +52,10 @@ impl TypedValue for String {
         Ok(s.finish())
     }
 
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        Ok(*self == *other.downcast_ref::<String>().unwrap())
+    }
+
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(other.downcast_ref::<String>().unwrap().deref()))
     }

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -305,6 +305,31 @@ impl TypedValue for Tuple {
         Ok(s.finish())
     }
 
+    fn equals(&self, other: &Value) -> Result<bool, ValueError> {
+        let other = other.downcast_ref::<Tuple>().unwrap();
+
+        if self.content.len() != other.content.len() {
+            return Ok(false);
+        }
+
+        let mut self_iter = self.content.iter();
+        let mut other_iter = other.content.iter();
+
+        loop {
+            match (self_iter.next(), other_iter.next()) {
+                (Some(a), Some(b)) => {
+                    if !a.equals(b)? {
+                        return Ok(false);
+                    }
+                }
+                (None, None) => {
+                    return Ok(true);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
     fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<Tuple>().unwrap();
@@ -336,7 +361,7 @@ impl TypedValue for Tuple {
 
     fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
         for x in self.content.iter() {
-            if x.compare(other)? == Ordering::Equal {
+            if x.equals(other)? {
                 return Ok(true);
             }
         }

--- a/starlark/tests/go-testcases/builtins.sky
+++ b/starlark/tests/go-testcases/builtins.sky
@@ -44,25 +44,29 @@ assert_eq(sorted([42, 123, 3]), [3, 42, 123])
 assert_eq(sorted([42, 123, 3], reverse=True), [123, 42, 3])
 assert_eq(sorted(["wiz", "foo", "bar"]), ["bar", "foo", "wiz"])
 assert_eq(sorted(["wiz", "foo", "bar"], reverse=True), ["wiz", "foo", "bar"])
-assert_eq(sorted([1, 2, None, 3]), [1, 2, 3, None])
-assert_eq(sorted([1, "one"]), [1, "one"])
+sorted([1, 2, None, 3])       ###   compare not supported for types
+---
+sorted([1, "one"])            ###   compare not supported for types
+---
 # custom key function
 assert_eq(sorted(["two", "three", "four"], key=len),
           ["two", "four", "three"])
 assert_eq(sorted(["two", "three", "four"], key=len, reverse=True),
           ["three", "four", "two"])
----
-# why should that fails?
-# sorted([1, 2, 3], key=None)  # Type of parameters mismatch
+sorted([1, 2, 3], key=None)   ###   call() not supported for type NoneType
 ---
 # sort is stable
 pairs = [(4, 0), (3, 1), (4, 2), (2, 3), (3, 4), (1, 5), (2, 6), (3, 7)]
-def fn(x): return x[0]
-assert_eq(sorted(pairs, key=fn),
+def first(t): return t[0]
+assert_eq(sorted(pairs, key=first),
           [(1, 5),
            (2, 3), (2, 6),
            (3, 1), (3, 4), (3, 7),
            (4, 0), (4, 2)])
+
+sorted(1)                     ###   The type 'int' is not iterable
+
+---
 
 # reversed
 assert_eq(reversed([1, 144, 81, 16]), [16, 81, 144, 1])
@@ -107,7 +111,7 @@ assert_(range(0) < range(1))
 # <number> in <range>
 assert_(1 in range(3))
 ---
-assert_(True in range(3))  # The go implementation does not support that but python does.
+assert_(True not in range(3))  # The go implementation does not support that but python returns True.
 ---
 assert_("one" not in range(10))
 ---

--- a/starlark/tests/go-testcases/misc.sky
+++ b/starlark/tests/go-testcases/misc.sky
@@ -38,15 +38,18 @@
 
 def lam(): None
 
-# All comparisons are legal
-None < False
-False < list
-list < {}
-{} < lam
-lam < 0
-0 < []
-[] < ""
-"" < ()
+# Ordered comparisons require values of the same type.
+None < False  ###  compare not supported for types NoneType and bool
+---
+False < list  ###  compare not supported for types bool and function
+---
+list < {}     ###  compare not supported for types function and dict
+---
+0 < []        ###  compare not supported for types int and list
+---
+[] < ""       ###  compare not supported for types list and str
+---
+"" < ()       ###  compare not supported for types string and tuple
 
 ---
 # cyclic data structures

--- a/starlark/tests/java-testcases/min_max.sky
+++ b/starlark/tests/java-testcases/min_max.sky
@@ -33,15 +33,15 @@ min(1)  ### type 'int' is not iterable
 ---
 min([])  ### Argument is an empty iterable, min() expect a non empty iterable
 ---
-assert_eq(min(1, "2", True), 1) # Ignoring: this is is correct in python -- Cannot compare int with string
+assert_eq(min(1, "2", True), 1)     ###  compare not supported for types
 ---
-assert_eq(min([1, "2", True]), 1) # Ignoring: this is is correct in python -- Cannot compare int with string
+assert_eq(min([1, "2", True]), 1)   ###  compare not supported for types
 ---
 max(1) ### type 'int' is not iterable
 ---
 max([]) ### Argument is an empty iterable, max() expect a non empty iterable
 ---
-assert_eq(max(1, '2', True), '2') # Ignoring: this is is correct in python -- Cannot compare int with string
+assert_eq(max(1, '2', True), '2')   ###  compare not supported for types
 ---
-assert_eq(max([1, '2', True]), '2') # Ignoring: this is is correct in python -- Cannot compare int with string
+assert_eq(max([1, '2', True]), '2') ###  compare not supported for types
 ---


### PR DESCRIPTION
As title says.

In addition to that:

* Compare between objects of different types now always results in
  error (issue #54)
* In particular `False` is no longer comparable with `0`
* Compare is unimplemented for `dict`, `set` and `struct` types
* Fixed panic in `sorted` where types are not comparable
* `Value` no longer implements `Ord`
* fixed `min` and `max` to return error when types are not comparable