### PR TITLE
Local variable referenced before assignment

### DIFF
--- a/starlark-test/tests/go-testcases/assign.sky
+++ b/starlark-test/tests/go-testcases/assign.sky
@@ -138,13 +138,11 @@ def use_before_def():
 use_before_def() ### Variable was not found
 
 ---
-# What is that test? Why should it fails?
-
 x = [1]
 x.extend([2]) # ok
 
 def f():
-   x += [4] # # # Variable was not found?
+   x += [4]    ### Local variable referenced before assignment
 
 f()
 

--- a/starlark-test/tests/go-testcases/list.sky
+++ b/starlark-test/tests/go-testcases/list.sky
@@ -123,12 +123,11 @@ def list_extend():
 list_extend()
 
 ---
-# TODO: This is a weird behavior += will bind locally but read globally, is it unwanted?
 # Unlike list.extend(iterable), list += iterable makes its LHS name local.
 a_list = []
 def f4():
-  a_list += [1] # binding use => a_list is a local var
-f4()  # # # Variable not found
+  a_list += [1]   ###   Local variable referenced before assignment
+f4()
 ---
 # list += <not iterable>
 def f5():

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -27,6 +27,7 @@ use std::rc::Rc;
 // CM prefix = Critical Module
 const FROZEN_ENV_ERROR_CODE: &str = "CM00";
 const NOT_FOUND_ERROR_CODE: &str = "CM01";
+const LOCAL_VARIABLE_REFERENCED_BEFORE_ASSIGNMENT: &str = "CM03";
 pub(crate) const LOAD_NOT_SUPPORTED_ERROR_CODE: &str = "CM02";
 const CANNOT_IMPORT_ERROR_CODE: &str = "CE02";
 
@@ -37,6 +38,7 @@ pub enum EnvironmentError {
     TryingToMutateFrozenEnvironment,
     /// Variables was no found.
     VariableNotFound(String),
+    LocalVariableReferencedBeforeAssignment(String),
     /// Cannot import private symbol, i.e. underscore prefixed
     CannotImportPrivateSymbol(String),
 }
