### PR TITLE
Avoid allocating new vector when creating a Tuple

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -587,7 +587,7 @@ fn eval_transformed<'a>(transformed: &TransformedExpr, context: &EvaluationConte
             for i in v {
                 r.push(eval_transformed(i, context)?);
             }
-            Ok(Value::new(tuple::Tuple::new(r.as_slice())))
+            Ok(Value::new(tuple::Tuple::new(r)))
         }
         TransformedExpr::List(ref v, ..) => {
             let mut r = Vec::with_capacity(v.len());
@@ -661,7 +661,7 @@ fn eval_expr(expr: &AstExpr, context: &EvaluationContext) -> EvalResult {
     match expr.node {
         Expr::Tuple(ref v) => {
             let r = eval_vector!(v, context);
-            Ok(Value::new(tuple::Tuple::new(r.as_slice())))
+            Ok(Value::new(tuple::Tuple::new(r)))
         }
         Expr::Dot(ref e, ref s) => eval_dot(expr, e, s, context),
         Expr::Call(ref e, ref pos, ref named, ref args, ref kwargs) => {

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -740,7 +740,7 @@ starlark_module! {global_functions =>
                 idx += step;
             }
         }
-        Ok(Value::new(tuple::Tuple::new(r.as_slice())))
+        Ok(Value::new(tuple::Tuple::new(r)))
     }
 
     /// [repr](
@@ -891,7 +891,7 @@ starlark_module! {global_functions =>
                 l.push(x.clone())
             }
         }
-        Ok(Value::new(tuple::Tuple::new(l.as_slice())))
+        Ok(Value::new(tuple::Tuple::new(l)))
     }
 
     /// [type](

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -61,14 +61,8 @@ pub(crate) fn slice_vector<'a, I: Iterator<Item = &'a Value>>(
 }
 
 impl Tuple {
-    pub fn new(values: &[Value]) -> Tuple {
-        let mut result = Tuple {
-            content: Vec::new(),
-        };
-        for x in values.iter() {
-            result.content.push(x.clone());
-        }
-        result
+    pub fn new(values: Vec<Value>) -> Tuple {
+        Tuple { content: values }
     }
 }
 
@@ -362,7 +356,7 @@ impl TypedValue for Tuple {
     ) -> ValueResult {
         let (start, stop, stride) =
             Value::convert_slice_indices(self.length()?, start, stop, stride)?;
-        Ok(Value::new(Tuple::new(&slice_vector(
+        Ok(Value::new(Tuple::new(slice_vector(
             start,
             stop,
             stride,


### PR DESCRIPTION
Before this commit:

```
test bench_bubble_sort ... bench:      70,733 ns/iter (+/- 7,037)
```

With this commit:

```
test bench_bubble_sort ... bench:      65,081 ns/iter (+/- 7,969)
```

Speed up is because of many calls to `range` in the benchmark.

Note we should probably eventally make `range` result a builtin object.