### PR TITLE
NoLoadFileLoader

### DIFF
--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 // CM prefix = Critical Module
 const FROZEN_ENV_ERROR_CODE: &str = "CM00";
 const NOT_FOUND_ERROR_CODE: &str = "CM01";
+pub(crate) const LOAD_NOT_SUPPORTED_ERROR_CODE: &str = "CM02";
 const CANNOT_IMPORT_ERROR_CODE: &str = "CE02";
 
 #[derive(Debug)]

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -1019,6 +1019,7 @@ pub fn eval_file<T: FileLoader + 'static>(
 }
 
 pub mod interactive;
+pub mod noload;
 pub mod simple;
 
 pub mod call_stack;

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -1,0 +1,62 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define simpler version of the evaluation function,
+//! which does not support `load(...)` statement.
+
+use crate::environment::{Environment, LOAD_NOT_SUPPORTED_ERROR_CODE};
+use crate::eval::{EvalException, FileLoader};
+use crate::syntax::dialect::Dialect;
+use crate::values::Value;
+use codemap::CodeMap;
+use codemap_diagnostic::{Diagnostic, Level};
+use std::sync::{Arc, Mutex};
+
+/// File loader which returns error unconditionally.
+pub struct NoLoadFileLoader;
+
+impl FileLoader for NoLoadFileLoader {
+    fn load(&self, _path: &str) -> Result<Environment, EvalException> {
+        Err(EvalException::DiagnosedError(Diagnostic {
+            level: Level::Error,
+            message: "ErrorFileLoader does not support loading".to_owned(),
+            code: Some(LOAD_NOT_SUPPORTED_ERROR_CODE.to_owned()),
+            spans: Vec::new(),
+        }))
+    }
+}
+
+/// Evaluate a string content, mutate the environment accordingly and return the evaluated value.
+///
+/// # Arguments
+///
+/// __This version uses the [NoLoadFileLoader](NoLoadFileLoader.struct.html) implementation for
+/// the file loader__
+///
+/// * map: the codemap object used for diagnostics
+/// * path: the name of the file being evaluated, for diagnostics
+/// * content: the content to evaluate
+/// * dialect: Starlark language dialect
+/// * env: the environment to mutate during the evaluation
+/// * global: the environment used to resolve type values
+pub fn eval(
+    map: &Arc<Mutex<CodeMap>>,
+    path: &str,
+    content: &str,
+    dialect: Dialect,
+    env: &mut Environment,
+    globals: Environment,
+) -> Result<Value, Diagnostic> {
+    super::eval(map, path, content, dialect, env, globals, NoLoadFileLoader)
+}

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -14,8 +14,8 @@
 
 use crate::environment::Environment;
 use crate::eval::testutil::starlark_no_diagnostic;
-use crate::eval::RECURSION_ERROR_CODE;
-use crate::eval::{eval, simple, testutil, EvalException, FileLoader};
+use crate::eval::{eval, testutil, EvalException, FileLoader};
+use crate::eval::{noload, RECURSION_ERROR_CODE};
 use crate::syntax::dialect::Dialect;
 use crate::values::Value;
 use codemap::CodeMap;
@@ -164,7 +164,7 @@ fn test_context_captured() {
 x = 17
 def f(): return x
 "#;
-            simple::eval(
+            noload::eval(
                 &Arc::new(Mutex::new(CodeMap::new())),
                 path,
                 f_bzl,

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -15,6 +15,7 @@
 //! Macro to test starlark code execution
 use crate::environment;
 use crate::eval;
+use crate::eval::noload;
 use crate::syntax::dialect::Dialect;
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
@@ -24,7 +25,7 @@ use std::sync;
 pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     let mut env = environment::Environment::new("test");
-    match eval::simple::eval(
+    match noload::eval(
         &map,
         "<test>",
         snippet,

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -130,7 +130,7 @@ mod test {
     use crate::starlark_signature_extraction;
     use crate::starlark_signatures;
 
-    use crate::eval::simple::eval;
+    use crate::eval::noload::eval;
     use crate::stdlib::global_environment;
     use crate::syntax::dialect::Dialect;
     use crate::values::Value;

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! A module with the standard function and constants that are by default in all dialect of Starlark
-use crate::eval::simple::eval;
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use linked_hash_map::LinkedHashMap;
@@ -22,6 +21,7 @@ use std::error::Error;
 use std::sync;
 
 use crate::environment::Environment;
+use crate::eval::noload::eval;
 use crate::syntax::dialect::Dialect;
 use crate::values::dict::Dictionary;
 use crate::values::none::NoneType;
@@ -975,7 +975,7 @@ pub mod tests {
     use super::global_environment;
     use super::starlark_default;
     use super::Dialect;
-    use crate::eval::simple::eval;
+    use crate::eval::noload::eval;
     use codemap::CodeMap;
     use codemap_diagnostic::Diagnostic;
     use std::sync;


### PR DESCRIPTION
`simple::eval` is sometimes problematic: it may access the file
system even if evaluation supposed to be in memory only.

In particular, in tests it should be clear that no filesystem access
happens.

`NoLoadFileLoader` and `noload::eval` return error on `load(...)`
statement.