### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Lots of editors understand it out of the box, in particular, IDEA.

The important property is `insert_final_newline = true` which is
`false` by default in IDEA.