### PR TITLE
Fix unused mut warning

### DIFF
--- a/starlark/src/values/string/interpolation.rs
+++ b/starlark/src/values/string/interpolation.rs
@@ -310,7 +310,7 @@ impl ArgsFormat {
 
     pub fn format(self, other: Value) -> Result<String, ValueError> {
         let mut r = self.init;
-        let mut other_iter;
+        let other_iter;
         let mut arg_iter: Box<dyn Iterator<Item = Value>> = if self.positional_count > 1 {
             other_iter = Some(other.iter()?);
             other_iter.as_ref().unwrap().iter()


### PR DESCRIPTION
```
warning: variable does not need to be mutable
   --> starlark/src/values/string/interpolation.rs:313:13
    |
313 |         let mut other_iter;
    |             ----^^^^^^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: #[warn(unused_mut)] on by default
```