### PR TITLE
Avoid unnecessary name allocation for nested contexts

### DIFF
--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -150,7 +150,7 @@ struct WrappedMethod {
 }
 
 struct Def {
-    name: String,
+    _name: String,
     signature: Vec<FunctionParameter>,
     function_type: FunctionType,
     stmts: AstStatement,
@@ -258,7 +258,7 @@ impl Function {
         // and optimizations in the future.
         Value::new(Def {
             function_type: FunctionType::Def(name.clone(), module),
-            name,
+            _name: name,
             signature,
             stmts,
             captured_env: env,
@@ -539,7 +539,6 @@ impl TypedValue for Def {
         )?;
 
         eval_def(
-            &self.name,
             call_stack,
             &self.signature,
             &self.stmts,


### PR DESCRIPTION
Name might be convenient for debugging but it has too high performance
overhead.

Before this commit:

```
test bench_empty       ... bench:         947 ns/iter (+/- 90)
```

After this commit:

```
test bench_empty       ... bench:         586 ns/iter (+/- 61)
```