### PR TITLE
Replace Into<ValueError> with From ... for ValueError

### DIFF
--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -70,9 +70,9 @@ impl Into<RuntimeError> for EnvironmentError {
     }
 }
 
-impl Into<ValueError> for EnvironmentError {
-    fn into(self) -> ValueError {
-        ValueError::Runtime(self.into())
+impl From<EnvironmentError> for ValueError {
+    fn from(e: EnvironmentError) -> Self {
+        ValueError::Runtime(e.into())
     }
 }
 

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -789,20 +789,16 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     string.join(this: String, #to_join) {
-        ok!(
-            to_join.iter()?.fold(
-                Ok(String::new()),
-                |a, x| {
-                    check_string!(x, join);
-                    let a = a.unwrap();
-                    if a.is_empty() {
-                        Ok(x.to_str())
-                    } else {
-                        Ok(format!("{}{}{}", a, this, x.to_str()))
-                    }
-                }
-            )?
-        );
+        let mut r = String::new();
+        for (index, item) in to_join.iter()?.enumerate() {
+            if index != 0 {
+                r.push_str(&this);
+            }
+            check_string!(item, join);
+            let item = item.downcast_ref::<String>().unwrap();
+            r.push_str(&*item);
+        }
+        ok!(r)
     }
 
     /// [string.lower](

--- a/starlark/src/values/error.rs
+++ b/starlark/src/values/error.rs
@@ -98,15 +98,15 @@ impl<T: Into<RuntimeError>> SyntaxError for T {
     }
 }
 
-impl Into<ValueError> for RuntimeError {
-    fn into(self) -> ValueError {
-        ValueError::Runtime(self)
+impl From<RuntimeError> for ValueError {
+    fn from(e: RuntimeError) -> Self {
+        ValueError::Runtime(e)
     }
 }
 
-impl Into<ValueError> for StringInterpolationError {
-    fn into(self) -> ValueError {
-        ValueError::StringInterpolation(self)
+impl From<StringInterpolationError> for ValueError {
+    fn from(e: StringInterpolationError) -> Self {
+        ValueError::StringInterpolation(e)
     }
 }
 

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -214,9 +214,9 @@ impl Into<RuntimeError> for FunctionError {
     }
 }
 
-impl Into<ValueError> for FunctionError {
-    fn into(self) -> ValueError {
-        ValueError::Runtime(self.into())
+impl From<FunctionError> for ValueError {
+    fn from(e: FunctionError) -> Self {
+        ValueError::Runtime(e.into())
     }
 }
 

--- a/starlark/src/values/string/interpolation.rs
+++ b/starlark/src/values/string/interpolation.rs
@@ -244,7 +244,7 @@ impl ArgsFormat {
             } else {
                 let next = chars
                     .next()
-                    .ok_or_else(|| StringInterpolationError::UnexpectedEOFPercent.into())?;
+                    .ok_or(StringInterpolationError::UnexpectedEOFPercent)?;
                 let (named_or_positional, format_char) = if next == '(' {
                     let mut name = String::new();
                     loop {
@@ -264,7 +264,7 @@ impl ArgsFormat {
                         NamedOrPositional::Named(name),
                         chars
                             .next()
-                            .ok_or_else(|| StringInterpolationError::UnexpectedEOFPercent.into())?,
+                            .ok_or(StringInterpolationError::UnexpectedEOFPercent)?,
                     )
                 } else {
                     (NamedOrPositional::Positional, next)


### PR DESCRIPTION
`Into` trait documentation recommends implementing `From`:

> One should only implement `Into` if a conversion to a type outside
> the current crate is required. Otherwise one should always prefer
> implementing [`From`] over `Into` because implementing [`From`]
> automatically provides one with a implementation of `Into` thanks to
> the blanket implementation in the standard library. [`From`] cannot do
> these type of conversions because of Rust's orphaning rules.

`From` also makes conversion compatible with `Into` and enables
conversion with operator `?`.