### PR TITLE
Adopt Python syntax for positional-only function parameters

### DIFF
--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -200,7 +200,6 @@ def f(): return x
 fn test_type_values_are_imported_from_caller() {
     use crate::starlark_fun;
     use crate::starlark_module;
-    use crate::starlark_param_name;
     use crate::starlark_parse_param_type;
     use crate::starlark_signature;
     use crate::starlark_signature_extraction;

--- a/starlark/src/linked_hash_set/stdlib.rs
+++ b/starlark/src/linked_hash_set/stdlib.rs
@@ -36,7 +36,7 @@ starlark_module! {global =>
     /// iterable sequence x.
     ///
     /// With no argument, `set()` returns a new empty set.
-    set(?#a) {
+    set(?a, /) {
         let mut s = Set::default();
         if let Some(a) = a {
             for x in &a.iter()? {
@@ -70,7 +70,7 @@ starlark_module! {global =>
     /// x == set([1, 2, 3])
     /// # )"#).unwrap());
     /// ```
-    set.add(this, #el) {
+    set.add(this, el, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         this.insert_if_absent(el)?;
         Ok(Value::new(NoneType::None))
@@ -183,7 +183,7 @@ starlark_module! {global =>
     /// x == set([4])
     /// # "#).unwrap());
     /// ```
-    set.difference_update(this, #other) {
+    set.difference_update(this, other, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         let previous_length = this.len() as usize;
         let mut values = Vec::with_capacity(previous_length);
@@ -219,7 +219,7 @@ starlark_module! {global =>
     /// x == set([1, 3])
     /// # )"#).unwrap());
     /// ```
-    set.discard(this, #needle) {
+    set.discard(this, needle, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         this.remove(&needle)?;
         Ok(Value::new(NoneType::None))
@@ -287,7 +287,7 @@ starlark_module! {global =>
     /// x == set([2])
     /// # "#).unwrap());
     /// ```
-    set.intersection_update(this, #other) {
+    set.intersection_update(this, other, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         let previous_length = this.len();
         let mut values = Vec::with_capacity(previous_length);
@@ -323,7 +323,7 @@ starlark_module! {global =>
     /// x.isdisjoint(set([1, 5])) == False
     /// # )"#).unwrap());
     /// ```
-    set.isdisjoint(this, #other) {
+    set.isdisjoint(this, other, /) {
         ok!(Set::compare(&this, &other, &|s1, s2| Ok(s1.intersection(s2).next().is_none()))?)
     }
 
@@ -347,7 +347,7 @@ starlark_module! {global =>
     /// x.issubset(set([1, 2, 3, 4, 5])) == True
     /// # )"#).unwrap());
     /// ```
-    set.issubset(this, #other) {
+    set.issubset(this, other, /) {
         ok!(Set::compare(&this, &other, &|this, other| Ok(this.is_subset(other)))?)
     }
 
@@ -371,7 +371,7 @@ starlark_module! {global =>
     /// x.issuperset(set([1, 2, 3, 4, 5])) == False
     /// # )"#).unwrap());
     /// ```
-    set.issuperset(this, #other) {
+    set.issuperset(this, other, /) {
         ok!(Set::compare(&this, &other, &|this, other| Ok(other.is_subset(this)))?)
     }
 
@@ -399,7 +399,7 @@ starlark_module! {global =>
     /// x == set([3])
     /// # )"#).unwrap());
     /// ```
-    set.pop(this, #index = NoneType::None) {
+    set.pop(this, index = NoneType::None, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         let length = this.len() as i64;
         let index = if index.get_type() == "NoneType" {
@@ -448,7 +448,7 @@ starlark_module! {global =>
     ///
     /// A subsequent call to `x.remove(2)` would yield an error because the element won't be
     /// found.
-    set.remove(this, #needle) {
+    set.remove(this, needle, /) {
         let mut this = this.downcast_mut::<Set>()?.unwrap();
         let did_remove = this.remove(&needle)?;
         if did_remove {
@@ -483,7 +483,7 @@ starlark_module! {global =>
     /// x.symmetric_difference(z) == set([1, 2, 3, 4, 5])
     /// # )"#).unwrap());
     /// ```
-    set.symmetric_difference(this, #other) {
+    set.symmetric_difference(this, other, /) {
         Set::compare(&this, &other, &|s1, s2| {
             Ok(Set::from(s1.symmetric_difference(s2).cloned().collect()).unwrap())
         })
@@ -523,7 +523,7 @@ starlark_module! {global =>
     /// z == set([5])
     /// # )"#).unwrap());
     /// ```
-    set.symmetric_difference_update(this, #other) {
+    set.symmetric_difference_update(this, other, /) {
         let symmetric_difference = Set::compare(&this, &other, &|s1, s2| {
             Ok(Set::from(s1.symmetric_difference(s2).cloned().collect()).unwrap())
         })?;

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -78,7 +78,7 @@ starlark_module! {global =>
     /// x.get("three", 0) == 0
     /// # )"#).unwrap());
     /// ```
-    dict.get(this, #key, #default = NoneType::None) {
+    dict.get(this, key, default = NoneType::None, /) {
         match this.at(key) {
             Err(ValueError::KeyNotFound(..)) => Ok(default),
             x => x
@@ -160,7 +160,7 @@ starlark_module! {global =>
     /// ```python
     /// x.pop("four")  # error: missing key
     /// ```
-    dict.pop(this, #key, #default = NoneType::None) {
+    dict.pop(this, key, default = NoneType::None, /) {
         let mut this = this.downcast_mut::<Dictionary>()?.unwrap();
         match this.remove(&key)? {
             Some(x) => Ok(x),
@@ -244,7 +244,7 @@ starlark_module! {global =>
     /// x == {"one": 1, "two": 2, "three": 0, "four": None}
     /// # )"#).unwrap());
     /// ```
-    dict.setdefault(this, #key, #default = NoneType::None) {
+    dict.setdefault(this, key, default = NoneType::None, /) {
         let mut this = this.downcast_mut::<Dictionary>()?.unwrap();
         if let Some(r) = this.get(&key)? {
             return Ok(r.clone())
@@ -285,7 +285,7 @@ starlark_module! {global =>
     /// x == {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
     /// # )"#).unwrap());
     /// ```
-    dict.update(this, ?#pairs, **kwargs) {
+    dict.update(this, ?pairs, /, **kwargs) {
         if let Some(pairs) = pairs {
             match pairs.get_type() {
                 "list" => for v in &pairs.iter()? {

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -47,7 +47,7 @@ starlark_module! {global =>
     /// x == [1, 2, 3]
     /// # )"#).unwrap());
     /// ```
-    list.append(this, #el) {
+    list.append(this, el, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
         this.push(el)?;
         Ok(Value::new(NoneType::None))
@@ -100,7 +100,7 @@ starlark_module! {global =>
     /// x == [1, 2, 3, "foo"]
     /// # )"#).unwrap());
     /// ```
-    list.extend(this, #other) {
+    list.extend(this, other, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
         this.extend(other)?;
         Ok(Value::new(NoneType::None))
@@ -135,7 +135,7 @@ starlark_module! {global =>
     /// x.index("a", -2) == 5  # bananA
     /// # )"#).unwrap());
     /// ```
-    list.index(this, #needle, #start = 0, #end = NoneType::None) {
+    list.index(this, needle, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         let it = this.iter()?;
         let mut it = it.iter().skip(start).take(end - start);
@@ -175,7 +175,7 @@ starlark_module! {global =>
     /// x == ["a", "b", "c", "d", "e"]
     /// # )"#).unwrap());
     /// ```
-    list.insert(this, #index, #el) {
+    list.insert(this, index, el, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
         convert_indices!(this, index);
         this.insert(index, el)?;
@@ -206,7 +206,7 @@ starlark_module! {global =>
     /// x == [1]
     /// # )"#).unwrap());
     /// ```
-    list.pop(this, ?#index) {
+    list.pop(this, ?index, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
         let index = match index {
             Some(index) => index.to_int()?,
@@ -242,7 +242,7 @@ starlark_module! {global =>
     /// A subsequence call to `x.remove(2)` would yield an error because the element won't be
     /// found.
     /// ```
-    list.remove(this, #needle) {
+    list.remove(this, needle, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
         this.remove(needle)?;
         Ok(Value::new(NoneType::None))

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -125,7 +125,6 @@ impl<T: TryParamConvertFromValue> TryParamConvertFromValue for EitherValueOrNone
 mod test {
     use crate::starlark_fun;
     use crate::starlark_module;
-    use crate::starlark_param_name;
     use crate::starlark_parse_param_type;
     use crate::starlark_signature;
     use crate::starlark_signature_extraction;

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -90,7 +90,7 @@ starlark_module! {global_functions =>
     /// any([0, False]) == False
     /// # )").unwrap());
     /// ```
-    any(#x) {
+    any(x, /) {
         for i in &x.iter()? {
             if i.to_bool() {
                 return Ok(Value::new(true));
@@ -123,7 +123,7 @@ starlark_module! {global_functions =>
     /// all([0, False]) == False
     /// # )").unwrap());
     /// ```
-    all(#x) {
+    all(x, /) {
         for i in &x.iter()? {
             if !i.to_bool() {
                 return Ok(Value::new(false));
@@ -162,7 +162,7 @@ starlark_module! {global_functions =>
     /// bool(0) == False
     /// # )").unwrap());
     /// ```
-    bool(#x = false) {
+    bool(x = false, /) {
         Ok(Value::new(x.to_bool()))
     }
 
@@ -187,7 +187,7 @@ starlark_module! {global_functions =>
     /// chr(0x1F63F) == '😿'
     /// # )").unwrap());
     /// ```
-    chr(#i) {
+    chr(i, /) {
         let cp = i.to_int()? as u32;
         match std::char::from_u32(cp) {
             Some(x) => Ok(Value::new(x.to_string())),
@@ -233,7 +233,7 @@ starlark_module! {global_functions =>
     /// dict([(1, 2)], x=3) == {1: 2, 'x': 3}
     /// # )").unwrap());
     /// ```
-    dict(?#a, **kwargs) {
+    dict(?a, /, **kwargs) {
         let mut map = Dictionary::new();
         if let Some(a) = a {
             match a.get_type() {
@@ -297,7 +297,7 @@ starlark_module! {global_functions =>
     /// "capitalize" in dir("abc")
     /// # ))).unwrap());
     /// ```
-    dir(env env, #x) {
+    dir(env env, x, /) {
         let mut result = env.list_type_value(&x);
         if let Ok(v) = x.dir_attr() {
             result.extend(v);
@@ -327,7 +327,7 @@ starlark_module! {global_functions =>
     /// enumerate(["one", "two"], 1) == [(1, "one"), (2, "two")]
     /// # )"#).unwrap());
     /// ```
-    enumerate(#it, #offset: i64 = 0) {
+    enumerate(it, offset: i64 = 0, /) {
         let v : Vec<Value> =
             it
             .iter()?
@@ -353,7 +353,7 @@ starlark_module! {global_functions =>
     /// getattr("banana", "split")("a") == ["b", "n", "n", ""] # equivalent to "banana".split("a")
     /// # "#).unwrap());
     /// ```
-    getattr(env env, #a, #attr: String, #default = NoneType::None) {
+    getattr(env env, a, attr: String, default = NoneType::None, /) {
         match a.get_attr(&attr) {
             Ok(v) => Ok(v),
             x => match env.get_type_value(&a, &attr) {
@@ -373,7 +373,7 @@ starlark_module! {global_functions =>
     /// ): test if an object has an attribute
     ///
     /// `hasattr(x, name)` reports whether x has an attribute (field or method) named `name`.
-    hasattr(env env, #a, #attr: String) {
+    hasattr(env env, a, attr: String, /) {
         Ok(Value::new(
             match env.get_type_value(&a, &attr) {
                 Some(..) => true,
@@ -393,7 +393,7 @@ starlark_module! {global_functions =>
     /// `hash(x) == hash(y)``.
     ///
     /// `hash` fails if x, or any value upon which its hash depends, is unhashable.
-    hash(#a) {
+    hash(a, /) {
         Ok(Value::new(a.get_hash()? as i64))
     }
 
@@ -418,7 +418,7 @@ starlark_module! {global_functions =>
     /// specified by name.
     ///
     /// `int()` with no arguments returns 0.
-    int(#a, ?base) {
+    int(a, /, ?base) {
         if a.get_type() == "string" {
             let s = a.to_str();
             let base = match base {
@@ -498,7 +498,7 @@ starlark_module! {global_functions =>
     /// `len(x)` returns the number of elements in its argument.
     ///
     /// It is a dynamic error if its argument is not a sequence.
-    len(#a) {
+    len(a, /) {
         Ok(Value::new(a.length()?))
     }
 
@@ -510,7 +510,7 @@ starlark_module! {global_functions =>
     /// iterable sequence x.
     ///
     /// With no argument, `list()` returns a new empty list.
-    list(?#a) {
+    list(?a, /) {
         if let Some(a) = a {
             Ok(Value::from(a.to_vec()?))
         } else {
@@ -659,7 +659,7 @@ starlark_module! {global_functions =>
     /// ord("Й")                                == 1049
     /// # )"#).unwrap());
     /// ```
-    ord(#a) {
+    ord(a, /) {
         if a.get_type() != "string" || a.length()? != 1 {
             starlark_err!(
                 ORD_EXPECT_ONE_CHAR_ERROR_CODE,
@@ -707,7 +707,7 @@ starlark_module! {global_functions =>
     /// list(range(10, 3, -2))                  == [10, 8, 6, 4]
     /// # )"#).unwrap());
     /// ```
-    range(#a1: i64, ?#a2: Option<i64>, ?#a3: Option<i64>) {
+    range(a1: i64, ?a2: Option<i64>, ?a3: Option<i64>, /) {
         let start = match a2 {
             None => 0,
             Some(_) => a1,
@@ -749,7 +749,7 @@ starlark_module! {global_functions =>
     /// repr([1, "x"])          == "[1, \"x\"]"
     /// # )"#).unwrap());
     /// ```
-    repr(#a) {
+    repr(a, /) {
         Ok(Value::new(a.to_repr()))
     }
 
@@ -770,7 +770,7 @@ starlark_module! {global_functions =>
     /// reversed({"one": 1, "two": 2}.keys())           == ["two", "one"]
     /// # )"#).unwrap());
     /// ```
-    reversed(#a) {
+    reversed(a, /) {
         let v: Vec<Value> = a.to_vec()?;
         let v: Vec<Value> = v.into_iter().rev().collect();
         Ok(Value::from(v))
@@ -803,7 +803,7 @@ starlark_module! {global_functions =>
     /// sorted(["two", "three", "four"], key=len, reverse=True)  == ["three", "four", "two"] # longest to shortest
     /// # )"#).unwrap());
     /// ```
-    sorted(call_stack cs, env e, #x, ?key, reverse = false) {
+    sorted(call_stack cs, env e, x, /, ?key, reverse = false) {
         let it = x.iter()?;
         let x = it.iter();
         let mut it = match key {
@@ -865,7 +865,7 @@ starlark_module! {global_functions =>
     /// str([1, "x"])                   == "[1, \"x\"]"
     /// # )"#).unwrap());
     /// ```
-    _str(#a) {
+    _str(a, /) {
         Ok(Value::new(a.to_str()))
     }
 
@@ -874,7 +874,7 @@ starlark_module! {global_functions =>
     /// ): returns a tuple containing the elements of the iterable x.
     ///
     /// With no arguments, `tuple()` returns the empty tuple.
-    tuple(?#a) {
+    tuple(?a, /) {
         if let Some(a) = a {
             Ok(Value::new(tuple::Tuple::new(a.to_vec()?)))
         } else {
@@ -894,7 +894,7 @@ starlark_module! {global_functions =>
     /// type(0)                 == "int"
     /// # )"#).unwrap());
     /// ```
-    _type(#a) {
+    _type(a, /) {
         Ok(Value::new(a.get_type().to_owned()))
     }
 

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -299,7 +299,7 @@ starlark_module! {global =>
     /// "hello, world!".count("o", 7, 12) == 1  # in "world"
     /// # )"#).unwrap());
     /// ```
-    string.count(this: String, #needle: String, #start = 0, #end = NoneType::None) {
+    string.count(this: String, needle: String, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         let n = needle.as_str();
         let mut counter = 0 as i64;
@@ -328,7 +328,7 @@ starlark_module! {global =>
     /// "filename.sky".endswith(".sky") == True
     /// # )"#).unwrap());
     /// ```
-    string.endswith(this: String, #suffix: String) {
+    string.endswith(this: String, suffix: String, /) {
         ok!(this.ends_with(suffix.as_str()))
     }
 
@@ -359,7 +359,7 @@ starlark_module! {global =>
     /// "bonbon".find("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.find(this: String, #needle: String, #start = 0, #end = NoneType::None) {
+    string.find(this: String, needle: String, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         let needle = needle.to_str();
         if let Some(substring) = this.as_str().get(start..end) {
@@ -511,7 +511,7 @@ starlark_module! {global =>
     /// "bonbon".index("on", 2, 5) # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.index(this: String, #needle: String, #start = 0, #end = NoneType::None) {
+    string.index(this: String, needle: String, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.find(needle.as_str()) {
@@ -785,7 +785,7 @@ starlark_module! {global =>
     /// "a".join("ctmrn".split_codepoints()) == "catamaran"
     /// # )"#).unwrap());
     /// ```
-    string.join(this: String, #to_join) {
+    string.join(this: String, to_join, /) {
         let mut r = String::new();
         let to_join_iter = to_join.iter()?;
         for (index, item) in to_join_iter.iter().enumerate() {
@@ -854,7 +854,7 @@ starlark_module! {global =>
     /// "one/two/three".partition("/")	 == ("one", "/", "two/three")
     /// # )"#).unwrap());
     /// ```
-    string.partition(this: String, #needle = " ") {
+    string.partition(this: String, needle = " ", /) {
         check_string!(needle, partition);
         let needle = needle.to_str();
         if needle.is_empty() {
@@ -896,7 +896,7 @@ starlark_module! {global =>
     /// "banana".replace("a", "o", 2)	 == "bonona"
     /// # )"#).unwrap());
     /// ```
-    string.replace(this: String, #old: String, #new: String, ?#count: Option<usize>) {
+    string.replace(this: String, old: String, new: String, ?count: Option<usize>, /) {
         ok!(
             match count {
                 None => this.replace(old.as_str(), new.as_str()),
@@ -927,7 +927,7 @@ starlark_module! {global =>
     /// "bonbon".rfind("on", 2, 5) == -1
     /// # )"#).unwrap());
     /// ```
-    string.rfind(this: String, #needle: String, #start = 0, #end = NoneType::None) {
+    string.rfind(this: String, needle: String, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         if let Some(substring) = this.as_str().get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
@@ -959,7 +959,7 @@ starlark_module! {global =>
     /// "bonbon".rindex("on", 2, 5)   # error: substring not found  (in "nbo")
     /// # )"#).is_err());
     /// ```
-    string.rindex(this: String, #needle: String, #start = 0, #end = NoneType::None) {
+    string.rindex(this: String, needle: String, start = 0, end = NoneType::None, /) {
         convert_indices!(this, start, end);
         if let Some(substring) = this.get(start..end) {
             if let Some(offset) = substring.rfind(needle.as_str()) {
@@ -987,7 +987,7 @@ starlark_module! {global =>
     /// "one/two/three".rpartition("/")	 == ("one/two", "/", "three")
     /// # )"#).unwrap());
     /// ```
-    string.rpartition(this: String, #needle: String = " ".to_owned()) {
+    string.rpartition(this: String, needle: String = " ".to_owned(), /) {
         if needle.is_empty() {
             starlark_err!(
                 INCORRECT_PARAMETER_TYPE_ERROR_CODE,
@@ -1030,7 +1030,7 @@ starlark_module! {global =>
     /// "one two  three".rsplit(None, 1) == ["one two", "three"]
     /// # )"#).unwrap());
     /// ```
-    string.rsplit(this: String, #sep = NoneType::None, #maxsplit = NoneType::None) {
+    string.rsplit(this: String, sep = NoneType::None, maxsplit = NoneType::None, /) {
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
         } else {
@@ -1121,7 +1121,7 @@ starlark_module! {global =>
     /// "banana".split("n", 1) == ["ba", "ana"]
     /// # )"#).unwrap());
     /// ```
-    string.split(this: String, #sep = NoneType::None, #maxsplit = NoneType::None) {
+    string.split(this: String, sep = NoneType::None, maxsplit = NoneType::None, /) {
         let this = this.to_str();
         let maxsplit = if maxsplit.get_type() == "NoneType" {
             None
@@ -1203,7 +1203,7 @@ starlark_module! {global =>
     /// "one\n\ntwo".splitlines(True) == ["one\n", "\n", "two"]
     /// # )"#).unwrap());
     /// ```
-    string.splitlines(this: String, #keepends = false) {
+    string.splitlines(this: String, keepends = false, /) {
         check_type!(keepends, "string.splitlines", bool);
         let this = this.to_str();
         let mut s = this.as_str();
@@ -1248,7 +1248,7 @@ starlark_module! {global =>
     /// "filename.sky".startswith("filename") == True
     /// # )"#).unwrap());
     /// ```
-    string.startswith(this: String, #prefix) {
+    string.startswith(this: String, prefix, /) {
         check_string!(prefix, startswith);
         ok!(this.to_str().starts_with(prefix.to_str().as_str()))
     }


### PR DESCRIPTION
Previously, native function was declared with this macro:

```
foo(#a, #b, c, d) { ... }
```

Currently it is declared with:

```
foo(a, b, /, c, d) { ... }
```

This simplifies macros, but also makes native function declaration
syntax similar to Python's
[PEP 508](https://www.python.org/dev/peps/pep-0570/).

This PR depends on not-yet accepted PR #205, and dear GitHub, please implement stacked PRs!