### PR TITLE
Compute `def` local slot indices before evaluation.

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -973,9 +973,9 @@ fn eval_stmt(stmt: &AstStatement, context: &EvaluationContext) -> EvalResult {
             iterable.unfreeze_for_iteration();
             result
         }
-        Statement::Def(ref name, ref params, ref stmts) => {
+        Statement::DefCompiled(ref stmt) => {
             let mut p = Vec::new();
-            for x in params.iter() {
+            for x in &stmt.params {
                 p.push(match x.node {
                     Parameter::Normal(ref n) => FunctionParameter::Normal(n.node.clone()),
                     Parameter::WithDefaultValue(ref n, ref v) => {
@@ -986,16 +986,16 @@ fn eval_stmt(stmt: &AstStatement, context: &EvaluationContext) -> EvalResult {
                 })
             }
             let f = Def::new(
-                name.node.clone(),
                 context.env.assert_module_env().name(),
                 p,
-                stmts.clone(),
+                stmt.clone(),
                 context.map.clone(),
                 context.env.assert_module_env().clone(),
             );
-            t(context.env.set(&name.node, f.clone()), name)?;
+            t(context.env.set(&stmt.name.node, f.clone()), &stmt.name)?;
             Ok(f)
         }
+        Statement::Def(..) => unreachable!(),
         Statement::Load(ref name, ref v) => {
             let loadenv = context.env.loader().load(name)?;
             for &(ref new_name, ref orig_name) in v.iter() {
@@ -1123,4 +1123,4 @@ pub mod testutil;
 #[cfg(test)]
 mod tests;
 
-mod def;
+pub(crate) mod def;

--- a/starlark/src/syntax/parser.rs
+++ b/starlark/src/syntax/parser.rs
@@ -185,10 +185,7 @@ pub fn parse_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             Dialect::Bzl => StarlarkParser::new().parse(content, filespan, lexer),
         }
     } {
-        Result::Ok(v) => {
-            Statement::validate_mod(&v, dialect)?;
-            Result::Ok(v)
-        }
+        Result::Ok(v) => Ok(Statement::compile_mod(v, dialect)?),
         Result::Err(p) => Result::Err(p.to_diagnostic(filespan)),
     }
 }


### PR DESCRIPTION
Before this diff `def` local variable indices were computed during
`def` statement evaluation.

Now local variable indices are computed right after module parsing
before module execution.

This change practically changes nothing for `def`, but something
similar need to be done with list-set-dict comprehensions: local
variable indices need to be computed at parse time, not at evaluation
time, because unlike `def` statement, comprehension statements are
executed multiple times.