### PR TITLE
Specialize TypedIterable::to_vec

### DIFF
--- a/starlark-test/benches/rust-benches/list.sky
+++ b/starlark-test/benches/rust-benches/list.sky
@@ -1,0 +1,2 @@
+def bench():
+    return list([1, 2, 3])

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -253,6 +253,10 @@ impl TypedIterable for Set {
     fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().map(|v| v.get_value().clone()))
     }
+
+    fn to_vec(&self) -> Vec<Value> {
+        self.content.iter().map(|v| v.get_value().clone()).collect()
+    }
 }
 
 #[cfg(test)]

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -125,8 +125,8 @@ starlark_module! {global =>
     /// # )"#).unwrap());
     /// ```
     dict.keys(this) {
-        let v : Vec<Value> = this.iter()?.iter().collect();
-        ok!(v)
+        let this = this.downcast_ref::<Dictionary>().unwrap();
+        Ok(Value::from(this.keys()))
     }
 
     /// [dict.pop](

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -511,13 +511,11 @@ starlark_module! {global_functions =>
     ///
     /// With no argument, `list()` returns a new empty list.
     list(?#a) {
-        let mut l = Vec::new();
         if let Some(a) = a {
-            for x in &a.iter()? {
-                l.push(x.clone())
-            }
+            Ok(Value::from(a.to_vec()?))
+        } else {
+            Ok(Value::from(Vec::<Value>::new()))
         }
-        Ok(Value::from(l))
     }
 
     /// [max](
@@ -773,8 +771,8 @@ starlark_module! {global_functions =>
     /// # )"#).unwrap());
     /// ```
     reversed(#a) {
-        let v : Vec<Value> = a.iter()?.iter().collect();
-        let v : Vec<Value> = v.into_iter().rev().collect();
+        let v: Vec<Value> = a.to_vec()?;
+        let v: Vec<Value> = v.into_iter().rev().collect();
         Ok(Value::from(v))
     }
 
@@ -877,13 +875,11 @@ starlark_module! {global_functions =>
     ///
     /// With no arguments, `tuple()` returns the empty tuple.
     tuple(?#a) {
-        let mut l = Vec::new();
         if let Some(a) = a {
-            for x in &a.iter()? {
-                l.push(x.clone())
-            }
+            Ok(Value::new(tuple::Tuple::new(a.to_vec()?)))
+        } else {
+            Ok(Value::new(tuple::Tuple::new(Vec::new())))
         }
-        Ok(Value::new(tuple::Tuple::new(l)))
     }
 
     /// [type](

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -86,6 +86,10 @@ impl Dictionary {
     pub fn remove_hashed(&mut self, key: &HashedValue) -> Option<Value> {
         self.content.remove(key)
     }
+
+    pub fn keys(&self) -> Vec<Value> {
+        self.content.keys().map(|k| k.get_value().clone()).collect()
+    }
 }
 
 impl<T1: Into<Value> + Hash + Eq + Clone, T2: Into<Value> + Eq + Clone> TryFrom<HashMap<T1, T2>>
@@ -226,7 +230,11 @@ impl TypedValue for Dictionary {
 
 impl TypedIterable for Dictionary {
     fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(self.content.iter().map(|x| x.0.get_value().clone()))
+        Box::new(self.content.keys().map(|x| x.get_value().clone()))
+    }
+
+    fn to_vec(&self) -> Vec<Value> {
+        self.content.keys().map(|x| x.get_value().clone()).collect()
     }
 }
 

--- a/starlark/src/values/iter.rs
+++ b/starlark/src/values/iter.rs
@@ -21,6 +21,11 @@ use crate::values::Value;
 pub trait TypedIterable: 'static {
     /// Make an iterator.
     fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a>;
+
+    /// Specialized faster version of iteration when results as vec is needed
+    fn to_vec(&self) -> Vec<Value> {
+        self.to_iter().into_iter().collect()
+    }
 }
 
 /// Iterable which contains borrowed reference to a sequence.
@@ -35,6 +40,10 @@ impl<'a> RefIterable<'a> {
 
     pub fn iter(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         self.r.to_iter()
+    }
+
+    pub fn to_vec(&self) -> Vec<Value> {
+        self.r.to_vec()
     }
 }
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -299,6 +299,10 @@ impl TypedIterable for List {
     fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().cloned())
     }
+
+    fn to_vec(&self) -> Vec<Value> {
+        self.content.clone()
+    }
 }
 
 #[cfg(test)]

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1137,6 +1137,9 @@ impl Value {
     pub fn iter<'a>(&'a self) -> Result<RefIterable<'a>, ValueError> {
         self.value_holder().iter()
     }
+    pub fn to_vec(&self) -> Result<Vec<Value>, ValueError> {
+        Ok(self.iter()?.to_vec())
+    }
     pub fn length(&self) -> Result<i64, ValueError> {
         self.value_holder().length()
     }

--- a/starlark/src/values/range.rs
+++ b/starlark/src/values/range.rs
@@ -216,6 +216,10 @@ impl TypedIterable for Range {
     fn to_iter(&self) -> Box<dyn Iterator<Item = Value>> {
         Box::new(RangeIterator(self.clone()))
     }
+
+    fn to_vec(&self) -> Vec<Value> {
+        RangeIterator(self.clone()).collect()
+    }
 }
 
 #[cfg(test)]

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -430,6 +430,10 @@ impl TypedIterable for Tuple {
     fn to_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Value> + 'a> {
         Box::new(self.content.iter().cloned())
     }
+
+    fn to_vec(&self) -> Vec<Value> {
+        self.content.clone()
+    }
 }
 
 impl From<()> for Value {


### PR DESCRIPTION
This benchmark:

```
list([1, 2, 3])
```

becomes about 10% faster.