### PR TITLE
Value::iter without collecting into a Vec

### DIFF
--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -39,7 +39,7 @@ starlark_module! {global =>
     set(?#a) {
         let mut s = Set::default();
         if let Some(a) = a {
-            for x in a.iter()? {
+            for x in &a.iter()? {
                 s.insert_if_absent(x)?;
             }
         }
@@ -151,7 +151,7 @@ starlark_module! {global =>
     /// ```
     set.difference(this, *others) {
         let mut ret = Set::default();
-        for el in this.iter()? {
+        for el in &this.iter()? {
             let mut is_in_any_other = false;
             for other in &others {
                 if other.is_in(&el)?.to_bool() {
@@ -254,7 +254,7 @@ starlark_module! {global =>
     /// ```
     set.intersection(this, *others) {
         let mut ret = Set::default();
-        for el in this.iter()? {
+        for el in &this.iter()? {
             let mut is_in_every_other = true;
             for other in &others {
                 if !other.is_in(&el)?.to_bool() {
@@ -529,7 +529,7 @@ starlark_module! {global =>
         })?;
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         this.clear();
-        for item in symmetric_difference.iter()? {
+        for item in &symmetric_difference.iter()? {
             this.insert(item)?;
         }
         Ok(Value::new(NoneType::None))
@@ -563,11 +563,11 @@ starlark_module! {global =>
     /// ```
     set.union(this, *others) {
         let mut ret = Set::default();
-        for el in this.iter()? {
+        for el in &this.iter()? {
             ret.insert_if_absent(el)?;
         }
         for other in others {
-            for el in other.iter()? {
+            for el in &other.iter()? {
                 ret.insert_if_absent(el)?;
             }
         }
@@ -598,7 +598,7 @@ starlark_module! {global =>
     set.update(this, *others) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         for other in others {
-            for el in other.iter()? {
+            for el in &other.iter()? {
                 this.insert_if_absent(el)?;
             }
         }

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -16,6 +16,7 @@
 use crate::linked_hash_set::set_impl::LinkedHashSet;
 use crate::values::error::ValueError;
 use crate::values::hashed_value::HashedValue;
+use crate::values::iter::TypedIterable;
 use crate::values::*;
 use std::num::Wrapping;
 
@@ -220,8 +221,8 @@ impl TypedValue for Set {
         )))
     }
 
-    fn iter<'a>(&'a self) -> Result<Box<Iterator<Item = Value> + 'a>, ValueError> {
-        Ok(Box::new(self.content.iter().map(|x| x.get_value().clone())))
+    fn iter(&self) -> Result<&TypedIterable, ValueError> {
+        Ok(self)
     }
 
     /// Concatenate `other` to the current value.
@@ -248,7 +249,7 @@ impl TypedValue for Set {
             for x in self.content.iter() {
                 result.content.insert(x.clone());
             }
-            for x in other.iter()? {
+            for x in &other.iter()? {
                 result
                     .content
                     .insert_if_absent(HashedValue::new(x.clone())?);
@@ -267,6 +268,12 @@ impl TypedValue for Set {
             .map(Wrapping)
             .fold(Wrapping(0_u64), |acc, v| acc + v)
             .0)
+    }
+}
+
+impl TypedIterable for Set {
+    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+        Box::new(self.content.iter().map(|v| v.get_value().clone()))
     }
 }
 

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -127,7 +127,7 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     dict.keys(this) {
-        let v : Vec<Value> = this.iter()?.collect();
+        let v : Vec<Value> = this.iter()?.iter().collect();
         ok!(v)
     }
 
@@ -290,7 +290,7 @@ starlark_module! {global =>
     dict.update(this, ?#pairs, **kwargs) {
         if let Some(pairs) = pairs {
             match pairs.get_type() {
-                "list" => for v in pairs.iter()? {
+                "list" => for v in &pairs.iter()? {
                     if v.length()? != 2 {
                         starlark_err!(
                             INCORRECT_PARAMETER_TYPE_ERROR_CODE,
@@ -303,7 +303,7 @@ starlark_module! {global =>
                     }
                     this.set_at(v.at(Value::new(0))?, v.at(Value::new(1))?)?;
                 },
-                "dict" => for k in pairs.iter()? {
+                "dict" => for k in &pairs.iter()? {
                     this.set_at(k.clone(), pairs.at(k)?)?
                 },
                 x => starlark_err!(

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -137,7 +137,8 @@ starlark_module! {global =>
     /// ```
     list.index(this, #needle, #start = 0, #end = NoneType::None) {
         convert_indices!(this, start, end);
-        let mut it = this.iter()?.skip(start).take(end - start);
+        let it = this.iter()?;
+        let mut it = it.iter().skip(start).take(end - start);
         if let Some(offset) = it.position(|x| x == needle) {
             Ok(Value::new((offset + start) as i64))
         } else {

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -30,7 +30,7 @@ pub trait TryParamConvertFromValue: Sized {
 impl<T: TryParamConvertFromValue> TryParamConvertFromValue for Vec<T> {
     fn try_from(source: Value) -> Result<Self, ValueError> {
         let mut r = Vec::new();
-        for item in source.iter()? {
+        for item in &source.iter()? {
             r.push(T::try_from(item)?);
         }
         Ok(r)

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -88,7 +88,7 @@ starlark_module! {global_functions =>
     /// # )").unwrap());
     /// ```
     any(#x) {
-        for i in x.iter()? {
+        for i in &x.iter()? {
             if i.to_bool() {
                 return Ok(Value::new(true));
             }
@@ -121,7 +121,7 @@ starlark_module! {global_functions =>
     /// # )").unwrap());
     /// ```
     all(#x) {
-        for i in x.iter()? {
+        for i in &x.iter()? {
             if !i.to_bool() {
                 return Ok(Value::new(false));
             }
@@ -235,15 +235,16 @@ starlark_module! {global_functions =>
         if let Some(a) = a {
             match a.get_type() {
                 "dict" => {
-                    for k in a.iter()? {
+                    for k in &a.iter()? {
                         let v = a.at(k.clone())?;
                         map.set_at(k, v)?;
                     }
                 },
                 _ => {
-                   for el in a.iter()? {
+                   for el in &a.iter()? {
                        match el.iter() {
-                           Ok(mut it) => {
+                           Ok(it) => {
+                                let mut it = it.iter();
                                 let first = it.next();
                                 let second = it.next();
                                 if first.is_none() || second.is_none() || it.next().is_some() {
@@ -327,6 +328,7 @@ starlark_module! {global_functions =>
         let v : Vec<Value> =
             it
             .iter()?
+            .iter()
             .enumerate()
             .map(|(k, v)| Value::from((Value::new(k as i64 + offset), v)))
             .collect();
@@ -511,7 +513,7 @@ starlark_module! {global_functions =>
     list(?#a) {
         let mut l = Vec::new();
         if let Some(a) = a {
-            for x in a.iter()? {
+            for x in &a.iter()? {
                 l.push(x.clone())
             }
         }
@@ -546,7 +548,8 @@ starlark_module! {global_functions =>
         } else {
             Value::from(args)
         };
-        let mut it = args.iter()?;
+        let it = args.iter()?;
+        let mut it = it.iter();
         let mut max = match it.next() {
             Some(x) => x,
             None => starlark_err!(
@@ -602,7 +605,8 @@ starlark_module! {global_functions =>
         } else {
             Value::from(args)
         };
-        let mut it = args.iter()?;
+        let it = args.iter()?;
+        let mut it = it.iter();
         let mut min = match it.next() {
             Some(x) => x,
             None => starlark_err!(
@@ -779,7 +783,7 @@ starlark_module! {global_functions =>
     /// # )"#).unwrap());
     /// ```
     reversed(#a) {
-        let v : Vec<Value> = a.iter()?.collect();
+        let v : Vec<Value> = a.iter()?.iter().collect();
         let v : Vec<Value> = v.into_iter().rev().collect();
         Ok(Value::from(v))
     }
@@ -812,7 +816,8 @@ starlark_module! {global_functions =>
     /// # )"#).unwrap());
     /// ```
     sorted(call_stack cs, env e, #x, ?key, reverse = false) {
-        let x = x.iter()?;
+        let it = x.iter()?;
+        let x = it.iter();
         let mut it = match key {
             None => {
                 x.map(|x| (x.clone(), x)).collect()
@@ -884,7 +889,7 @@ starlark_module! {global_functions =>
     tuple(?#a) {
         let mut l = Vec::new();
         if let Some(a) = a {
-            for x in a.iter()? {
+            for x in &a.iter()? {
                 l.push(x.clone())
             }
         }
@@ -934,7 +939,7 @@ starlark_module! {global_functions =>
         for arg in args {
             let first = v.is_empty();
             let mut idx = 0;
-            for e in arg.iter()? {
+            for e in &arg.iter()? {
                 if first {
                     v.push(Value::from((e.clone(),)));
                     idx += 1;

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -790,7 +790,8 @@ starlark_module! {global =>
     /// ```
     string.join(this: String, #to_join) {
         let mut r = String::new();
-        for (index, item) in to_join.iter()?.enumerate() {
+        let to_join_iter = to_join.iter()?;
+        for (index, item) in to_join_iter.iter().enumerate() {
             if index != 0 {
                 r.push_str(&this);
             }
@@ -1354,7 +1355,8 @@ mod tests {
     fn test_format_capture() {
         let args = Value::from(vec!["1", "2", "3"]);
         let mut kwargs = dict::Dictionary::new();
-        let mut it = args.iter().unwrap();
+        let it = args.iter().unwrap();
+        let mut it = it.iter();
         let mut captured_by_index = false;
         let mut captured_by_order = false;
 
@@ -1431,7 +1433,8 @@ mod tests {
         )
         .is_err());
         captured_by_order = false;
-        it = args.iter().unwrap();
+        let it = args.iter().unwrap();
+        let mut it = it.iter();
         assert_eq!(
             format_capture(
                 "{1",

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -378,7 +378,7 @@ impl TypedValue for Function {
         let mut av = positional;
         if let Some(x) = args {
             match x.iter() {
-                Ok(y) => av.extend(y),
+                Ok(y) => av.extend(y.iter()),
                 Err(..) => return Err(FunctionError::ArgsArrayIsNotIterable.into()),
             }
         };
@@ -388,7 +388,7 @@ impl TypedValue for Function {
         if let Some(x) = kwargs {
             match x.iter() {
                 Ok(y) => {
-                    for n in y {
+                    for n in &y {
                         if n.get_type() == "string" {
                             let k = n.to_str();
                             if let Ok(v) = x.at(n) {

--- a/starlark/src/values/iter.rs
+++ b/starlark/src/values/iter.rs
@@ -1,0 +1,57 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Iterable for Starlark objects.
+
+use crate::values::Value;
+use std::cell::Ref;
+
+/// Type to be implemented by types which are iterable.
+pub trait TypedIterable: 'static {
+    /// Make an iterator.
+    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a>;
+}
+
+/// Iterable which contains borrowed reference to a sequence.
+pub struct RefIterable<'a> {
+    r: Ref<'a, TypedIterable>,
+}
+
+impl<'a> RefIterable<'a> {
+    pub fn new(r: Ref<'a, TypedIterable>) -> RefIterable<'a> {
+        RefIterable { r }
+    }
+
+    pub fn iter(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+        self.r.to_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a RefIterable<'a> {
+    type Item = Value;
+    type IntoIter = Box<Iterator<Item = Value> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Fake iterable needed to be able to do `Ref::map` with error.
+pub(crate) struct FakeTypedIterable;
+
+impl TypedIterable for FakeTypedIterable {
+    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+        unreachable!()
+    }
+}

--- a/starlark/src/values/string/interpolation.rs
+++ b/starlark/src/values/string/interpolation.rs
@@ -310,8 +310,10 @@ impl ArgsFormat {
 
     pub fn format(self, other: Value) -> Result<String, ValueError> {
         let mut r = self.init;
+        let mut other_iter;
         let mut arg_iter: Box<dyn Iterator<Item = Value>> = if self.positional_count > 1 {
-            other.iter()?
+            other_iter = Some(other.iter()?);
+            other_iter.as_ref().unwrap().iter()
         } else if self.positional_count == 1 {
             Box::new(iter::once(other.clone()))
         } else if self.named_count != 0 {
@@ -319,7 +321,8 @@ impl ArgsFormat {
         } else {
             // If both positional count is zero and named count is zero
             // we should check that iterable has zero elements.
-            other.iter()?
+            other_iter = Some(other.iter()?);
+            other_iter.as_ref().unwrap().iter()
         };
         for (named_or_positional, format, tail) in self.parameters {
             let arg = match named_or_positional {

--- a/starlark/tests/go-testcases/assign.sky
+++ b/starlark/tests/go-testcases/assign.sky
@@ -8,7 +8,7 @@ assert_eq(b, 2)
 assert_eq(c, 3)
 
 ---
-(x,) = 1         ### len() not supported for type int
+(x,) = 1         ### The type 'int' is not iterable
 ---
 a, b, c = 1, 2   ### Unpacked
 ---
@@ -23,7 +23,7 @@ assert_eq(a, 1)
 assert_eq(b, 2)
 assert_eq(c, 3)
 ---
-[a, b, c,] = 1  ### len() not supported for type int
+[a, b, c,] = 1  ### The type 'int' is not iterable
 ---
 [a, b, c] = 1, 2  ### Unpacked
 ---

--- a/starlark/tests/go-testcases/string.sky
+++ b/starlark/tests/go-testcases/string.sky
@@ -85,7 +85,7 @@ assert_eq("abc"[2], "c")
 # x[i] = ...
 x2 = "abc"
 def f(): x2[1] = 'B'
-f() ### Cannot [] = types string and int
+f() ### Immutable
 ---
 
 # slicing, x[i:j]


### PR DESCRIPTION
There are two subtleties in this PR.

**First**, Rust standard library has no `RefVal` object which
contains not a reference like `Ref` but a value bound to `RefVal`
lifetime.  Seems like it is not possible to implement `RefVal`
safely in current Rust.

Since it's not possible to return anything except references inside
`RefCell`, returned value is "iterable", not "iterator" (simply
downcast `TypedValue`).

It's not possible to implement `IntoIterator` for `Ref`, so
`IntoIterator` is implemented for `&Ref` (`&RefIterable`).

Thus iteration over value returned by `Value::iter` now looks like this:

```rust
let v: Value = ...
for item in &v.iter()? { ... }
```

And if an iterator is needed explicitly, iterable need to be stored
in a temporary variable.

```rust
let v: Value = ...
let iterble = v.iter()?;
let mut iterator = iter.iter();
iterator.next();

// this is invalid because iterator lifetime is bound to iterable
// let mut iterator = v.iter()?.iter();
```

**Second**, mutability flag is hidden inside `TypedValue`, so to
query mutability we need to borrow `TypedValue` first. But we need
to check mutability before invoking mutating operations.

So `Value` has now magic `borrow_mut_check_mutability` function,
which borrows immutably after `borrow_mut` failed to return proper
error.