### PR TITLE
Freeze environment when child is created

### DIFF
--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -147,6 +147,7 @@ impl Environment {
 
     /// Create a new child environment for this environment
     pub fn child(&self, name: &str) -> Environment {
+        self.freeze();
         Environment {
             env: Rc::new(RefCell::new(EnvironmentContent {
                 name_: name.to_owned(),
@@ -182,7 +183,7 @@ impl Environment {
     }
 
     pub fn import_symbol(
-        &mut self,
+        &self,
         env: &Environment,
         symbol: &str,
         new_name: &str,


### PR DESCRIPTION
Function evaluation no longer creates an "environment".  Environment
is heavyweight object, while function only needs "locals".

This is a step towards fixing two issues:
* being able to share frozen environment between threads
* function should not be able to access parent (module) environment,
  if that the value is assigned later in the function

E. g. this code should fail:

```
x = 1
def f():
  print(x)
  x = 2
```