### PR TITLE
[] += [] should be an error

### DIFF
--- a/starlark-test/tests/rust-testcases/control.sky
+++ b/starlark-test/tests/rust-testcases/control.sky
@@ -3,3 +3,11 @@
 def zzz():
     return
     break   ###  break cannot be used outside of loop
+---
+def qqq():
+    # note this is a parse time error
+    [] += []      ###  incorrect augmented assignment target
+---
+def qqq():
+    a = []
+    (a,) += [[]]  ###  incorrect augmented assignment target

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -63,7 +63,7 @@ build_file_: Statement = "\n"* <(<BuildTopStmt> "\n"+)*>
     => Statement::Statements(<>);
 
 TopStmt: AstStatement = { DefStmt, SimpleStmt<BuildTopStmt> };
-BuildTopStmt: AstStatement = { AssignStmt, ExprStmt, LoadStmt };
+BuildTopStmt: AstStatement = { AssignStmt, AugmentedAssignStmt, ExprStmt, LoadStmt };
 
 DefStmt: AstStatement = ASTS<DefStmt_>;
 DefStmt_: Statement =
@@ -125,22 +125,26 @@ SmallStmt: AstStatement = {
     <@L> "pass" <@R>
         => Statement::Pass.to_ast(file_span.subspan(<>)),
     AssignStmt,
+    AugmentedAssignStmt,
     ExprStmt
 };
 
-AssignOp: AssignOp = {
-    "=" => AssignOp::Assign,
-    "+=" => AssignOp::Increment,
-    "-=" => AssignOp::Decrement,
-    "*=" => AssignOp::Multiplier,
-    "/=" => AssignOp::Divider,
-    "//=" => AssignOp::FloorDivider,
-    "%=" => AssignOp::Percent,
+AssignStmt: AstStatement = ASTS<AssignStmt_>;
+AssignStmt_: Statement = <TestList> "=" <TestList>
+        => Statement::Assign(<>);
+
+AugmentedAssignOp: AugmentedAssignOp = {
+    "+=" => AugmentedAssignOp::Increment,
+    "-=" => AugmentedAssignOp::Decrement,
+    "*=" => AugmentedAssignOp::Multiplier,
+    "/=" => AugmentedAssignOp::Divider,
+    "//=" => AugmentedAssignOp::FloorDivider,
+    "%=" => AugmentedAssignOp::Percent,
 };
 
-AssignStmt: AstStatement = ASTS<AssignStmt_>;
-AssignStmt_: Statement = <TestList> <AssignOp> <TestList>
-        => Statement::Assign(<>);
+AugmentedAssignStmt: AstStatement = ASTS<AugmentedAssignStmt_>;
+AugmentedAssignStmt_: Statement = <lhs:TestList> <op:AugmentedAssignOp> <rhs:TestList>
+        =>? Ok(Statement::AugmentedAssign(AugmentedAssignTargetExpr::from_expr(lhs)?, op, rhs));
 
 // In python ExprStmt is an AssignStmt (
 // https://docs.python.org/3/reference/grammar.html). This ExprStmt is

--- a/starlark/src/syntax/grammar_tests.rs
+++ b/starlark/src/syntax/grammar_tests.rs
@@ -202,6 +202,22 @@ fail(2)
 }
 
 #[test]
+fn augmented_assignment_incorrect_target() {
+    let program = "[] += 1";
+    let lexer = super::lexer::Lexer::new(program);
+    let mut codemap = codemap::CodeMap::new();
+    let filespan = codemap
+        .add_file("<test>".to_owned(), program.to_owned())
+        .span;
+    match StarlarkParser::new().parse(program, filespan, lexer) {
+        Ok(..) => panic!("expecting error"),
+        Err(e) => {
+            assert!(format!("{:?}", e).contains("incorrect augmented assignment target"));
+        }
+    };
+}
+
+#[test]
 fn smoke_test() {
     let map = Arc::new(Mutex::new(codemap::CodeMap::new()));
     let mut diagnostics = Vec::new();


### PR DESCRIPTION
According to Stalark spec, augmented assignment target can be only
a name, an index expression, or a dot expression.

Filter out all other expression at parser level and simplify augmented
assignment evaluation.