### PR TITLE
Restrict augmented assignment to a global variable at parse level

### DIFF
--- a/starlark-test/tests/go-testcases/assign.sky
+++ b/starlark-test/tests/go-testcases/assign.sky
@@ -148,7 +148,7 @@ f()
 
 ---
 
-z += 3 ### Variable was not found
+z += 3 ### Augmented assignment is a binding and not allowed on a global variable
 
 ---
 # It's ok to define a global that shadows a built-in.


### PR DESCRIPTION
Previously it was a runtime error.

Note Starlark spec also requires it to be a static error.