### PR TITLE
Simplify "for" statement grammar a little

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -894,17 +894,11 @@ fn eval_stmt(stmt: &AstStatement, context: &mut EvaluationContext) -> EvalResult
                 eval_stmt(st2, context)
             }
         }
-        Statement::For(
-            AstClause {
-                ref span,
-                node: Clause::For(ref e1, ref e2),
-            },
-            ref st,
-        ) => {
+        Statement::For(ref e1, ref e2, ref st) => {
             let mut iterable = eval_expr(e2, context)?;
             let mut result = Ok(Value::new(NoneType::None));
             iterable.freeze_for_iteration();
-            for v in &t(iterable.iter(), span)? {
+            for v in &t(iterable.iter(), &e2.span)? {
                 set_expr(e1, context, v)?;
                 match eval_stmt(st, context) {
                     Err(EvalException::Break(..)) => break,
@@ -919,13 +913,6 @@ fn eval_stmt(stmt: &AstStatement, context: &mut EvaluationContext) -> EvalResult
             iterable.unfreeze_for_iteration();
             result
         }
-        Statement::For(
-            AstClause {
-                span: ref _s,
-                ref node,
-            },
-            ..
-        ) => panic!("The parser returned an invalid for clause: {:?}", node),
         Statement::Def(ref name, ref params, ref stmts) => {
             let mut p = Vec::new();
             for x in params.iter() {

--- a/starlark/src/syntax/ast.rs
+++ b/starlark/src/syntax/ast.rs
@@ -243,7 +243,7 @@ pub enum Statement {
     Statements(Vec<AstStatement>),
     If(AstExpr, AstStatement),
     IfElse(AstExpr, AstStatement, AstStatement),
-    For(AstClause, AstStatement),
+    For(AstExpr, AstExpr, AstStatement),
     Def(AstString, Vec<AstParameter>, AstStatement),
     Load(AstString, Vec<(AstString, AstString)>),
 }
@@ -570,8 +570,8 @@ impl Statement {
                 writeln!(f, "{}else:", tab)?;
                 suite2.node.fmt_with_tab(f, tab + "  ")
             }
-            Statement::For(ref clause, ref suite) => {
-                writeln!(f, "{}for {}:", tab, clause.node)?;
+            Statement::For(ref bind, ref coll, ref suite) => {
+                writeln!(f, "{}for {} in {}:", tab, bind.node, coll.node)?;
                 suite.node.fmt_with_tab(f, tab + "  ")
             }
             Statement::Def(ref name, ref params, ref suite) => {

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -101,8 +101,8 @@ ElseStmt: AstStatement = {
 };
 
 ForStmt: AstStatement = ASTS<ForStmt_>;
-ForStmt_: Statement = <c:ForInClause> ":" <s:Suite>
-    => Statement::For(c, s);
+ForStmt_: Statement = "for" <e:ExprList> "in" <c:OrTest> ":" <s:Suite>
+    => Statement::For(e, c, s);
 
 SimpleStmt<S>: AstStatement =
     <l:@L> <e:S> <v:(";" <S>)*> ";"? <r:@R> "\n" => {


### PR DESCRIPTION
The only valid clause is "in", ensure it at type level.