### PR TITLE
Detach interpreter AST from parser AST

### DIFF
--- a/starlark/src/eval/compiler.rs
+++ b/starlark/src/eval/compiler.rs
@@ -1,0 +1,219 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for translation of AST into interpreter-friendly data structures
+
+use crate::eval::expr::AssignTargetExprCompiled;
+use crate::eval::expr::AstClauseCompiled;
+use crate::eval::expr::AstGlobalOrSlot;
+use crate::eval::expr::ClauseCompiled;
+use crate::eval::expr::ExprCompiled;
+use crate::eval::expr::GlobalOrSlot;
+use crate::eval::locals::LocalsBuilder;
+use crate::eval::locals::LocalsQuery;
+use crate::syntax::ast::AstClause;
+use crate::syntax::ast::AstExpr;
+use crate::syntax::ast::AstString;
+use crate::syntax::ast::Clause;
+use crate::syntax::ast::Expr;
+use codemap::Span;
+use codemap::Spanned;
+use codemap_diagnostic::Diagnostic;
+
+/// Encapsulate differences between compilation of module scope vs
+/// function or comprehension scope
+pub(crate) trait LocalOrGlobalCompiler {
+    /// Resolve identifier to either local slot or global name
+    fn ident(&self, ident: AstString) -> GlobalOrSlot;
+
+    fn ast_ident(&self, ident: AstString) -> AstGlobalOrSlot {
+        Spanned {
+            span: ident.span,
+            node: self.ident(ident),
+        }
+    }
+
+    /// Compile list comprehension
+    fn list_comprenesion(
+        &mut self,
+        span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic>;
+    /// Compile set comprehension
+    fn set_comprenesion(
+        &mut self,
+        span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic>;
+    /// Compile dict comprehension
+    fn dict_comprenesion(
+        &mut self,
+        span: Span,
+        key: AstExpr,
+        value: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic>;
+}
+
+pub(crate) struct LocalCompiler<'a> {
+    locals_query: &'a mut LocalsQuery<'a>,
+}
+
+impl<'a> LocalCompiler<'a> {
+    pub fn new(locals_query: &'a mut LocalsQuery<'a>) -> LocalCompiler<'a> {
+        LocalCompiler { locals_query }
+    }
+}
+
+impl<'a> LocalCompiler<'a> {
+    fn compile_clauses<R, E>(&mut self, clauses: Vec<AstClause>, expr: E) -> Result<R, Diagnostic>
+    where
+        E: FnOnce(Vec<AstClauseCompiled>, &mut LocalCompiler) -> Result<R, Diagnostic>,
+    {
+        let mut transformed_clauses = Vec::new();
+        let mut scope_count = 0;
+        for clause in clauses {
+            transformed_clauses.push(Spanned {
+                span: clause.span,
+                node: match clause.node {
+                    Clause::If(expr) => ClauseCompiled::If(ExprCompiled::compile(expr, self)?),
+                    Clause::For(target, expr) => {
+                        let expr = ExprCompiled::compile(expr, self)?;
+                        self.locals_query.push_next_scope();
+                        scope_count += 1;
+                        let target = AssignTargetExprCompiled::compile(target, self)?;
+                        ClauseCompiled::For(target, expr)
+                    }
+                },
+            });
+        }
+        let r = expr(transformed_clauses, self)?;
+        for _ in 0..scope_count {
+            self.locals_query.pop_scope();
+        }
+        Ok(r)
+    }
+}
+
+impl<'a> LocalOrGlobalCompiler for LocalCompiler<'a> {
+    fn ident(&self, ident: AstString) -> GlobalOrSlot {
+        match self.locals_query.local_slot(&ident.node) {
+            Some(slot) => GlobalOrSlot::Slot(slot, ident.node),
+            None => GlobalOrSlot::Global(ident.node),
+        }
+    }
+
+    fn list_comprenesion(
+        &mut self,
+        _span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_clauses(clauses, |clauses, compiler| {
+            let expr = ExprCompiled::compile(expr, compiler)?;
+            Ok(ExprCompiled::ListComprehension(expr, clauses))
+        })
+    }
+
+    fn set_comprenesion(
+        &mut self,
+        _span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_clauses(clauses, |clauses, compiler| {
+            let expr = ExprCompiled::compile(expr, compiler)?;
+            Ok(ExprCompiled::SetComprehension(expr, clauses))
+        })
+    }
+
+    fn dict_comprenesion(
+        &mut self,
+        _span: Span,
+        key: AstExpr,
+        value: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_clauses(clauses, |clauses, compiler| {
+            let key = ExprCompiled::compile(key, compiler)?;
+            let value = ExprCompiled::compile(value, compiler)?;
+            Ok(ExprCompiled::DictComprehension((key, value), clauses))
+        })
+    }
+}
+
+pub(crate) struct GlobalCompiler;
+
+impl GlobalCompiler {
+    fn compile_comprehension_in_global_scope(
+        &self,
+        expr: AstExpr,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        let mut locals_builder = LocalsBuilder::default();
+
+        Expr::collect_locals(&expr, &mut locals_builder);
+
+        let locals = locals_builder.build();
+
+        let mut locals_query = LocalsQuery::new(&locals);
+
+        let expr = ExprCompiled::compile_local(expr, &mut locals_query)?;
+
+        Ok(ExprCompiled::Local(expr, locals))
+    }
+}
+
+impl LocalOrGlobalCompiler for GlobalCompiler {
+    fn ident(&self, ident: AstString) -> GlobalOrSlot {
+        GlobalOrSlot::Global(ident.node)
+    }
+    fn list_comprenesion(
+        &mut self,
+        span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_comprehension_in_global_scope(Box::new(Spanned {
+            span,
+            node: Expr::ListComprehension(expr, clauses),
+        }))
+    }
+
+    fn set_comprenesion(
+        &mut self,
+        span: Span,
+        expr: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_comprehension_in_global_scope(Box::new(Spanned {
+            span,
+            node: Expr::SetComprehension(expr, clauses),
+        }))
+    }
+
+    fn dict_comprenesion(
+        &mut self,
+        span: Span,
+        key: AstExpr,
+        value: AstExpr,
+        clauses: Vec<AstClause>,
+    ) -> Result<ExprCompiled, Diagnostic> {
+        self.compile_comprehension_in_global_scope(Box::new(Spanned {
+            span,
+            node: Expr::DictComprehension((key, value), clauses),
+        }))
+    }
+}

--- a/starlark/src/eval/compr.rs
+++ b/starlark/src/eval/compr.rs
@@ -15,29 +15,29 @@
 //! List/dict/set comprenension evaluation.
 
 use crate::eval::eval_expr;
+use crate::eval::expr::AstClauseCompiled;
+use crate::eval::expr::ClauseCompiled;
 use crate::eval::set_expr;
 use crate::eval::t;
 use crate::eval::EvalException;
 use crate::eval::EvaluationContext;
-use crate::syntax::ast::AstClause;
-use crate::syntax::ast::Clause;
 
 pub(crate) fn eval_one_dimensional_comprehension<
     F: FnMut(&EvaluationContext) -> Result<(), EvalException>,
 >(
     expr: &mut F,
-    clauses: &[AstClause],
+    clauses: &[AstClauseCompiled],
     context: &EvaluationContext,
 ) -> Result<(), EvalException> {
     if let Some((first, tl)) = clauses.split_first() {
         match &first.node {
-            Clause::If(ref cond) => {
+            ClauseCompiled::If(ref cond) => {
                 if !eval_expr(cond, context)?.to_bool() {
                     return Ok(());
                 }
                 eval_one_dimensional_comprehension(expr, tl, context)
             }
-            Clause::For(ref var, ref iter) => {
+            ClauseCompiled::For(ref var, ref iter) => {
                 let mut iterable = eval_expr(iter, context)?;
                 iterable.freeze_for_iteration();
                 for item in &t(iterable.iter(), iter)? {

--- a/starlark/src/eval/expr.rs
+++ b/starlark/src/eval/expr.rs
@@ -1,0 +1,268 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interpreter-ready expr
+
+use crate::eval::compiler::GlobalCompiler;
+use crate::eval::compiler::LocalCompiler;
+use crate::eval::compiler::LocalOrGlobalCompiler;
+use crate::eval::locals::Locals;
+use crate::eval::locals::LocalsQuery;
+use crate::syntax::ast::AssignTargetExpr;
+use crate::syntax::ast::AstAssignTargetExpr;
+use crate::syntax::ast::AstAugmentedAssignTargetExpr;
+use crate::syntax::ast::AstExpr;
+use crate::syntax::ast::AstInt;
+use crate::syntax::ast::AstString;
+use crate::syntax::ast::AugmentedAssignTargetExpr;
+use crate::syntax::ast::BinOp;
+use crate::syntax::ast::Expr;
+use codemap::Spanned;
+use codemap_diagnostic::Diagnostic;
+
+/// After syntax check each variable is resolved to either global or slot
+#[derive(Debug, Clone)]
+pub(crate) enum GlobalOrSlot {
+    Global(String),
+    Slot(usize, String),
+}
+pub(crate) type AstGlobalOrSlot = Spanned<GlobalOrSlot>;
+
+#[derive(Debug, Clone)]
+pub(crate) enum AssignTargetExprCompiled {
+    Name(AstGlobalOrSlot),
+    Dot(AstExprCompiled, AstString),
+    ArrayIndirection(AstExprCompiled, AstExprCompiled),
+    Subtargets(Vec<AstAssignTargetExprCompiled>),
+}
+pub(crate) type AstAssignTargetExprCompiled = Spanned<AssignTargetExprCompiled>;
+
+#[derive(Debug, Clone)]
+pub(crate) enum AugmentedAssignTargetExprCompiled {
+    // TODO: there's no augmented assignment for global
+    Name(AstGlobalOrSlot),
+    Dot(AstExprCompiled, AstString),
+    ArrayIndirection(AstExprCompiled, AstExprCompiled),
+}
+pub(crate) type AstAugmentedAssignTargetExprCompiled = Spanned<AugmentedAssignTargetExprCompiled>;
+
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub(crate) enum ClauseCompiled {
+    For(AstAssignTargetExprCompiled, AstExprCompiled),
+    If(AstExprCompiled),
+}
+pub(crate) type AstClauseCompiled = Spanned<ClauseCompiled>;
+
+/// Interperter-ready version of [`Expr`](crate::syntax::ast::Expr)
+#[derive(Debug, Clone)]
+pub(crate) enum ExprCompiled {
+    Tuple(Vec<AstExprCompiled>),
+    Dot(AstExprCompiled, AstString),
+    Call(
+        AstExprCompiled,
+        Vec<AstExprCompiled>,
+        Vec<(AstString, AstExprCompiled)>,
+        Option<AstExprCompiled>,
+        Option<AstExprCompiled>,
+    ),
+    ArrayIndirection(AstExprCompiled, AstExprCompiled),
+    Slice(
+        AstExprCompiled,
+        Option<AstExprCompiled>,
+        Option<AstExprCompiled>,
+        Option<AstExprCompiled>,
+    ),
+    Name(AstGlobalOrSlot),
+    // local variable index
+    IntLiteral(AstInt),
+    StringLiteral(AstString),
+    Not(AstExprCompiled),
+    Minus(AstExprCompiled),
+    Plus(AstExprCompiled),
+    Op(BinOp, AstExprCompiled, AstExprCompiled),
+    If(AstExprCompiled, AstExprCompiled, AstExprCompiled), // Order: condition, v1, v2 <=> v1 if condition else v2
+    List(Vec<AstExprCompiled>),
+    Set(Vec<AstExprCompiled>),
+    Dict(Vec<(AstExprCompiled, AstExprCompiled)>),
+    ListComprehension(AstExprCompiled, Vec<AstClauseCompiled>),
+    SetComprehension(AstExprCompiled, Vec<AstClauseCompiled>),
+    DictComprehension((AstExprCompiled, AstExprCompiled), Vec<AstClauseCompiled>),
+    /// Creates a local scope for evaluation of subexpression in global scope.
+    /// Used for evaluate comprehensions in global scope.
+    Local(AstExprCompiled, Locals),
+}
+
+#[doc(hidden)]
+pub(crate) type AstExprCompiled = Box<Spanned<ExprCompiled>>;
+
+impl ExprCompiled {
+    pub(crate) fn compile<C: LocalOrGlobalCompiler>(
+        expr: AstExpr,
+        compiler: &mut C,
+    ) -> Result<AstExprCompiled, Diagnostic> {
+        Ok(Box::new(Spanned {
+            span: expr.span,
+            node: match expr.node {
+                Expr::Tuple(args) => ExprCompiled::Tuple(
+                    args.into_iter()
+                        .map(|a| Self::compile(a, compiler))
+                        .collect::<Result<_, _>>()?,
+                ),
+                Expr::List(args) => ExprCompiled::List(
+                    args.into_iter()
+                        .map(|a| Self::compile(a, compiler))
+                        .collect::<Result<_, _>>()?,
+                ),
+                Expr::Set(args) => ExprCompiled::Set(
+                    args.into_iter()
+                        .map(|a| Self::compile(a, compiler))
+                        .collect::<Result<_, _>>()?,
+                ),
+                Expr::Dict(args) => ExprCompiled::Dict(
+                    args.into_iter()
+                        .map(|(k, v)| {
+                            Ok((Self::compile(k, compiler)?, Self::compile(v, compiler)?))
+                        })
+                        .collect::<Result<_, _>>()?,
+                ),
+                Expr::Identifier(ident) => ExprCompiled::Name(Spanned {
+                    span: ident.span,
+                    node: compiler.ident(ident),
+                }),
+                Expr::Dot(object, field) => {
+                    ExprCompiled::Dot(Self::compile(object, compiler)?, field)
+                }
+                Expr::ArrayIndirection(array, index) => ExprCompiled::ArrayIndirection(
+                    Self::compile(array, compiler)?,
+                    Self::compile(index, compiler)?,
+                ),
+                Expr::Call(f, args, kwargs, star, star_star) => ExprCompiled::Call(
+                    Self::compile(f, compiler)?,
+                    args.into_iter()
+                        .map(|a| Self::compile(a, compiler))
+                        .collect::<Result<_, _>>()?,
+                    kwargs
+                        .into_iter()
+                        .map(|(k, v)| Ok((k, Self::compile(v, compiler)?)))
+                        .collect::<Result<_, _>>()?,
+                    star.map(|e| Self::compile(e, compiler)).transpose()?,
+                    star_star.map(|e| Self::compile(e, compiler)).transpose()?,
+                ),
+                Expr::Slice(array, a, b, c) => ExprCompiled::Slice(
+                    Self::compile(array, compiler)?,
+                    a.map(|e| Self::compile(e, compiler)).transpose()?,
+                    b.map(|e| Self::compile(e, compiler)).transpose()?,
+                    c.map(|e| Self::compile(e, compiler)).transpose()?,
+                ),
+                Expr::IntLiteral(i) => ExprCompiled::IntLiteral(i),
+                Expr::StringLiteral(s) => ExprCompiled::StringLiteral(s),
+                Expr::Not(e) => ExprCompiled::Not(Self::compile(e, compiler)?),
+                Expr::Plus(e) => ExprCompiled::Plus(Self::compile(e, compiler)?),
+                Expr::Minus(e) => ExprCompiled::Minus(Self::compile(e, compiler)?),
+                Expr::Op(op, lhs, rhs) => ExprCompiled::Op(
+                    op,
+                    Self::compile(lhs, compiler)?,
+                    Self::compile(rhs, compiler)?,
+                ),
+                Expr::If(cond, then_expr, else_expr) => ExprCompiled::If(
+                    Self::compile(cond, compiler)?,
+                    Self::compile(then_expr, compiler)?,
+                    Self::compile(else_expr, compiler)?,
+                ),
+                Expr::ListComprehension(expr, clauses) => {
+                    compiler.list_comprenesion(expr.span, expr, clauses)?
+                }
+                Expr::SetComprehension(expr, clauses) => {
+                    compiler.set_comprenesion(expr.span, expr, clauses)?
+                }
+                Expr::DictComprehension((key, value), clauses) => {
+                    compiler.dict_comprenesion(expr.span, key, value, clauses)?
+                }
+            },
+        }))
+    }
+
+    pub(crate) fn compile_local<'a>(
+        expr: AstExpr,
+        locals_query: &'a mut LocalsQuery<'a>,
+    ) -> Result<AstExprCompiled, Diagnostic> {
+        Self::compile(expr, &mut LocalCompiler::new(locals_query))
+    }
+
+    pub(crate) fn compile_global(expr: AstExpr) -> Result<AstExprCompiled, Diagnostic> {
+        Self::compile(expr, &mut GlobalCompiler)
+    }
+}
+
+impl AssignTargetExprCompiled {
+    pub(crate) fn compile<C: LocalOrGlobalCompiler>(
+        expr: AstAssignTargetExpr,
+        compiler: &mut C,
+    ) -> Result<AstAssignTargetExprCompiled, Diagnostic> {
+        Ok(Spanned {
+            span: expr.span,
+            node: match expr.node {
+                AssignTargetExpr::Identifier(a) => {
+                    AssignTargetExprCompiled::Name(compiler.ast_ident(a))
+                }
+                AssignTargetExpr::Slot(..) => unreachable!(),
+                AssignTargetExpr::ArrayIndirection(array, index) => {
+                    AssignTargetExprCompiled::ArrayIndirection(
+                        ExprCompiled::compile(array, compiler)?,
+                        ExprCompiled::compile(index, compiler)?,
+                    )
+                }
+                AssignTargetExpr::Dot(object, field) => {
+                    AssignTargetExprCompiled::Dot(ExprCompiled::compile(object, compiler)?, field)
+                }
+                AssignTargetExpr::Subtargets(subtargets) => AssignTargetExprCompiled::Subtargets(
+                    subtargets
+                        .into_iter()
+                        .map(|t| AssignTargetExprCompiled::compile(t, compiler))
+                        .collect::<Result<_, _>>()?,
+                ),
+            },
+        })
+    }
+}
+
+impl AugmentedAssignTargetExprCompiled {
+    pub(crate) fn compile_impl<C: LocalOrGlobalCompiler>(
+        expr: AstAugmentedAssignTargetExpr,
+        compiler: &mut C,
+    ) -> Result<AstAugmentedAssignTargetExprCompiled, Diagnostic> {
+        Ok(Spanned {
+            span: expr.span,
+            node: match expr.node {
+                AugmentedAssignTargetExpr::Identifier(a) => {
+                    AugmentedAssignTargetExprCompiled::Name(compiler.ast_ident(a))
+                }
+                AugmentedAssignTargetExpr::Slot(..) => unreachable!(),
+                AugmentedAssignTargetExpr::ArrayIndirection(array, index) => {
+                    AugmentedAssignTargetExprCompiled::ArrayIndirection(
+                        ExprCompiled::compile(array, compiler)?,
+                        ExprCompiled::compile(index, compiler)?,
+                    )
+                }
+                AugmentedAssignTargetExpr::Dot(object, field) => {
+                    AugmentedAssignTargetExprCompiled::Dot(
+                        ExprCompiled::compile(object, compiler)?,
+                        field,
+                    )
+                }
+            },
+        })
+    }
+}


### PR DESCRIPTION
The important changes are:

* `Expr` enum no longer has `Slot` or `Local` variants
* `ExprCompiled` enum now explicitly references global identifier
  or slot, not any identifier

The rest of the diff is mostly mechanical changes.

This is similar to #202.