### PR TITLE
Use flat variable storage for nested scopes in local context

### DIFF
--- a/starlark/src/eval/compr.rs
+++ b/starlark/src/eval/compr.rs
@@ -14,214 +14,43 @@
 
 //! List/dict/set comprenension evaluation.
 
-use crate::eval::{eval_expr, make_set, set_expr, t, EvalException, EvalResult, EvaluationContext};
-use crate::syntax::ast::AssignTargetExpr;
-use crate::syntax::ast::AstAssignTargetExpr;
+use crate::eval::eval_expr;
+use crate::eval::set_expr;
+use crate::eval::t;
+use crate::eval::EvalException;
+use crate::eval::EvaluationContext;
 use crate::syntax::ast::AstClause;
-use crate::syntax::ast::AstExpr;
 use crate::syntax::ast::Clause;
-use crate::syntax::ast::Expr;
-use crate::syntax::ast::ToAst;
-use crate::values::dict::Dictionary;
-use crate::values::{TypedValue, Value};
-use codemap::{Span, Spanned};
-use codemap_diagnostic::Diagnostic;
-use std::collections::HashMap;
-use std::iter;
 
-/// For clause followed by zero or more if clauses.
-///
-/// Each `for` clause defines a scope while `if` doesn't.
-#[derive(Debug, Clone)]
-pub struct ClauseForCompiled {
-    var: AstAssignTargetExpr,
-    over: AstExpr,
-    ifs: Vec<AstExpr>,
-    local_names_to_indices: HashMap<String, usize>,
-}
-
-impl ClauseForCompiled {
-    fn to_raw<'a>(&'a self) -> impl Iterator<Item = AstClause> + 'a {
-        iter::once(
-            Clause::For(self.var.clone(), self.over.clone())
-                .to_ast(self.var.span.merge(self.over.span)),
-        )
-        .chain(
-            self.ifs
-                .iter()
-                .map(|ifc| Clause::If(ifc.clone()).to_ast(ifc.span)),
-        )
-    }
-
-    fn compiled_to_raw(clauses: &[ClauseForCompiled]) -> Vec<AstClause> {
-        clauses.iter().flat_map(ClauseForCompiled::to_raw).collect()
-    }
-
-    fn compile_clause(clause: ClauseForCompiled) -> Result<ClauseForCompiled, Diagnostic> {
-        let ClauseForCompiled {
-            var,
-            over,
-            ifs,
-            mut local_names_to_indices,
-        } = clause;
-        debug_assert!(local_names_to_indices.is_empty());
-        AssignTargetExpr::collect_locals_from_assign_expr(&var, &mut local_names_to_indices);
-        let var = AssignTargetExpr::compile(var)?;
-        let over = Expr::compile(over)?;
-        let ifs = ifs
-            .into_iter()
-            .map(|expr| {
-                let expr = Expr::transform_locals_to_slots(expr, &local_names_to_indices);
-                let expr = Expr::compile(expr)?;
-                Ok(expr)
-            })
-            .collect::<Result<_, _>>()?;
-        Ok(ClauseForCompiled {
-            var,
-            over,
-            ifs,
-            local_names_to_indices,
-        })
-    }
-
-    fn compile_clauses(clauses: Vec<AstClause>) -> Result<Vec<ClauseForCompiled>, Diagnostic> {
-        let mut compiled: Vec<ClauseForCompiled> = Vec::new();
-        for clause in clauses {
-            match clause.node {
-                Clause::For(var, over) => compiled.push(ClauseForCompiled {
-                    var,
-                    over,
-                    ifs: Vec::new(),
-                    local_names_to_indices: Default::default(),
-                }),
-                Clause::If(cond) => {
-                    compiled.last_mut().unwrap().ifs.push(cond);
-                }
-            }
-        }
-        compiled
-            .into_iter()
-            .map(ClauseForCompiled::compile_clause)
-            .collect::<Result<_, _>>()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ComprehensionCompiled {
-    List(AstExpr, Vec<ClauseForCompiled>),
-    Set(AstExpr, Vec<ClauseForCompiled>),
-    // key, value, clauses
-    Dict(AstExpr, AstExpr, Vec<ClauseForCompiled>),
-}
-
-impl ComprehensionCompiled {
-    pub(crate) fn new_list(
-        expr: AstExpr,
-        clauses: Vec<AstClause>,
-    ) -> Result<ComprehensionCompiled, Diagnostic> {
-        let fors = ClauseForCompiled::compile_clauses(clauses)?;
-        Ok(ComprehensionCompiled::List(
-            Expr::transform_locals_to_slots(expr, &fors.last().unwrap().local_names_to_indices),
-            fors,
-        ))
-    }
-
-    pub(crate) fn new_set(
-        expr: AstExpr,
-        clauses: Vec<AstClause>,
-    ) -> Result<ComprehensionCompiled, Diagnostic> {
-        let fors = ClauseForCompiled::compile_clauses(clauses)?;
-        Ok(ComprehensionCompiled::Set(
-            Expr::transform_locals_to_slots(expr, &fors.last().unwrap().local_names_to_indices),
-            fors,
-        ))
-    }
-
-    pub(crate) fn new_dict(
-        key: AstExpr,
-        value: AstExpr,
-        clauses: Vec<AstClause>,
-    ) -> Result<ComprehensionCompiled, Diagnostic> {
-        let fors = ClauseForCompiled::compile_clauses(clauses)?;
-        Ok(ComprehensionCompiled::Dict(
-            Expr::transform_locals_to_slots(key, &fors.last().unwrap().local_names_to_indices),
-            Expr::transform_locals_to_slots(value, &fors.last().unwrap().local_names_to_indices),
-            fors,
-        ))
-    }
-
-    pub(crate) fn to_raw(&self) -> Expr {
-        match self {
-            ComprehensionCompiled::List(expr, fors) => {
-                Expr::ListComprehension(expr.clone(), ClauseForCompiled::compiled_to_raw(&fors))
-            }
-            ComprehensionCompiled::Set(expr, fors) => {
-                Expr::SetComprehension(expr.clone(), ClauseForCompiled::compiled_to_raw(&fors))
-            }
-            ComprehensionCompiled::Dict(key, value, fors) => Expr::DictComprehension(
-                (key.clone(), value.clone()),
-                ClauseForCompiled::compiled_to_raw(&fors),
-            ),
-        }
-    }
-
-    pub(crate) fn eval(&self, expr_span: Span, context: &EvaluationContext) -> EvalResult {
-        match self {
-            ComprehensionCompiled::List(expr, fors) => {
-                let mut values = Vec::new();
-                eval_one_dimensional_comprehension(&expr, &fors, context, &mut values)?;
-                Ok(Value::from(values))
-            }
-            ComprehensionCompiled::Set(expr, fors) => {
-                let mut values = Vec::new();
-                eval_one_dimensional_comprehension(&expr, &fors, context, &mut values)?;
-                make_set(values, context, expr_span)
-            }
-            ComprehensionCompiled::Dict(key, value, fors) => {
-                let mut r = Dictionary::new_typed();
-                let tuple = Box::new(Spanned {
-                    span: key.span.merge(value.span),
-                    // TODO: clone might be expensive
-                    node: Expr::Tuple(vec![key.clone(), value.clone()]),
-                });
-                let mut pairs = Vec::new();
-                eval_one_dimensional_comprehension(&tuple, &fors, context, &mut pairs)?;
-                for e in pairs {
-                    let k = t(e.at(Value::from(0)), &tuple)?;
-                    let v = t(e.at(Value::from(1)), &tuple)?;
-                    t(r.set_at(k, v), &tuple)?;
-                }
-                Ok(Value::new(r))
-            }
-        }
-    }
-}
-
-fn eval_one_dimensional_comprehension<'a>(
-    e: &AstExpr,
-    clauses: &[ClauseForCompiled],
+pub(crate) fn eval_one_dimensional_comprehension<
+    F: FnMut(&EvaluationContext) -> Result<(), EvalException>,
+>(
+    expr: &mut F,
+    clauses: &[AstClause],
     context: &EvaluationContext,
-    collect: &mut Vec<Value>,
 ) -> Result<(), EvalException> {
-    if let Some((c, tl)) = clauses.split_first() {
-        let mut iterable = eval_expr(&c.over, context)?;
-        iterable.freeze_for_iteration();
-        'f: for i in &t(iterable.iter(), &c.over.span)? {
-            let context = context.child(&c.local_names_to_indices);
-            set_expr(&c.var, &context, i)?;
-
-            for ifc in &c.ifs {
-                if !eval_expr(ifc, &context)?.to_bool() {
-                    continue 'f;
+    if let Some((first, tl)) = clauses.split_first() {
+        match &first.node {
+            Clause::If(ref cond) => {
+                if !eval_expr(cond, context)?.to_bool() {
+                    return Ok(());
                 }
+                eval_one_dimensional_comprehension(expr, tl, context)
             }
+            Clause::For(ref var, ref iter) => {
+                let mut iterable = eval_expr(iter, context)?;
+                iterable.freeze_for_iteration();
+                for item in &t(iterable.iter(), iter)? {
+                    set_expr(var, context, item)?;
 
-            eval_one_dimensional_comprehension(e, tl, &context, collect)?;
+                    eval_one_dimensional_comprehension(expr, tl, context)?;
+                }
+
+                iterable.unfreeze_for_iteration();
+                Ok(())
+            }
         }
-
-        iterable.unfreeze_for_iteration();
     } else {
-        collect.push(eval_expr(e, &context)?);
+        expr(context)
     }
-    Ok(())
 }

--- a/starlark/src/eval/locals.rs
+++ b/starlark/src/eval/locals.rs
@@ -1,0 +1,222 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities to work with scope local variables.
+
+use std::collections::hash_map;
+use std::collections::HashMap;
+
+#[derive(Default, Debug, Clone)]
+struct Scope {
+    /// Name to slot mapping in current scope
+    name_to_slot: HashMap<String, usize>,
+    nested_scopes: Vec<Scope>,
+}
+
+/// Mapping of local variables and scopes to local variable slots
+#[derive(Default, Debug, Clone)]
+#[doc(hidden)]
+pub struct Locals {
+    locals: Scope,
+    local_count: usize,
+}
+
+/// Utility to assign slots to local variables
+#[derive(Default)]
+pub(crate) struct LocalsBuilder {
+    locals: Locals,
+    current_scope_path: Vec<usize>,
+}
+
+/// Utility to query slots assigned to local variables
+pub(crate) struct LocalsQuery<'a> {
+    locals: &'a Locals,
+    current_scope_path: Vec<usize>,
+    next: usize,
+}
+
+impl Scope {
+    /// Find local variable index in given scope
+    fn local_index(&self, name: &str, scope_path: &[usize]) -> Option<usize> {
+        let deepest_index = if let Some((first, rem)) = scope_path.split_first() {
+            self.nested_scopes[*first].local_index(name, rem)
+        } else {
+            None
+        };
+        match deepest_index {
+            Some(index) => Some(index),
+            None => self.name_to_slot.get(name).cloned(),
+        }
+    }
+
+    fn scope_by_path<'a>(&'a self, path: &[usize]) -> &'a Scope {
+        match path.split_first() {
+            Some((&first, rem)) => self.nested_scopes[first].scope_by_path(rem),
+            None => self,
+        }
+    }
+}
+
+impl Locals {
+    /// Return the number of local variable slots
+    pub fn len(&self) -> usize {
+        self.local_count
+    }
+
+    pub fn top_level_name_to_slot(&self, name: &str) -> Option<usize> {
+        self.locals.local_index(name, &[])
+    }
+}
+
+impl LocalsBuilder {
+    fn current_locals(&mut self) -> &mut Scope {
+        let mut locals = &mut self.locals.locals;
+        for &index in &self.current_scope_path {
+            locals = &mut locals.nested_scopes[index];
+        }
+        locals
+    }
+
+    /// Create a new nested scope
+    pub fn push_scope(&mut self) {
+        let locals = self.current_locals();
+        locals.nested_scopes.push(Scope::default());
+        let n = locals.nested_scopes.len() - 1;
+        self.current_scope_path.push(n);
+    }
+
+    /// Go to one scope down
+    pub fn pop_scope(&mut self) {
+        self.current_scope_path.pop().unwrap();
+    }
+
+    /// Register a variable in current scope
+    pub fn register_local(&mut self, name: &str) {
+        let local_count = self.locals.local_count;
+        if let hash_map::Entry::Vacant(e) =
+            self.current_locals().name_to_slot.entry(name.to_owned())
+        {
+            e.insert(local_count);
+        }
+        self.locals.local_count += 1;
+    }
+
+    /// Finish the building
+    pub fn build(self) -> Locals {
+        // sanity check
+        assert!(self.current_scope_path.is_empty());
+
+        self.locals
+    }
+}
+
+impl<'a> LocalsQuery<'a> {
+    pub fn new(locals: &'a Locals) -> LocalsQuery<'a> {
+        LocalsQuery {
+            locals,
+            current_scope_path: Vec::new(),
+            next: 0,
+        }
+    }
+
+    /// Return a slot for a variable visible in current scope.
+    /// Local could be registered in current scope or in parent scopes,
+    /// but not in nested scopes.
+    pub fn local_slot(&self, name: &str) -> Option<usize> {
+        self.locals
+            .locals
+            .local_index(name, &self.current_scope_path)
+    }
+
+    /// Go to the next nested scope
+    pub fn push_next_scope(&mut self) {
+        self.current_scope_path.push(self.next);
+        self.next = 0;
+    }
+
+    /// Pop a scope
+    pub fn pop_scope(&mut self) {
+        // We must not leave the current scope if
+        // nested scopes were not traversed
+        assert_eq!(
+            self.next,
+            self.locals
+                .locals
+                .scope_by_path(&self.current_scope_path)
+                .nested_scopes
+                .len()
+        );
+
+        self.next = self.current_scope_path.pop().unwrap() + 1;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn one_level() {
+        let mut builder = LocalsBuilder::default();
+        builder.register_local("a");
+        builder.register_local("b");
+        builder.register_local("a");
+        let locals = builder.build();
+        let query = LocalsQuery::new(&locals);
+        assert_eq!(Some(0), query.local_slot("a"));
+        assert_eq!(Some(1), query.local_slot("b"));
+        assert_eq!(None, query.local_slot("c"));
+    }
+
+    #[test]
+    fn override_on_second_level() {
+        let mut builder = LocalsBuilder::default();
+        builder.register_local("a");
+        builder.push_scope();
+        builder.register_local("a");
+        builder.pop_scope();
+        let locals = builder.build();
+        let mut query = LocalsQuery::new(&locals);
+        assert_eq!(Some(0), query.local_slot("a"));
+        query.push_next_scope();
+        assert_eq!(Some(1), query.local_slot("a"));
+        query.pop_scope();
+        assert_eq!(Some(0), query.local_slot("a"));
+    }
+
+    #[test]
+    fn overrride_twice_on_second_level() {
+        // Here we have three distinct `a` variables:
+        // in the top scope, and in two nested scopes
+        let mut builder = LocalsBuilder::default();
+        builder.register_local("a");
+        builder.push_scope();
+        builder.register_local("a");
+        builder.pop_scope();
+        builder.push_scope();
+        builder.register_local("a");
+        builder.pop_scope();
+        let locals = builder.build();
+        let mut query = LocalsQuery::new(&locals);
+        assert_eq!(Some(0), query.local_slot("a"));
+        query.push_next_scope();
+        assert_eq!(Some(1), query.local_slot("a"));
+        query.pop_scope();
+        assert_eq!(Some(0), query.local_slot("a"));
+        query.push_next_scope();
+        assert_eq!(Some(2), query.local_slot("a"));
+        query.pop_scope();
+        assert_eq!(Some(0), query.local_slot("a"));
+    }
+}

--- a/starlark/src/eval/stmt.rs
+++ b/starlark/src/eval/stmt.rs
@@ -15,16 +15,13 @@
 //! Interpreter-ready statement
 
 use crate::eval::def::DefCompiled;
-use crate::syntax::ast::AssignTargetExpr;
-use crate::syntax::ast::AstAssignTargetExpr;
 use crate::syntax::ast::AstAugmentedAssignTargetExpr;
 use crate::syntax::ast::AstExpr;
 use crate::syntax::ast::AstStatement;
 use crate::syntax::ast::AstString;
 use crate::syntax::ast::AugmentedAssignOp;
-use crate::syntax::ast::AugmentedAssignTargetExpr;
-use crate::syntax::ast::Expr;
 use crate::syntax::ast::Statement;
+use crate::syntax::ast::{AstAssignTargetExpr, AugmentedAssignTargetExpr, Expr};
 use codemap::Spanned;
 use codemap_diagnostic::Diagnostic;
 
@@ -50,15 +47,56 @@ pub(crate) enum StatementCompiled {
 pub struct BlockCompiled(pub(crate) Vec<AstStatementCompiled>);
 
 impl BlockCompiled {
-    fn compile_stmts(stmts: Vec<AstStatement>) -> Result<BlockCompiled, Diagnostic> {
+    fn compile_local_stmts(stmts: Vec<AstStatement>) -> Result<BlockCompiled, Diagnostic> {
         let mut r = Vec::new();
         for stmt in stmts {
-            r.extend(Self::compile_stmt(stmt)?.0);
+            r.extend(Self::compile_local(stmt)?.0);
         }
         Ok(BlockCompiled(r))
     }
 
-    pub(crate) fn compile_stmt(stmt: AstStatement) -> Result<BlockCompiled, Diagnostic> {
+    pub(crate) fn compile_local(stmt: AstStatement) -> Result<BlockCompiled, Diagnostic> {
+        Ok(BlockCompiled(vec![Spanned {
+            span: stmt.span,
+            node: match stmt.node {
+                Statement::Def(..) => unreachable!(),
+                Statement::For(var, over, body) => {
+                    StatementCompiled::For(var, over, BlockCompiled::compile_local(body)?)
+                }
+                Statement::Return(expr) => StatementCompiled::Return(expr),
+                Statement::If(cond, then_block) => StatementCompiled::IfElse(
+                    cond,
+                    BlockCompiled::compile_local(then_block)?,
+                    BlockCompiled(Vec::new()),
+                ),
+                Statement::IfElse(conf, then_block, else_block) => StatementCompiled::IfElse(
+                    conf,
+                    BlockCompiled::compile_local(then_block)?,
+                    BlockCompiled::compile_local(else_block)?,
+                ),
+                Statement::Statements(stmts) => return BlockCompiled::compile_local_stmts(stmts),
+                Statement::Expression(e) => StatementCompiled::Expression(e),
+                Statement::Assign(left, right) => StatementCompiled::Assign(left, right),
+                Statement::AugmentedAssign(left, op, right) => {
+                    StatementCompiled::AugmentedAssign(left, op, right)
+                }
+                Statement::Load(module, args) => StatementCompiled::Load(module, args),
+                Statement::Pass => return Ok(BlockCompiled(Vec::new())),
+                Statement::Break => StatementCompiled::Break,
+                Statement::Continue => StatementCompiled::Continue,
+            },
+        }]))
+    }
+
+    fn compile_global_stmts(stmts: Vec<AstStatement>) -> Result<BlockCompiled, Diagnostic> {
+        let mut r = Vec::new();
+        for stmt in stmts {
+            r.extend(Self::compile_global(stmt)?.0);
+        }
+        Ok(BlockCompiled(r))
+    }
+
+    pub(crate) fn compile_global(stmt: AstStatement) -> Result<BlockCompiled, Diagnostic> {
         Ok(BlockCompiled(vec![Spanned {
             span: stmt.span,
             node: match stmt.node {
@@ -66,40 +104,42 @@ impl BlockCompiled {
                     StatementCompiled::Def(DefCompiled::new(name, params, suite)?)
                 }
                 Statement::For(var, over, body) => StatementCompiled::For(
-                    AssignTargetExpr::compile(var)?,
-                    Expr::compile(over)?,
-                    BlockCompiled::compile_stmt(body)?,
+                    var,
+                    Expr::compile_global(over)?,
+                    BlockCompiled::compile_global(body)?,
                 ),
-                Statement::Return(expr) => {
-                    StatementCompiled::Return(expr.map(Expr::compile).transpose()?)
-                }
                 Statement::If(cond, then_block) => StatementCompiled::IfElse(
-                    cond,
-                    BlockCompiled::compile_stmt(then_block)?,
+                    Expr::compile_global(cond)?,
+                    BlockCompiled::compile_global(then_block)?,
                     BlockCompiled(Vec::new()),
                 ),
-                Statement::IfElse(conf, then_block, else_block) => StatementCompiled::IfElse(
-                    conf,
-                    BlockCompiled::compile_stmt(then_block)?,
-                    BlockCompiled::compile_stmt(else_block)?,
+                Statement::IfElse(cond, then_block, else_block) => StatementCompiled::IfElse(
+                    Expr::compile_global(cond)?,
+                    BlockCompiled::compile_global(then_block)?,
+                    BlockCompiled::compile_global(else_block)?,
                 ),
-                Statement::Statements(stmts) => {
-                    return Self::compile_stmts(stmts);
+                Statement::Statements(stmts) => return BlockCompiled::compile_global_stmts(stmts),
+                Statement::Expression(expr) => {
+                    StatementCompiled::Expression(Expr::compile_global(expr)?)
                 }
-                Statement::Expression(e) => StatementCompiled::Expression(Expr::compile(e)?),
-                Statement::Assign(left, right) => StatementCompiled::Assign(
-                    AssignTargetExpr::compile(left)?,
-                    Expr::compile(right)?,
-                ),
-                Statement::AugmentedAssign(left, op, right) => StatementCompiled::AugmentedAssign(
-                    AugmentedAssignTargetExpr::compile(left)?,
-                    op,
-                    Expr::compile(right)?,
-                ),
-                Statement::Load(module, args) => StatementCompiled::Load(module, args),
+                Statement::Return(Some(expr)) => {
+                    StatementCompiled::Return(Some(Expr::compile_global(expr)?))
+                }
+                Statement::Assign(target, source) => {
+                    StatementCompiled::Assign(target, Expr::compile_global(source)?)
+                }
+                Statement::AugmentedAssign(target, op, source) => {
+                    StatementCompiled::AugmentedAssign(
+                        AugmentedAssignTargetExpr::compile_global(target)?,
+                        op,
+                        Expr::compile_global(source)?,
+                    )
+                }
+                Statement::Load(path, map) => StatementCompiled::Load(path, map),
                 Statement::Pass => return Ok(BlockCompiled(Vec::new())),
                 Statement::Break => StatementCompiled::Break,
                 Statement::Continue => StatementCompiled::Continue,
+                Statement::Return(None) => StatementCompiled::Return(None),
             },
         }]))
     }

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -16,7 +16,6 @@
 use crate::values::error::ValueError;
 use crate::values::hashed_value::HashedValue;
 use crate::values::iter::TypedIterable;
-use crate::values::none::NoneType;
 use crate::values::*;
 use linked_hash_map::LinkedHashMap; // To preserve insertion order
 use std::collections::HashMap;
@@ -76,12 +75,12 @@ impl Dictionary {
         self.content.get(key)
     }
 
-    pub fn insert(&mut self, key: Value, value: Value) -> Result<Value, ValueError> {
+    pub fn insert(&mut self, key: Value, value: Value) -> Result<(), ValueError> {
         let key = key.clone_for_container(self)?;
         let key = HashedValue::new(key)?;
         let value = value.clone_for_container(self)?;
         self.content.insert(key, value);
-        Ok(Value::new(NoneType::None))
+        Ok(())
     }
 
     pub fn remove_hashed(&mut self, key: &HashedValue) -> Option<Value> {


### PR DESCRIPTION
After this diff, comprehensions create a scope only during analysis,
but at runtime, comprehension locals are assigned different slots
in a flat variable space, as it happens in grown-up interpreters
or compilers.

Instead of a function scope, we have "local" scope which is created
for:
* function locals (including nested comprehension scopes)
* comprehension expressions in the module context

It's worth mentioning that in a local context (e. g. in a function
context) it is no longer possible to access a variable by name,
only by slot index (because name to slot index is no longer unique).

No slot optimization is performed at the moment, e. g. this program:

```
_ = [x for x in []]
_ = [x for x in []]
```

creates two slots for `x` variables in a function context. Should not
be a big issue, though.

This change significantly complicates analysis phase but simplifies
the runtime, which should be helpful to implement more optimizations
or GC.