### PR TITLE
Store Value in CallStack

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -453,18 +453,11 @@ fn eval_call(
         None
     };
     let f = eval_expr(e, context)?;
-    let descr = f.to_str();
     let mut new_stack = context.call_stack.clone();
     if context.call_stack.contains(f.function_id()) {
         Err(EvalException::Recursion(this.span, f.to_repr(), new_stack))
     } else {
-        let loc = { context.map.lock().unwrap().look_up_pos(this.span.low()) };
-        new_stack.push(
-            f.function_id(),
-            &descr,
-            loc.file.name(),
-            loc.position.line as u32,
-        );
+        new_stack.push(f.clone(), context.map.clone(), this.span.low());
         t(
             eval_expr(e, context)?.call(
                 &new_stack,


### PR DESCRIPTION
... and do not initialize stack frame descriptions prematurely.

Before this commit:

```
test bench_bubble_sort ... bench:     134,255 ns/iter (+/- 16,066)
test bench_empty       ... bench:       1,170 ns/iter (+/- 135)
```

With this diff:

```
test bench_bubble_sort ... bench:     100,340 ns/iter (+/- 21,709)
test bench_empty       ... bench:       1,157 ns/iter (+/- 775)
```