### PR TITLE
Fold starlark_module! macro a bit more

### DIFF
--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -125,6 +125,7 @@ impl<T: TryParamConvertFromValue> TryParamConvertFromValue for EitherValueOrNone
 mod test {
     use crate::starlark_fun;
     use crate::starlark_module;
+    use crate::starlark_param_name;
     use crate::starlark_parse_param_type;
     use crate::starlark_signature;
     use crate::starlark_signature_extraction;


### PR DESCRIPTION
Introduce the intermediate step which does a transformation like:

```
x: String, ...
```

into

```
(named) x: String, ...
```

so both named and unnamed arguments are handled uniformly by matching
on `$is_named:tt $t:ident` (`# x` or `(named) x`).

Resulting macros are even more complicated than before but contain
fewer repetitions (and fewer LOC), so it's possible to extend them
further without drowning in copypasta.