### PR TITLE
Make recursion counter thread-local

### DIFF
--- a/starlark/src/eval/call_stack.rs
+++ b/starlark/src/eval/call_stack.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //! Starlark call stack.
 
+use crate::values::error::ValueError;
+use std::cell::Cell;
 use std::fmt;
 
 /// Starlark call stack.
@@ -58,4 +60,68 @@ impl<'a> fmt::Display for DisplayWithNewlineBefore<'a> {
         }
         Ok(())
     }
+}
+
+// Maximum recursion level for comparison
+// TODO(dmarting): those are rather short, maybe make it configurable?
+#[cfg(debug_assertions)]
+const MAX_RECURSION: u32 = 200;
+
+#[cfg(not(debug_assertions))]
+const MAX_RECURSION: u32 = 3000;
+
+// A thread-local counter is used to detect too deep recursion.
+//
+// Thread-local is chosen instead of explicit function "recursion" parameter
+// for two reasons:
+// * It's possible to propagate stack depth across external functions like
+//   `Display::to_string` where passing a stack depth parameter is hard
+// * We need to guarantee that stack depth is not lost in complex invocation
+//   chains like function calls compare which calls native function which calls
+//   starlark function which calls to_str. We could change all evaluation stack
+//   signatures to accept some "context" parameters, but passing it as thread-local
+//   is easier.
+thread_local!(static STACK_DEPTH: Cell<u32> = Cell::new(0));
+
+/// Stored previous stack depth before calling `try_inc`.
+///
+/// Stores that previous stack depths back to thread-local on drop.
+#[must_use]
+pub struct StackGuard {
+    prev_depth: u32,
+}
+
+impl Drop for StackGuard {
+    fn drop(&mut self) {
+        STACK_DEPTH.with(|c| c.set(self.prev_depth));
+    }
+}
+
+/// Increment stack depth.
+fn inc() -> StackGuard {
+    let prev_depth = STACK_DEPTH.with(|c| {
+        let prev = c.get();
+        c.set(prev + 1);
+        prev
+    });
+    StackGuard { prev_depth }
+}
+
+/// Check stack depth does not exceed configured max stack depth.
+fn check() -> Result<(), ValueError> {
+    if STACK_DEPTH.with(Cell::get) >= MAX_RECURSION {
+        return Err(ValueError::TooManyRecursionLevel);
+    }
+    Ok(())
+}
+
+/// Try increment stack depth.
+///
+/// Return opaque `StackGuard` object which resets stack to previous value
+/// on `drop`.
+///
+/// If stack depth exceeds configured limit, return error.
+pub fn try_inc() -> Result<StackGuard, ValueError> {
+    check()?;
+    Ok(inc())
 }

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -323,7 +323,7 @@ where
 {
     let l = left.eval(context)?;
     let r = right.eval(context)?;
-    Ok(Value::new(cmp(t!(l.compare(&r, 0), this)?)))
+    Ok(Value::new(cmp(t!(l.compare(&r), this)?)))
 }
 
 fn eval_slice(

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -163,7 +163,7 @@ impl TypedValue for Set {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         let other = other.downcast_ref::<Self>().unwrap();
         if self
             .content

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -831,9 +831,9 @@ starlark_module! {global_functions =>
         it.sort_by(
             |x : &(Value, Value), y : &(Value, Value)| {
                 if reverse {
-                    x.1.compare(&y.1, 0).unwrap().reverse()
+                    x.1.compare(&y.1).unwrap().reverse()
                 } else {
-                    x.1.compare(&y.1, 0).unwrap()
+                    x.1.compare(&y.1).unwrap()
                 }
             }
         );

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -65,7 +65,7 @@ impl TypedValue for StarlarkStruct {
             .any(|x| x.same_as(other) || x.is_descendant(other))
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         let other = other.downcast_ref::<StarlarkStruct>().unwrap();
         let mut self_keys: Vec<_> = self.fields.keys().collect();
         let mut other_keys: Vec<_> = other.fields.keys().collect();
@@ -81,7 +81,7 @@ impl TypedValue for StarlarkStruct {
                 (Some(s_k), Some(o_k)) => {
                     let s_v = self.fields.get(s_k).unwrap();
                     let o_v = other.fields.get(o_k).unwrap();
-                    match s_v.compare(o_v, recursion + 1)? {
+                    match s_v.compare(o_v)? {
                         Ordering::Equal => continue,
                         ordering => return Ok(ordering),
                     }

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -28,7 +28,7 @@ impl From<bool> for Value {
 impl TypedValue for bool {
     immutable!();
     any!();
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(&*other.downcast_ref::<bool>().unwrap()))
     }
     fn to_repr(&self) -> String {

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -146,7 +146,7 @@ impl TypedValue for Dictionary {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<Dictionary>().unwrap();
         let mut v1: Vec<Value> = self.iter()?.collect();
@@ -163,11 +163,11 @@ impl TypedValue for Dictionary {
                 (None, Some(..)) => return Ok(Ordering::Less),
                 (Some(..), None) => return Ok(Ordering::Greater),
                 (Some(k1), Some(k2)) => {
-                    let r = k1.compare(&k2, recursion + 1)?;
+                    let r = k1.compare(&k2)?;
                     if r != Ordering::Equal {
                         return Ok(r);
                     }
-                    let r = self.at(k1)?.compare(&other.at(k2)?, recursion + 1)?;
+                    let r = self.at(k1)?.compare(&other.at(k2)?)?;
                     if r != Ordering::Equal {
                         return Ok(r);
                     }

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -81,7 +81,7 @@ where
 impl TypedValue for i64 {
     immutable!();
     any!();
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(&*other.downcast_ref::<i64>().unwrap()))
     }
     fn to_str(&self) -> String {

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -143,7 +143,7 @@ impl TypedValue for List {
         !self.content.is_empty()
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<List>().unwrap();
         let mut iter1 = self.iter()?;
@@ -154,7 +154,7 @@ impl TypedValue for List {
                 (None, Some(..)) => return Ok(Ordering::Less),
                 (Some(..), None) => return Ok(Ordering::Greater),
                 (Some(v1), Some(v2)) => {
-                    let r = v1.compare(&v2, recursion + 1)?;
+                    let r = v1.compare(&v2)?;
                     if r != Ordering::Equal {
                         return Ok(r);
                     }
@@ -174,7 +174,7 @@ impl TypedValue for List {
 
     fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
         for x in self.content.iter() {
-            if x.compare(other, 0)? == Ordering::Equal {
+            if x.compare(other)? == Ordering::Equal {
                 return Ok(true);
             }
         }

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -25,7 +25,7 @@ pub enum NoneType {
 impl TypedValue for NoneType {
     immutable!();
     any!();
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<NoneType>().unwrap();
         Ok(Ordering::Equal)

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -52,7 +52,7 @@ impl TypedValue for String {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &Value, _recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         Ok(self.cmp(other.downcast_ref::<String>().unwrap().deref()))
     }
 

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -305,7 +305,7 @@ impl TypedValue for Tuple {
         Ok(s.finish())
     }
 
-    fn compare(&self, other: &Value, recursion: u32) -> Result<Ordering, ValueError> {
+    fn compare(&self, other: &Value) -> Result<Ordering, ValueError> {
         // assert type
         other.downcast_ref::<Tuple>().unwrap();
         let mut iter1 = self.iter()?;
@@ -316,7 +316,7 @@ impl TypedValue for Tuple {
                 (None, Some(..)) => return Ok(Ordering::Less),
                 (Some(..), None) => return Ok(Ordering::Greater),
                 (Some(v1), Some(v2)) => {
-                    let r = v1.compare(&v2, recursion + 1)?;
+                    let r = v1.compare(&v2)?;
                     if r != Ordering::Equal {
                         return Ok(r);
                     }
@@ -336,7 +336,7 @@ impl TypedValue for Tuple {
 
     fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
         for x in self.content.iter() {
-            if x.compare(other, 0)? == Ordering::Equal {
+            if x.compare(other)? == Ordering::Equal {
                 return Ok(true);
             }
         }


### PR DESCRIPTION
This practically changes nothing for `compare` where it is used
now, but it could be used in other operations which are potentially
recursive.

Simple example: this code example crashes Starlark REPL:

```
def f():
    a = []
    for i in range(100000):
        a = [a]
    return len(str(a))

print(f())
```

It should return a proper error instead. A thread-local counter can be
used to detect too deep recursion.

We could patch all functions signatures to accept `recursion` (or
`context`) parameter, however:

* thread-local is convenient here
* explicit parameters cannot be passed through external functions
  where signatures cannot be modified (like `Vec::eq`)

Similarly, we can implement thread-local allocation counters (to
avoid OOM) and instruction counters (to prevent programs which are
guaranteed to terminate in million years).