### PR TITLE
Do not allocate memory for small values

### DIFF
--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -29,6 +29,11 @@ impl From<bool> for Value {
 impl TypedValue for bool {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "bool";
+
+    fn new_value(self) -> Value {
+        Value(ValueInner::Bool(ValueHolder::new(self)))
+    }
+
     fn to_repr(&self) -> String {
         if *self {
             "True".to_owned()

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -83,6 +83,11 @@ where
 impl TypedValue for i64 {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "int";
+
+    fn new_value(self) -> Value {
+        Value(ValueInner::Int(ValueHolder::new(self)))
+    }
+
     fn equals(&self, other: &i64) -> Result<bool, ValueError> {
         Ok(self == other)
     }

--- a/starlark/src/values/mutability.rs
+++ b/starlark/src/values/mutability.rs
@@ -82,7 +82,7 @@ pub trait RefCellOrImmutable {
 }
 
 /// Container for immutable data
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ImmutableCell<T>(T);
 
 impl<T> RefCellOrImmutable for RefCell<T> {
@@ -142,7 +142,7 @@ pub trait MutabilityCell: fmt::Debug {
     fn new() -> Self;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ImmutableMutability;
 #[derive(Debug)]
 pub struct MutableMutability(Cell<IterableMutability>);

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 use std::iter;
 
 /// Define the NoneType type
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NoneType {
     None,
 }
@@ -29,6 +29,10 @@ pub enum NoneType {
 impl TypedValue for NoneType {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "NoneType";
+
+    fn new_value(self) -> Value {
+        Value(ValueInner::None(ValueHolder::new(self)))
+    }
 
     fn equals(&self, _other: &NoneType) -> Result<bool, ValueError> {
         Ok(true)


### PR DESCRIPTION
With this commit:

```
test bench_bubble_sort ... bench:     103,163 ns/iter (+/- 12,778)
test bench_empty       ... bench:         979 ns/iter (+/- 95)
```

Before this commit:

```
test bench_bubble_sort ... bench:     130,804 ns/iter (+/- 26,971)
test bench_empty       ... bench:       1,150 ns/iter (+/- 98)
```