@@ -48,12 +50,18 @@ impl Into<RuntimeError> for EnvironmentError {
                 EnvironmentError::TryingToMutateFrozenEnvironment => FROZEN_ENV_ERROR_CODE,
                 EnvironmentError::VariableNotFound(..) => NOT_FOUND_ERROR_CODE,
                 EnvironmentError::CannotImportPrivateSymbol(..) => CANNOT_IMPORT_ERROR_CODE,
+                EnvironmentError::LocalVariableReferencedBeforeAssignment(..) => {
+                    LOCAL_VARIABLE_REFERENCED_BEFORE_ASSIGNMENT
+                }
             },
             label: match self {
                 EnvironmentError::TryingToMutateFrozenEnvironment => {
                     "This value belong to a frozen environment".to_owned()
                 }
                 EnvironmentError::VariableNotFound(..) => "Variable was not found".to_owned(),
+                EnvironmentError::LocalVariableReferencedBeforeAssignment(..) => {
+                    "Local variable referenced before assignment".to_owned()
+                }
                 EnvironmentError::CannotImportPrivateSymbol(ref s) => {
                     format!("Symbol '{}' is private", s)
                 }
@@ -63,6 +71,9 @@ impl Into<RuntimeError> for EnvironmentError {
                     "Cannot mutate a frozen environment".to_owned()
                 }
                 EnvironmentError::VariableNotFound(s) => format!("Variable '{}' not found", s),
+                EnvironmentError::LocalVariableReferencedBeforeAssignment(ref s) => {
+                    format!("Local variable '{}' referenced before assignment", s)
+                }
                 EnvironmentError::CannotImportPrivateSymbol(s) => {
                     format!("Cannot import private symbol '{}'", s)
                 }

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -17,13 +17,14 @@
 use crate::environment::{Environment, TypeValues};
 use crate::eval::call_stack::CallStack;
 use crate::eval::{eval_stmt, EvalException, EvaluationContext, EvaluationContextEnvironment};
-use crate::syntax::ast::AstStatement;
+use crate::syntax::ast::{AstExpr, AstStatement, Expr, Statement};
 use crate::values::error::ValueError;
 use crate::values::function::{FunctionArg, FunctionParameter, FunctionType};
 use crate::values::none::NoneType;
 use crate::values::{function, Immutable, TypedValue, Value, ValueResult};
 use codemap::CodeMap;
 use linked_hash_map::LinkedHashMap;
+use std::collections::HashSet;
 use std::iter;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -35,6 +36,7 @@ pub(crate) struct Def {
     stmts: AstStatement,
     captured_env: Environment,
     map: Arc<Mutex<CodeMap>>,
+    local_names: HashSet<String>,
 }
 
 impl Def {
@@ -46,6 +48,20 @@ impl Def {
         map: Arc<Mutex<CodeMap>>,
         env: Environment,
     ) -> Value {
+        let mut local_names = HashSet::new();
+
+        for p in &signature {
+            local_names.insert(match p {
+                FunctionParameter::Normal(ref n)
+                | FunctionParameter::ArgsArray(ref n)
+                | FunctionParameter::KWArgsDict(ref n)
+                | FunctionParameter::WithDefaultValue(ref n, ..) => n.to_owned(),
+                FunctionParameter::Optional(..) => unreachable!(),
+            });
+        }
+
+        Def::collect_locals(&stmts, &mut local_names);
+
         // This can be implemented by delegating to `Function::new`,
         // but having a separate type allows slight more efficient implementation
         // and optimizations in the future.
@@ -55,7 +71,53 @@ impl Def {
             stmts,
             captured_env: env,
             map,
+            local_names,
         })
+    }
+
+    fn collect_locals(stmt: &AstStatement, local_names: &mut HashSet<String>) {
+        match stmt.node {
+            Statement::Assign(ref dest, ..) => {
+                Def::collect_locals_from_assign_expr(dest, local_names);
+            }
+            Statement::For(ref dest, _, ref body) => {
+                Def::collect_locals_from_assign_expr(dest, local_names);
+                Def::collect_locals(body, local_names);
+            }
+            Statement::Statements(ref stmts) => {
+                for stmt in stmts {
+                    Def::collect_locals(stmt, local_names);
+                }
+            }
+            Statement::If(_, ref then_block) => {
+                Def::collect_locals(then_block, local_names);
+            }
+            Statement::IfElse(_, ref then_block, ref else_block) => {
+                Def::collect_locals(then_block, local_names);
+                Def::collect_locals(else_block, local_names);
+            }
+            Statement::Break
+            | Statement::Continue
+            | Statement::Pass
+            | Statement::Return(..)
+            | Statement::Expression(..)
+            | Statement::Load(..)
+            | Statement::Def(..) => {}
+        }
+    }
+
+    fn collect_locals_from_assign_expr(expr: &AstExpr, local_names: &mut HashSet<String>) {
+        match expr.node {
+            Expr::Tuple(ref exprs) | Expr::List(ref exprs) => {
+                for expr in exprs {
+                    Def::collect_locals_from_assign_expr(expr, local_names);
+                }
+            }
+            Expr::Identifier(ref ident) => {
+                local_names.insert(ident.node.clone());
+            }
+            _ => {}
+        }
     }
 
     fn eval(
@@ -69,6 +131,7 @@ impl Def {
             call_stack: call_stack.to_owned(),
             env: Rc::new(EvaluationContextEnvironment::Function(
                 self.captured_env.clone(),
+                self.local_names.clone(),
                 Default::default(),
             )),
             type_values,

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -38,7 +38,7 @@ use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use linked_hash_map::LinkedHashMap;
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -208,7 +208,11 @@ pub(crate) enum EvaluationContextEnvironment {
     /// Module-level
     Module(Environment, Rc<dyn FileLoader>),
     /// Function-level
-    Function(Environment, RefCell<HashMap<String, Value>>),
+    Function(
+        Environment,
+        HashSet<String>,
+        RefCell<HashMap<String, Value>>,
+    ),
     /// Scope inside function, e. g. list comprenension
     Nested(
         Rc<EvaluationContextEnvironment>,
@@ -242,10 +246,21 @@ impl EvaluationContextEnvironment {
     fn get(&self, name: &str) -> Result<Value, EnvironmentError> {
         match self {
             EvaluationContextEnvironment::Module(env, ..) => env.get(name),
-            EvaluationContextEnvironment::Function(env, locals) => {
+            EvaluationContextEnvironment::Function(env, local_names, locals) => {
                 match locals.borrow().get(name).cloned() {
-                    Some(v) => Ok(v),
-                    None => env.get(name),
+                    Some(v) => {
+                        debug_assert!(local_names.contains(name));
+                        Ok(v)
+                    }
+                    None => {
+                        if local_names.contains(name) {
+                            Err(EnvironmentError::LocalVariableReferencedBeforeAssignment(
+                                name.to_owned(),
+                            ))
+                        } else {
+                            env.get(name)
+                        }
+                    }
                 }
             }
             EvaluationContextEnvironment::Nested(parent, locals) => {
@@ -260,9 +275,12 @@ impl EvaluationContextEnvironment {
     fn set(&self, name: &str, value: Value) -> Result<(), EnvironmentError> {
         match self {
             EvaluationContextEnvironment::Module(env, ..) => env.set(name, value),
-            EvaluationContextEnvironment::Function(_, locals)
-            | EvaluationContextEnvironment::Nested(_, locals) => {
-                // TODO: check that local slot was previously allocated
+            EvaluationContextEnvironment::Nested(_, locals) => {
+                locals.borrow_mut().insert(name.to_owned(), value);
+                Ok(())
+            }
+            EvaluationContextEnvironment::Function(_, local_names, locals) => {
+                debug_assert!(local_names.contains(name));
                 locals.borrow_mut().insert(name.to_owned(), value);
                 Ok(())
             }


### PR DESCRIPTION
... should be an error.

From the [spec](https://git.io/fjPT4):

> If name is bound anywhere within a block, all uses of the name within
> the block are treated as references to that binding, even uses that
> appear before the binding.

It is not absolutely clear that explanation that this example should
fail:

```
x = 1
def foo():
    print(x)
    x = 1
```

However, both Python and Starlark Go fail with this example.