### PR TITLE
Store function locals in slots, not in hash map

### DIFF
--- a/starlark/src/syntax/ast.rs
+++ b/starlark/src/syntax/ast.rs
@@ -112,6 +112,8 @@ pub enum Expr {
     ArrayIndirection(AstExpr, AstExpr),
     Slice(AstExpr, Option<AstExpr>, Option<AstExpr>, Option<AstExpr>),
     Identifier(AstString),
+    // local variable index
+    Slot(usize, AstString),
     IntLiteral(AstInt),
     StringLiteral(AstString),
     Not(AstExpr),
@@ -535,7 +537,7 @@ impl Display for Expr {
                 }
                 Ok(())
             }
-            Expr::Identifier(ref s) => s.node.fmt(f),
+            Expr::Identifier(ref s) | Expr::Slot(_, ref s) => s.node.fmt(f),
             Expr::IntLiteral(ref i) => i.node.fmt(f),
             Expr::Not(ref e) => write!(f, "(not {})", e.node),
             Expr::Minus(ref e) => write!(f, "-{}", e.node),


### PR DESCRIPTION
Before this commit:

```
test bench_bubble_sort ... bench:      70,418 ns/iter (+/- 8,480)
```

With this commit:

```
test bench_bubble_sort ... bench:      57,370 ns/iter (+/- 6,832)
```

Similar optimization can be eventually done for global variables
and for function nested variables.