### PR TITLE
Mute dyn Trait warnings

### DIFF
--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -102,7 +102,7 @@ struct EnvironmentContent {
 }
 
 // Newtype so that EnvironmentContent can derive Debug.
-struct SetConstructor((Option<Box<Fn(Vec<Value>) -> ValueResult>>));
+struct SetConstructor((Option<Box<dyn Fn(Vec<Value>) -> ValueResult>>));
 
 impl std::fmt::Debug for SetConstructor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -212,7 +212,7 @@ impl Environment {
     ///
     /// The `Value` returned by this function is expected to be a one-dimensional collection
     /// containing no duplicates.
-    pub fn with_set_constructor(&self, constructor: Box<Fn(Vec<Value>) -> ValueResult>) {
+    pub fn with_set_constructor(&self, constructor: Box<dyn Fn(Vec<Value>) -> ValueResult>) {
         self.env.borrow_mut().set_constructor = SetConstructor(Some(constructor));
     }
 

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -47,7 +47,7 @@ impl Set {
     pub fn compare<Return>(
         v1: &Value,
         v2: &Value,
-        f: &Fn(
+        f: &dyn Fn(
             &LinkedHashSet<HashedValue>,
             &LinkedHashSet<HashedValue>,
         ) -> Result<Return, ValueError>,
@@ -118,7 +118,9 @@ impl From<Set> for Value {
 impl TypedValue for Set {
     type Holder = Mutable<Set>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().map(|v| v.get_value().clone()))
     }
 
@@ -204,7 +206,7 @@ impl TypedValue for Set {
         )))
     }
 
-    fn iter(&self) -> Result<&TypedIterable, ValueError> {
+    fn iter(&self) -> Result<&dyn TypedIterable, ValueError> {
         Ok(self)
     }
 
@@ -248,7 +250,7 @@ impl TypedValue for Set {
 }
 
 impl TypedIterable for Set {
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().map(|v| v.get_value().clone()))
     }
 }

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -26,7 +26,9 @@ pub struct StarlarkStruct {
 impl TypedValue for StarlarkStruct {
     type Holder = Immutable<StarlarkStruct>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.fields.values().cloned())
     }
 

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -46,7 +46,9 @@ impl TypedValue for bool {
         Ok(self.to_int().unwrap() as u64)
     }
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(iter::empty())
     }
 

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -129,7 +129,9 @@ impl<T1: Into<Value> + Hash + Eq + Clone, T2: Into<Value> + Eq + Clone>
 impl TypedValue for Dictionary {
     type Holder = Mutable<Dictionary>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         // XXX: We cannot freeze the key because they are immutable in rust, is it important?
         Box::new(
             self.content
@@ -224,7 +226,7 @@ impl TypedValue for Dictionary {
 }
 
 impl TypedIterable for Dictionary {
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().map(|x| x.0.get_value().clone()))
     }
 }

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -352,7 +352,9 @@ fn to_str(function_type: &FunctionType, signature: &[FunctionParameter]) -> Stri
 impl TypedValue for Function {
     type Holder = Immutable<Function>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(iter::empty())
     }
 
@@ -466,7 +468,9 @@ impl TypedValue for Function {
 impl TypedValue for WrappedMethod {
     type Holder = Immutable<WrappedMethod>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(vec![self.method.clone(), self.self_obj.clone()].into_iter())
     }
 

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -156,7 +156,9 @@ impl TypedValue for i64 {
         })
     }
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(iter::empty())
     }
 

--- a/starlark/src/values/iter.rs
+++ b/starlark/src/values/iter.rs
@@ -20,27 +20,27 @@ use crate::values::Value;
 /// Type to be implemented by types which are iterable.
 pub trait TypedIterable: 'static {
     /// Make an iterator.
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a>;
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a>;
 }
 
 /// Iterable which contains borrowed reference to a sequence.
 pub struct RefIterable<'a> {
-    r: RefOrRef<'a, TypedIterable>,
+    r: RefOrRef<'a, dyn TypedIterable>,
 }
 
 impl<'a> RefIterable<'a> {
-    pub fn new(r: RefOrRef<'a, TypedIterable>) -> RefIterable<'a> {
+    pub fn new(r: RefOrRef<'a, dyn TypedIterable>) -> RefIterable<'a> {
         RefIterable { r }
     }
 
-    pub fn iter(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    pub fn iter(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         self.r.to_iter()
     }
 }
 
 impl<'a> IntoIterator for &'a RefIterable<'a> {
     type Item = Value;
-    type IntoIter = Box<Iterator<Item = Value> + 'a>;
+    type IntoIter = Box<dyn Iterator<Item = Value> + 'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -51,7 +51,7 @@ impl<'a> IntoIterator for &'a RefIterable<'a> {
 pub(crate) struct FakeTypedIterable;
 
 impl TypedIterable for FakeTypedIterable {
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         unreachable!()
     }
 }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -103,7 +103,9 @@ impl List {
 impl TypedValue for List {
     type Holder = Mutable<List>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().cloned())
     }
 
@@ -214,7 +216,7 @@ impl TypedValue for List {
         )))
     }
 
-    fn iter(&self) -> Result<&TypedIterable, ValueError> {
+    fn iter(&self) -> Result<&dyn TypedIterable, ValueError> {
         Ok(self)
     }
 
@@ -297,7 +299,7 @@ impl TypedValue for List {
 }
 
 impl TypedIterable for List {
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().cloned())
     }
 }

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -560,7 +560,8 @@ pub trait TypedValue: Sized + 'static {
     /// #
     /// # }
     /// ```
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a>;
+    fn values_for_descendant_check_and_freeze<'a>(&'a self)
+        -> Box<dyn Iterator<Item = Value> + 'a>;
 
     /// Return a string describing of self, as returned by the str() function.
     fn to_str(&self) -> String {
@@ -1387,7 +1388,7 @@ mod tests {
 
             fn values_for_descendant_check_and_freeze<'a>(
                 &'a self,
-            ) -> Box<Iterator<Item = Value> + 'a> {
+            ) -> Box<dyn Iterator<Item = Value> + 'a> {
                 Box::new(iter::empty())
             }
         }

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -37,7 +37,9 @@ impl TypedValue for NoneType {
         Ok(Ordering::Equal)
     }
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(iter::empty())
     }
 

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -27,7 +27,9 @@ use std::iter;
 impl TypedValue for String {
     type Holder = Immutable<String>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(iter::empty())
     }
 

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -262,7 +262,9 @@ impl<
 impl TypedValue for Tuple {
     type Holder = Immutable<Tuple>;
 
-    fn values_for_descendant_check_and_freeze<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn values_for_descendant_check_and_freeze<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Value> + 'a> {
         // Tuple are weird, immutable but with potentially mutable
         Box::new(self.content.iter().cloned())
     }
@@ -434,7 +436,7 @@ impl TypedValue for Tuple {
 }
 
 impl TypedIterable for Tuple {
-    fn to_iter<'a>(&'a self) -> Box<Iterator<Item = Value> + 'a> {
+    fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().cloned())
     }
 }


### PR DESCRIPTION
In latest nightly using trait without `dyn` keyword is a warning.