### PR TITLE
Store FunctionId instead of repr in the stack

### DIFF
--- a/starlark/src/eval/call_stack.rs
+++ b/starlark/src/eval/call_stack.rs
@@ -14,20 +14,21 @@
 //! Starlark call stack.
 
 use crate::values::error::ValueError;
+use crate::values::FunctionId;
 use std::cell::Cell;
 use std::fmt;
 
 /// Starlark call stack.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct CallStack {
-    stack: Vec<(String, String)>,
+    stack: Vec<(FunctionId, String)>,
 }
 
 impl CallStack {
     /// Push an element to the stack
-    pub fn push(&mut self, function_id: &str, call_descr: &str, file_name: &str, line: u32) {
+    pub fn push(&mut self, function_id: FunctionId, call_descr: &str, file_name: &str, line: u32) {
         self.stack.push((
-            function_id.to_owned(),
+            function_id,
             format!(
                 "call to {} at {}:{}",
                 call_descr,
@@ -38,8 +39,8 @@ impl CallStack {
     }
 
     /// Test if call stack contains a function with given id.
-    pub fn contains(&self, function_id: &str) -> bool {
-        self.stack.iter().any(|(n, _)| n == function_id)
+    pub fn contains(&self, function_id: FunctionId) -> bool {
+        self.stack.iter().any(|(n, _)| n == &function_id)
     }
 
     /// Print call stack as multiline string

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -453,14 +453,18 @@ fn eval_call(
         None
     };
     let f = eval_expr(e, context)?;
-    let fname = f.to_repr();
     let descr = f.to_str();
     let mut new_stack = context.call_stack.clone();
-    if context.call_stack.contains(&fname) {
-        Err(EvalException::Recursion(this.span, fname, new_stack))
+    if context.call_stack.contains(f.function_id()) {
+        Err(EvalException::Recursion(this.span, f.to_repr(), new_stack))
     } else {
         let loc = { context.map.lock().unwrap().look_up_pos(this.span.low()) };
-        new_stack.push(&fname, &descr, loc.file.name(), loc.position.line as u32);
+        new_stack.push(
+            f.function_id(),
+            &descr,
+            loc.file.name(),
+            loc.position.line as u32,
+        );
         t(
             eval_expr(e, context)?.call(
                 &new_stack,

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -474,6 +474,10 @@ impl TypedValue for WrappedMethod {
         Box::new(vec![self.method.clone(), self.self_obj.clone()].into_iter())
     }
 
+    fn function_id(&self) -> Option<FunctionId> {
+        Some(FunctionId(self.method.data_ptr()))
+    }
+
     fn to_str(&self) -> String {
         self.method.to_str()
     }


### PR DESCRIPTION
... to detect recursion. Should be a little faster.

Bench with this commit:

```
test bench_bubble_sort ... bench:     131,337 ns/iter (+/- 16,588)
test bench_empty       ... bench:       1,135 ns/iter (+/- 88)
```

Bench before:

```
test bench_bubble_sort ... bench:     160,681 ns/iter (+/- 15,151)
test bench_empty       ... bench:       1,164 ns/iter (+/- 137)
```