### PR TITLE
Make `range` type a builtin

### DIFF
--- a/starlark-test/tests/go-testcases/builtins.sky
+++ b/starlark-test/tests/go-testcases/builtins.sky
@@ -78,10 +78,13 @@ assert_eq(dict({1:2, 3:4}), {1: 2, 3: 4})
 assert_eq(dict({1:2, 3:4}.items()), {1: 2, 3: 4})
 
 # range
-assert_eq("tuple", type(range(10)))
-assert_eq("(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)", str(range(0, 10, 1)))
-assert_eq("(1, 2, 3, 4, 5, 6, 7, 8, 9)", str(range(1, 10)))
-assert_eq("()", str(range(0, 10, -1)))
+assert_eq("range", type(range(10)))
+assert_eq("range(10)", str(range(0, 10, 1)))
+assert_eq("range(1, 10)", str(range(1, 10)))
+assert_eq(range(0, 5, 10), range(0, 5, 11))
+assert_eq("range(0, 10, -1)", str(range(0, 10, -1)))
+---
+{range(10): 10}  ###  CV04
 ---
 assert_(bool(range(1, 2)))
 assert_(not(range(2, 1))) # an empty range is false
@@ -97,17 +100,25 @@ assert_eq(list(range(10, 2, -3)), [10, 7, 4])
 assert_eq(list(range(-2, -10, -3)), [-2, -5, -8])
 assert_eq(list(range(-10, -2, 3)), [-10, -7, -4])
 assert_eq(list(range(10, 2, -1)), [10, 9, 8, 7, 6, 5, 4, 3])
----
-# TODO
-# range(3000000000)  # 3000000000 out of range # signed 32-bit values only
----
+assert_eq(list(range(5)[1:]), [1, 2, 3, 4])
+assert_eq(len(range(5)[1:]), 4)
+assert_eq(list(range(5)[:2]), [0, 1])
+assert_eq(list(range(10)[1:]), [1, 2, 3, 4, 5, 6, 7, 8, 9])
+assert_eq(list(range(10)[1:9:2]), [1, 3, 5, 7])
+assert_eq(list(range(10)[1:10:2]), [1, 3, 5, 7, 9])
+assert_eq(list(range(10)[1:11:2]), [1, 3, 5, 7, 9])
+assert_eq(list(range(10)[::-2]), [9, 7, 5, 3, 1])
+assert_eq(list(range(0, 10, 2)[::2]), [0, 4, 8])
+assert_eq(list(range(0, 10, 2)[::-2]), [8, 4, 0])
+# Works fine in Starlark Rust
+# assert.fails(lambda: range(3000000000), "3000000000 out of range") # signed 32-bit values only
+assert_eq(len(range(0x7fffffff)), 0x7fffffff) # O(1)
 # Two ranges compare equal if they denote the same sequence:
 assert_eq(range(0), range(2, 1, 3))       # []
 assert_eq(range(0, 3, 2), range(0, 4, 2)) # [0, 2]
 assert_(range(1, 10) != range(2, 10))
----
-assert_(range(0) < range(1))
----
+# Should not be comparable
+# assert.fails(lambda: range(0) < range(0), "range < range not implemented")
 # <number> in <range>
 assert_(1 in range(3))
 ---
@@ -115,7 +126,8 @@ assert_(True not in range(3))  # The go implementation does not support that but
 ---
 assert_("one" not in range(10))
 ---
-assert_(4 not in range(4))
+range(0, 0, 2)[:][0]   ### Index out of bound
+---
 
 # list
 assert_eq(sorted(list({"a": 1, "b": 2})), ['a', 'b'])

--- a/starlark/src/values/error.rs
+++ b/starlark/src/values/error.rs
@@ -253,6 +253,7 @@ impl PartialEq for ValueError {
                 &ValueError::OperationNotSupported { op: ref y, .. },
             ) if x == y => true,
             (&ValueError::IndexOutOfBound(x), &ValueError::IndexOutOfBound(y)) if x == y => true,
