### PR TITLE
Split Def from Function

### DIFF
--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -204,7 +204,7 @@ macro_rules! starlark_signatures {
             #[allow(unused_mut)]
             let mut signature = Vec::new();
             starlark_signature!(signature $($signature)*);
-            $env.set(name, $crate::values::function::Function::new(name.to_owned(), &$name, signature)).unwrap();
+            $env.set(name, $crate::values::function::Function::new(name.to_owned(), $name, signature)).unwrap();
         }
         $(starlark_signatures!{ $env,
             $($rest)+
@@ -217,7 +217,7 @@ macro_rules! starlark_signatures {
             let mut signature = Vec::new();
             starlark_signature!(signature $($signature)*);
             $env.add_type_value(stringify!($ty), name,
-                $crate::values::function::Function::new(name.to_owned(), &$name, signature));
+                $crate::values::function::Function::new(name.to_owned(), $name, signature));
         }
         $(starlark_signatures!{ $env,
             $($rest)+


### PR DESCRIPTION
* `Function` how holds a function pointer (and not a closure)
* `Def` is introduced which stores `def`

```
cargo build --bins
```

With this commit: `11792240`.

Before this commit: `12022256`.

So debug binary size is 2% smaller now (because we no longer
instantiate a closure for each native function), but my main
motivation is to split native/def evaluation paths to allow certain
def-specific optimizations and fixes.