### PR TITLE
Generate multiple rust unit tests for each .sky test

### DIFF
--- a/starlark-test/tests/rust-testcases/josharian_fuzzing.sky
+++ b/starlark-test/tests/rust-testcases/josharian_fuzzing.sky
@@ -13,6 +13,9 @@ assert_eq(0in[1,2,3], False)
 assert_eq('a'.find('', 1, 0), -1)
 assert_eq('a'.rfind('', 1, 0), -1)
 'a'.index('', 1, 0)  ### [UF00]
+---
+assert_eq('a'.find('', 1, 0), -1)
+assert_eq('a'.rfind('', 1, 0), -1)
 'a'.rindex('', 1, 0)  ### [UF00]
 ---
 # https://github.com/google/starlark-rust/issues/64: alphabetize dir entries


### PR DESCRIPTION
Debugging interpreter crashes in tests is somewhat inconvenient:
when tests panics, there's only a stack trace, but no information
which test failed.

This commit fixes the issue to some degeree: now each test (separated
by `---`) is now a separate Rust test case.

Generated test code now looks like this:
https://gist.github.com/stepancheg/c68a83f8a0e5309ad8cec8ad4283658a