### PR TITLE
More refactoring of function signature

### DIFF
--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -27,7 +27,10 @@ use crate::syntax::ast::AugmentedAssignTargetExpr;
 use crate::syntax::ast::Expr;
 use crate::syntax::ast::Statement;
 use crate::values::error::ValueError;
-use crate::values::function::{FunctionParameter, FunctionType};
+use crate::values::function::FunctionParameter;
+use crate::values::function::FunctionSignature;
+use crate::values::function::FunctionType;
+use crate::values::function::StrOrRepr;
 use crate::values::none::NoneType;
 use crate::values::{function, Immutable, TypedValue, Value, ValueResult};
 use codemap::{CodeMap, Spanned};
@@ -163,7 +166,7 @@ impl DefCompiled {
 
 /// Starlark function internal representation and implementation of [`TypedValue`].
 pub(crate) struct Def {
-    signature: Vec<FunctionParameter>,
+    signature: FunctionSignature,
     function_type: FunctionType,
     captured_env: Environment,
     map: Arc<Mutex<CodeMap>>,
@@ -173,7 +176,7 @@ pub(crate) struct Def {
 impl Def {
     pub fn new(
         module: String,
-        signature: Vec<FunctionParameter>,
+        signature: FunctionSignature,
         stmt: DefCompiled,
         map: Arc<Mutex<CodeMap>>,
         env: Environment,
@@ -203,11 +206,11 @@ impl TypedValue for Def {
     }
 
     fn to_str_impl(&self, buf: &mut String) -> fmt::Result {
-        function::to_str(buf, &self.function_type, &self.signature)
+        function::str_impl(buf, &self.function_type, &self.signature, StrOrRepr::Str)
     }
 
     fn to_repr_impl(&self, buf: &mut String) -> fmt::Result {
-        function::repr_impl(buf, &self.function_type, &self.signature)
+        function::str_impl(buf, &self.function_type, &self.signature, StrOrRepr::Repr)
     }
 
     fn call(
@@ -239,12 +242,15 @@ impl TypedValue for Def {
             kwargs,
         )?;
 
-        for s in &self.signature {
+        for (s, positional_only) in self.signature.iter() {
             let (name, v) = match s {
-                FunctionParameter::Normal(ref name) => (name, parser.next_normal(name)?),
-                FunctionParameter::WithDefaultValue(ref name, ref default_value) => {
-                    (name, parser.next_with_default_value(name, default_value))
+                FunctionParameter::Normal(ref name) => {
+                    (name, parser.next_normal(name, positional_only)?)
                 }
+                FunctionParameter::WithDefaultValue(ref name, ref default_value) => (
+                    name,
+                    parser.next_with_default_value(name, positional_only, default_value),
+                ),
                 FunctionParameter::ArgsArray(ref name) => (name, parser.next_args_array().into()),
                 FunctionParameter::KWArgsDict(ref name) => {
                     (name, parser.next_kwargs_dict().try_into().unwrap())

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -29,7 +29,9 @@ use crate::syntax::errors::SyntaxError;
 use crate::syntax::lexer::{LexerIntoIter, LexerItem};
 use crate::syntax::parser::{parse, parse_file, parse_lexer};
 use crate::values::error::ValueError;
-use crate::values::function::{FunctionParameter, WrappedMethod};
+use crate::values::function::FunctionParameter;
+use crate::values::function::FunctionSignature;
+use crate::values::function::WrappedMethod;
 use crate::values::none::NoneType;
 use crate::values::*;
 use codemap::{CodeMap, Span, Spanned};
@@ -853,7 +855,7 @@ fn eval_stmt(stmt: &AstStatementCompiled, context: &EvaluationContext) -> EvalRe
             }
             let f = Def::new(
                 context.env.assert_module_env().name(),
-                p,
+                FunctionSignature::new(p, 0),
                 stmt.clone(),
                 context.map.clone(),
                 context.env.assert_module_env().clone(),


### PR DESCRIPTION
* Explicitly track positional arguments internally instead of name mangling
* Introduce `FunctionSignature` data type
* Change function `str` and `repr` to use PEP 508
* Add tests

Before:

```
>>> list
<native function list>(?$a)
```

Now:

```
>>> list
<native function list>(?a, /)
```