### PR TITLE
Typecheck do_bench function in stable and beta

### DIFF
--- a/starlark-test/src/lib.rs
+++ b/starlark-test/src/lib.rs
@@ -147,7 +147,21 @@ def assert_(cond, msg="assertion failed"):
     }
 }
 
-#[cfg(rustc_nightly)]
+#[cfg(not(rustc_nightly))]
+pub struct Bencher {}
+
+#[cfg(not(rustc_nightly))]
+impl Bencher {
+    pub fn iter<T, F>(&mut self, mut _inner: F)
+    where
+        F: FnMut() -> T,
+    {
+        // Bencher included here to typecheck `do_bench` function
+        // in stable and also to mute unused imports warnings
+        panic!("Bencher available only in nightly");
+    }
+}
+
 pub fn do_bench(bencher: &mut Bencher, path: &str) {
     let mut content = String::new();
     let mut file = File::open(path).unwrap();


### PR DESCRIPTION
We cannot do bench in stable or beta because `Bencher` is available
only in nightly, but still enable `do_bench` function in stable or
beta to be able to do meaningful `cargo check` in stable or beta:
* to typecheck the function
* to mute unused imports warnings