### PR TITLE
Use typed links in rustdoc

### DIFF
--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -38,8 +38,8 @@ impl EvalError {
 ///
 /// # Arguments
 ///
-/// __This version uses the [SimpleFileLoader](SimpleFileLoader.struct.html) implementation for
-/// the file loader__
+/// __This version uses the [`SimpleFileLoader`](crate::eval::simple::SimpleFileLoader)
+/// implementation for the file loader__
 ///
 /// * path: the name of the file being evaluated, for diagnostics
 /// * content: the content to evaluate
@@ -62,8 +62,8 @@ pub fn eval(
 /// Evaluate a file, mutate the environment accordingly, and return the value of the last
 /// statement, or a printable error.
 ///
-/// __This version uses the [SimpleFileLoader](SimpleFileLoader.struct.html) implementation for
-/// the file loader__
+/// __This version uses the [`SimpleFileLoader`](crate::eval::simple::SimpleFileLoader)
+/// implementation for the file loader__
 ///
 /// # Arguments
 ///

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -962,7 +962,7 @@ pub fn eval_def(
 /// * dialect: starlark syntax dialect
 /// * lexer: the custom lexer to use
 /// * env: the environment to mutate during the evaluation
-/// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
+/// * file_loader: the [`FileLoader`] to react to `load()` statements.
 #[allow(clippy::too_many_arguments)]
 pub fn eval_lexer<
     T1: Iterator<Item = LexerItem>,
@@ -996,7 +996,7 @@ pub fn eval_lexer<
 ///   More information about the difference can be found in [this module's
 ///   documentation](index.html#build_file).
 /// * env: the environment to mutate during the evaluation
-/// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
+/// * file_loader: the [`FileLoader`] to react to `load()` statements.
 pub fn eval<T: FileLoader + 'static>(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
@@ -1023,7 +1023,7 @@ pub fn eval<T: FileLoader + 'static>(
 ///   More information about the difference can be found in [this module's
 ///   documentation](index.html#build_file).
 /// * env: the environment to mutate during the evaluation
-/// * file_loader: the [FileLoader](trait.FileLoader.html) to react to `load()` statements.
+/// * file_loader: the [`FileLoader`] to react to `load()` statements.
 pub fn eval_file<T: FileLoader + 'static>(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -41,7 +41,7 @@ impl FileLoader for NoLoadFileLoader {
 ///
 /// # Arguments
 ///
-/// __This version uses the [NoLoadFileLoader](NoLoadFileLoader.struct.html) implementation for
+/// __This version uses the [`NoLoadFileLoader`] implementation for
 /// the file loader__
 ///
 /// * map: the codemap object used for diagnostics

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -72,7 +72,7 @@ impl FileLoader for SimpleFileLoader {
 ///
 /// # Arguments
 ///
-/// __This version uses the [SimpleFileLoader](SimpleFileLoader.struct.html) implementation for
+/// __This version uses the [`SimpleFileLoader`] implementation for
 /// the file loader__
 ///
 /// * map: the codemap object used for diagnostics
@@ -101,7 +101,7 @@ pub fn eval(
 
 /// Evaluate a file, mutate the environment accordingly and return the evaluated value.
 ///
-/// __This version uses the [SimpleFileLoader](SimpleFileLoader.struct.html) implementation for
+/// __This version uses the [`SimpleFileLoader`] implementation for
 /// the file loader__
 ///
 /// # Arguments

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -70,6 +70,9 @@
 //! * [list](values::list),
 //! * [tuple](values::tuple), and
 //! * [function](values::function).
+
+#![deny(intra_doc_link_resolution_failure)]
+
 pub mod environment;
 #[doc(hidden)]
 pub mod syntax;

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! # Defining a new type
 //!
-//! Defining a new Starlark type can be done by implenting the [TypedValue](trait.TypedValue.html)
+//! Defining a new Starlark type can be done by implenting the [`TypedValue`](crate::values::TypedValue)
 //! trait. All method of that trait are operation needed by Starlark interpreter to understand the
 //! type. Most of `TypedValue` methods are optional with default implementations returning error.
 //!
@@ -612,15 +612,13 @@ pub trait TypedValue: Sized + 'static {
 
     /// Compare `self` with `other`.
     ///
-    /// This method returns a result of type
-    /// [Ordering](https://doc.rust-lang.org/std/cmp/enum.Ordering.html).
+    /// This method returns a result of type [`Ordering`].
     ///
     /// `other` parameter is of type `Self` so it is safe to downcast it.
     ///
     /// Default implementation returns error.
     ///
-    /// __Note__: This does not use the
-    ///       (PartialOrd)[https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html] trait as
+    /// __Note__: This does not use the [`PartialOrd`] trait as
     ///       the trait needs to know the actual type of the value we compare.
     fn compare(&self, _other: &Self) -> Result<Ordering, ValueError> {
         Err(ValueError::OperationNotSupported {


### PR DESCRIPTION
Rustdoc allows safe links syntax, where link pointer is a type name
and not URL.

Also added crate level instruction

```
 #![deny(intra_doc_link_resolution_failure)]
```

which asserts that these links point to correct types.