+            (&ValueError::IntegerOverflow, &ValueError::IntegerOverflow) => true,
             _ => false,
         }
     }

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1264,7 +1264,11 @@ impl dyn ValueHolderDyn {
     pub fn convert_index(&self, len: i64) -> Result<i64, ValueError> {
         match self.to_int() {
             Ok(x) => {
-                let i = if x < 0 { len + x } else { x };
+                let i = if x < 0 {
+                    len.checked_add(x).ok_or(ValueError::IntegerOverflow)?
+                } else {
+                    x
+                };
                 if i < 0 || i >= len {
                     Err(ValueError::IndexOutOfBound(i))
                 } else {
@@ -1385,6 +1389,7 @@ pub mod iter;
 pub mod list;
 pub mod mutability;
 pub mod none;
+pub mod range;
 pub mod string;
 pub mod tuple;
 

--- a/starlark/src/values/range.rs
+++ b/starlark/src/values/range.rs
@@ -1,0 +1,278 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `range()` builtin implementation
+
+use crate::values::iter::TypedIterable;
+use crate::values::{Immutable, TypedValue, Value, ValueError};
+use std::num::NonZeroI64;
+use std::{iter, mem};
+
+/// Representation of `range()` type.
+#[derive(Clone, Debug)]
+pub struct Range {
+    start: i64,
+    stop: i64,
+    step: NonZeroI64,
+}
+
+impl Range {
+    pub fn new(start: i64, stop: i64, step: NonZeroI64) -> Range {
+        Range { start, stop, step }
+    }
+}
+
+/// Implementation of iterator over range.
+struct RangeIterator(Range);
+
+impl Iterator for RangeIterator {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        if !self.0.to_bool() {
+            return None;
+        }
+
+        let new_start = self.0.start.saturating_add(self.0.step.get());
+        Some(Value::new(mem::replace(&mut self.0.start, new_start)))
+    }
+}
+
+impl TypedValue for Range {
+    const TYPE: &'static str = "range";
+
+    fn to_str(&self) -> String {
+        self.to_repr()
+    }
+
+    fn to_repr(&self) -> String {
+        if self.step.get() != 1 {
+            format!("range({}, {}, {})", self.start, self.stop, self.step)
+        } else if self.start != 0 {
+            format!("range({}, {})", self.start, self.stop)
+        } else {
+            format!("range({})", self.stop)
+        }
+    }
+
+    fn to_bool(&self) -> bool {
+        (self.start < self.stop && self.step.get() > 0)
+            || (self.start > self.stop && self.step.get() < 0)
+    }
+
+    fn length(&self) -> Result<i64, ValueError> {
+        if self.start == self.stop {
+            return Ok(0);
+        }
+
+        // If step is into opposite direction of stop, then length is zero.
+        if (self.stop >= self.start) != (self.step.get() > 0) {
+            return Ok(0);
+        }
+
+        // Convert range and step to `u64`
+        let (dist, step) = if self.step.get() >= 0 {
+            (
+                self.stop.wrapping_sub(self.start) as u64,
+                self.step.get() as u64,
+            )
+        } else {
+            (
+                self.start.wrapping_sub(self.stop) as u64,
+                self.step.get().wrapping_neg() as u64,
+            )
+        };
+        let i = ((dist - 1) / step + 1) as i64;
+        if i >= 0 {
+            Ok(i)
+        } else {
+            Err(ValueError::IntegerOverflow)
+        }
+    }
+
+    fn at(&self, index: Value) -> Result<Value, ValueError> {
+        let index = index.convert_index(self.length()?)?;
+        // Must not overflow if `length` is computed correctly
+        Ok(Value::new(self.start + self.step.get() * index))
+    }
+
+    fn equals(&self, other: &Range) -> Result<bool, ValueError> {
+        let self_length = self.length()?;
+        let other_length = other.length()?;
+        if self_length == 0 || other_length == 0 {
+            return Ok(self_length == other_length);
+        }
+        if self.start != other.start {
+            return Ok(false);
+        }
+        if self_length == 1 || other_length == 1 {
+            return Ok(self_length == other_length);
+        }
+        debug_assert!(self_length > 1);
+        debug_assert!(other_length > 1);
+        if self.step.get() == other.step.get() {
+            return Ok(self_length == other_length);
+        } else {
+            return Ok(false);
+        }
+    }
+
+    fn slice(
+        &self,
+        start: Option<Value>,
+        stop: Option<Value>,
+        stride: Option<Value>,
+    ) -> Result<Value, ValueError> {
+        let (start, stop, step) =
+            Value::convert_slice_indices(self.length()?, start, stop, stride)?;
+        return Ok(Value::new(Range {
+            start: self
+                .start
+                .checked_add(
+                    start
+                        .checked_mul(self.step.get())
+                        .ok_or(ValueError::IntegerOverflow)?,
+                )
+                .ok_or(ValueError::IntegerOverflow)?,
+            stop: self
+                .start
+                .checked_add(
+                    stop.checked_mul(self.step.get())
+                        .ok_or(ValueError::IntegerOverflow)?,
+                )
+                .ok_or(ValueError::IntegerOverflow)?,
+            step: NonZeroI64::new(
+                step.checked_mul(self.step.get())
+                    .ok_or(ValueError::IntegerOverflow)?,
+            )
+            .unwrap(),
+        }));
+    }
+
+    fn iter(&self) -> Result<&dyn TypedIterable, ValueError> {
+        Ok(self)
+    }
+
+    fn is_in(&self, other: &Value) -> Result<bool, ValueError> {
+        let other = match other.downcast_ref::<i64>() {
+            Some(other) => *other,
+            None => {
+                // Go implementation errors here,
+                // Python3 returns `False`.
+                // ```
+                // "a" in range(3)
+                // ```
+                return Ok(false);
+            }
+        };
+        if !self.to_bool() {
+            return Ok(false);
+        }
+        if self.start == other {
+            return Ok(true);
+        }
+        if self.step.get() > 0 {
+            if other < self.start || other >= self.stop {
+                return Ok(false);
+            }
+            Ok((other.wrapping_sub(self.start) as u64) % (self.step.get() as u64) == 0)
+        } else {
+            if other > self.start || other <= self.stop {
+                return Ok(false);
+            }
+            Ok(
+                (self.start.wrapping_sub(other) as u64) % (self.step.get().wrapping_neg() as u64)
+                    == 0,
+            )
+        }
+    }
+
+    type Holder = Immutable<Range>;
+
+    fn values_for_descendant_check_and_freeze(&self) -> Box<dyn Iterator<Item = Value>> {
+        Box::new(iter::empty())
+    }
+}
+
+/// For tests
+impl PartialEq for Range {
+    fn eq(&self, other: &Range) -> bool {
+        self.equals(other).unwrap()
+    }
+}
+
+impl TypedIterable for Range {
+    fn to_iter(&self) -> Box<dyn Iterator<Item = Value>> {
+        Box::new(RangeIterator(self.clone()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::values::range::Range;
+    use crate::values::{TypedValue, ValueError};
+    use std::i64;
+    use std::num::NonZeroI64;
+
+    fn range(start: i64, stop: i64, range: i64) -> Range {
+        Range {
+            start,
+            stop,
+            step: NonZeroI64::new(range).unwrap(),
+        }
+    }
+
+    fn range_start_stop(start: i64, stop: i64) -> Range {
+        range(start, stop, 1)
+    }
+
+    fn range_stop(stop: i64) -> Range {
+        range_start_stop(0, stop)
+    }
+
+    #[test]
+    fn length_stop() {
+        assert_eq!(Ok(0), range_stop(0).length());
+        assert_eq!(Ok(17), range_stop(17).length());
+    }
+
+    #[test]
+    fn length_start_stop() {
+        assert_eq!(Ok(20), range_start_stop(10, 30).length());
+        assert_eq!(Ok(0), range_start_stop(10, -30).length());
+        assert_eq!(
+            Ok(i64::max_value()),
+            range_start_stop(0, i64::max_value()).length()
+        );
+        assert_eq!(
+            Err(ValueError::IntegerOverflow),
+            range_start_stop(-1, i64::max_value()).length()
+        );
+    }
+
+    #[test]
+    fn length_start_stop_step() {
+        assert_eq!(Ok(5), range(0, 10, 2).length());
+        assert_eq!(Ok(5), range(0, 9, 2).length());
+        assert_eq!(Ok(0), range(0, 10, -2).length());
+        assert_eq!(Ok(5), range(10, 0, -2).length());
+        assert_eq!(Ok(5), range(9, 0, -2).length());
+        assert_eq!(Ok(1), range(4, 14, 10).length());
+    }
+
+    #[test]
+    fn eq() {
+        assert_eq!(range_stop(0), range(2, 1, 3));
+    }
+}

--- a/starlark/tests/rust-testcases/range.sky
+++ b/starlark/tests/rust-testcases/range.sky
@@ -1,0 +1,25 @@
+# Range tests
+
+# Content matters, not how range is created
+assert_eq(range(1), range(0, -1, -1))
+
+assert_eq(list(range(10)), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+assert_eq(list(range(3, 10)), [3, 4, 5, 6, 7, 8, 9])
+assert_eq(list(range(3, 10, 2)), [3, 5, 7, 9])
+assert_eq(list(range(10, 3, -2)), [10, 8, 6, 4])
+
+def f():
+    # Largest possible range, can create, can't really do much with it
+    r = range(-9223372036854775807-1, 9223372036854775807)
+    l = []
+    for x in r:
+        l += [x]
+        if len(l) == 3:
+            break
+    assert_eq([-9223372036854775807-1, -9223372036854775807, -9223372036854775807+1], l)
+f()
+
+---
+len(range(-9223372036854775807-1, 9223372036854775807))   ###   Integer overflow
+---
+assert_eq(9223372036854775807, len(range(-9223372036854775807, 9223372036854775807, 2)))


### PR DESCRIPTION
```
len(range(1000000000))
```

no longer crashes the interpreter. Also the benchmark is about 5%
faster now.