### PR TITLE
Detach interpreter AST from parser AST

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -19,8 +19,8 @@ extern crate structopt;
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::interactive::{eval, eval_file, EvalError};
+use starlark::eval::stmt::AstStatementCompiled;
 use starlark::stdlib::global_environment_with_extensions;
-use starlark::syntax::ast::AstStatement;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::parser::{parse, parse_file};
 use starlark::values::Value;
@@ -121,7 +121,7 @@ fn main() {
 }
 
 fn maybe_print_ast_or_exit(
-    result: Result<AstStatement, Diagnostic>,
+    result: Result<AstStatementCompiled, Diagnostic>,
     codemap: &Arc<Mutex<CodeMap>>,
 ) {
     match result {

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -16,6 +16,7 @@
 
 use crate::environment::{Environment, TypeValues};
 use crate::eval::call_stack::CallStack;
+use crate::eval::stmt::{AstStatementCompiled, StatementCompiled};
 use crate::eval::{
     eval_stmt, EvalException, EvaluationContext, EvaluationContextEnvironment, IndexedLocals,
 };
@@ -43,7 +44,7 @@ use std::sync::{Arc, Mutex};
 pub struct DefCompiled {
     pub(crate) name: AstString,
     pub(crate) params: Vec<AstParameter>,
-    pub(crate) suite: AstStatement,
+    pub(crate) suite: AstStatementCompiled,
     local_names_to_indices: HashMap<String, usize>,
 }
 
@@ -66,7 +67,7 @@ impl DefCompiled {
 
         let suite = DefCompiled::transform_locals(suite, &local_names_to_indices);
 
-        let suite = Statement::compile(suite)?;
+        let suite = StatementCompiled::compile(suite)?;
 
         Ok(DefCompiled {
             name,
@@ -108,7 +109,7 @@ impl DefCompiled {
             | Statement::Pass
             | Statement::Return(..)
             | Statement::Expression(..) => {}
-            Statement::Load(..) | Statement::Def(..) | Statement::DefCompiled(..) => unreachable!(),
+            Statement::Load(..) | Statement::Def(..) => unreachable!(),
         }
     }
 
@@ -147,9 +148,7 @@ impl DefCompiled {
                     DefCompiled::transform_locals(else_block, locals),
                 ),
                 s @ Statement::Break | s @ Statement::Continue | s @ Statement::Pass => s,
-                Statement::Def(..) | Statement::Load(..) | Statement::DefCompiled(..) => {
-                    unreachable!()
-                }
+                Statement::Def(..) | Statement::Load(..) => unreachable!(),
                 Statement::Expression(expr) => {
                     Statement::Expression(Expr::transform_locals_to_slots(expr, locals))
                 }

--- a/starlark/src/eval/stmt.rs
+++ b/starlark/src/eval/stmt.rs
@@ -1,0 +1,96 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interpreter-ready statement
+
+use crate::eval::def::DefCompiled;
+use crate::syntax::ast::AstAugmentedAssignTargetExpr;
+use crate::syntax::ast::AstExpr;
+use crate::syntax::ast::AstStatement;
+use crate::syntax::ast::AstString;
+use crate::syntax::ast::AugmentedAssignOp;
+use crate::syntax::ast::AugmentedAssignTargetExpr;
+use crate::syntax::ast::Expr;
+use crate::syntax::ast::Statement;
+use codemap::Spanned;
+use codemap_diagnostic::Diagnostic;
+
+#[doc(hidden)]
+pub type AstStatementCompiled = Box<Spanned<StatementCompiled>>;
+
+/// Interperter-ready version of [`Statement`](crate::syntax::ast::Statement)
+#[derive(Debug, Clone)]
+pub enum StatementCompiled {
+    Break,
+    Continue,
+    Pass,
+    Return(Option<AstExpr>),
+    Expression(AstExpr),
+    Assign(AstExpr, AstExpr),
+    AugmentedAssign(AstAugmentedAssignTargetExpr, AugmentedAssignOp, AstExpr),
+    Statements(Vec<AstStatementCompiled>),
+    If(AstExpr, AstStatementCompiled),
+    IfElse(AstExpr, AstStatementCompiled, AstStatementCompiled),
+    For(AstExpr, AstExpr, AstStatementCompiled),
+    Def(DefCompiled),
+    Load(AstString, Vec<(AstString, AstString)>),
+}
+
+impl StatementCompiled {
+    pub(crate) fn compile(stmt: AstStatement) -> Result<AstStatementCompiled, Diagnostic> {
+        Ok(Box::new(Spanned {
+            span: stmt.span,
+            node: match stmt.node {
+                Statement::Def(name, params, suite) => {
+                    StatementCompiled::Def(DefCompiled::new(name, params, suite)?)
+                }
+                Statement::For(var, over, body) => StatementCompiled::For(
+                    Expr::compile(var)?,
+                    Expr::compile(over)?,
+                    StatementCompiled::compile(body)?,
+                ),
+                Statement::Return(expr) => {
+                    StatementCompiled::Return(expr.map(Expr::compile).transpose()?)
+                }
+                Statement::If(cond, then_block) => {
+                    StatementCompiled::If(cond, StatementCompiled::compile(then_block)?)
+                }
+                Statement::IfElse(conf, then_block, else_block) => StatementCompiled::IfElse(
+                    conf,
+                    StatementCompiled::compile(then_block)?,
+                    StatementCompiled::compile(else_block)?,
+                ),
+                Statement::Statements(stmts) => StatementCompiled::Statements(
+                    stmts
+                        .into_iter()
+                        .map(StatementCompiled::compile)
+                        .collect::<Result<_, _>>()?,
+                ),
+                Statement::Expression(e) => StatementCompiled::Expression(Expr::compile(e)?),
+                Statement::Assign(left, right) => {
+                    StatementCompiled::Assign(Expr::compile(left)?, Expr::compile(right)?)
+                }
+                Statement::AugmentedAssign(left, op, right) => StatementCompiled::AugmentedAssign(
+                    AugmentedAssignTargetExpr::compile(left)?,
+                    op,
+                    Expr::compile(right)?,
+                ),
+                Statement::Load(module, args) => StatementCompiled::Load(module, args),
+                Statement::Pass => StatementCompiled::Pass,
+                Statement::Break => StatementCompiled::Break,
+                Statement::Continue => StatementCompiled::Continue,
+            },
+        }))
+    }
+}

--- a/starlark/src/syntax/parser.rs
+++ b/starlark/src/syntax/parser.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::ast::AstStatement;
 use super::dialect::Dialect;
 use super::errors::SyntaxError;
 use super::grammar::{BuildFileParser, StarlarkParser};
@@ -24,6 +23,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::sync::{Arc, Mutex};
 
+use crate::eval::stmt::AstStatementCompiled;
 use crate::syntax::ast::Statement;
 use lalrpop_util as lu;
 
@@ -172,7 +172,7 @@ pub fn parse_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     content: &str,
     dialect: Dialect,
     lexer: T2,
-) -> Result<AstStatement, Diagnostic> {
+) -> Result<AstStatementCompiled, Diagnostic> {
     let filespan = {
         map.lock()
             .unwrap()
@@ -204,7 +204,7 @@ pub fn parse(
     filename: &str,
     content: &str,
     dialect: Dialect,
-) -> Result<AstStatement, Diagnostic> {
+) -> Result<AstStatementCompiled, Diagnostic> {
     let content2 = content.to_owned();
     parse_lexer(map, filename, content, dialect, Lexer::new(&content2))
 }
@@ -226,7 +226,7 @@ pub fn parse_file(
     map: &Arc<Mutex<CodeMap>>,
     path: &str,
     dialect: Dialect,
-) -> Result<AstStatement, Diagnostic> {
+) -> Result<AstStatementCompiled, Diagnostic> {
     let mut content = String::new();
     let mut file = iotry!(File::open(path));
     iotry!(file.read_to_string(&mut content));


### PR DESCRIPTION
... for `Statement` only for now. So now we have `enum Statement` and
`enum StatementCompiled`, similar to added previously `DefCompiled` in
addition to `Def`.

`Statement::DefCompiled` variant is removed, and `StatementCompiled::Def`
variant now holds `DefCompiled`.

This change is done to make possible future changes in the interpreter
without complicating AST too much, for example, desugaring it into
bytecode-like interpreter.