### PR TITLE
Avoid allocation of call stack in each function call

### DIFF
--- a/starlark-test/src/lib.rs
+++ b/starlark-test/src/lib.rs
@@ -207,7 +207,7 @@ def assert_(cond, msg="assertion failed"):
     bencher.iter(|| {
         let env = env.child("bench");
         match bench_func.call(
-            &CallStack::default(),
+            &mut CallStack::default(),
             TypeValues::new(env),
             Vec::new(),
             LinkedHashMap::new(),

--- a/starlark/src/eval/call_stack.rs
+++ b/starlark/src/eval/call_stack.rs
@@ -41,6 +41,11 @@ impl CallStack {
         self.stack.push(Frame(function, code_map, pos));
     }
 
+    /// Pop an element from the stack, panic if stack is already empty.
+    pub fn pop(&mut self) {
+        self.stack.pop().unwrap();
+    }
+
     /// Test if call stack contains a function with given id.
     pub fn contains(&self, function_id: FunctionId) -> bool {
         self.stack

--- a/starlark/src/eval/compr.rs
+++ b/starlark/src/eval/compr.rs
@@ -23,11 +23,11 @@ use crate::eval::EvalException;
 use crate::eval::EvaluationContext;
 
 pub(crate) fn eval_one_dimensional_comprehension<
-    F: FnMut(&EvaluationContext) -> Result<(), EvalException>,
+    F: FnMut(&mut EvaluationContext) -> Result<(), EvalException>,
 >(
     expr: &mut F,
     clauses: &[AstClauseCompiled],
-    context: &EvaluationContext,
+    context: &mut EvaluationContext,
 ) -> Result<(), EvalException> {
     if let Some((first, tl)) = clauses.split_first() {
         match &first.node {

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -215,7 +215,7 @@ impl TypedValue for Def {
 
     fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
@@ -224,7 +224,7 @@ impl TypedValue for Def {
     ) -> ValueResult {
         // argument binding
         let mut ctx = EvaluationContext {
-            call_stack: call_stack.to_owned(),
+            call_stack,
             env: EvaluationContextEnvironment::Local(
                 self.captured_env.clone(),
                 IndexedLocals::new(&self.stmt.locals),

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -140,7 +140,7 @@ macro_rules! starlark_fun {
     ($(#[$attr:meta])* $fn:ident ( $($signature:tt)* ) { $($content:tt)* } $($($rest:tt)+)?) => {
         $(#[$attr])*
         fn $fn(
-            __call_stack: &$crate::eval::call_stack::CallStack,
+            __call_stack: &mut $crate::eval::call_stack::CallStack,
             __env: $crate::environment::TypeValues,
             mut args: $crate::values::function::ParameterParser,
         ) -> $crate::values::ValueResult {
@@ -156,7 +156,7 @@ macro_rules! starlark_fun {
             $($($rest:tt)+)?) => {
         $(#[$attr])*
         fn $fn(
-            __call_stack: &$crate::eval::call_stack::CallStack,
+            __call_stack: &mut $crate::eval::call_stack::CallStack,
             __env: $crate::environment::TypeValues,
             mut args: $crate::values::function::ParameterParser,
         ) -> $crate::values::ValueResult {

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -166,7 +166,7 @@ pub struct NativeFunction {
     /// Pointer to a native function.
     /// Note it is a function pointer, not `Box<Fn(...)>`
     /// to avoid generic instantiation and allocation for each native function.
-    function: fn(&CallStack, TypeValues, ParameterParser) -> ValueResult,
+    function: fn(&mut CallStack, TypeValues, ParameterParser) -> ValueResult,
     signature: FunctionSignature,
     function_type: FunctionType,
 }
@@ -254,7 +254,7 @@ impl From<FunctionError> for ValueError {
 impl NativeFunction {
     pub fn new(
         name: String,
-        function: fn(&CallStack, TypeValues, ParameterParser) -> ValueResult,
+        function: fn(&mut CallStack, TypeValues, ParameterParser) -> ValueResult,
         signature: FunctionSignature,
     ) -> Value {
         Value::new(NativeFunction {
@@ -510,7 +510,7 @@ impl TypedValue for NativeFunction {
 
     fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
@@ -553,7 +553,7 @@ impl TypedValue for WrappedMethod {
 
     fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -364,7 +364,7 @@ impl<T: TypedValue> ValueHolderDyn for ValueHolder<T> {
 
     fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
@@ -534,7 +534,7 @@ trait ValueHolderDyn {
 
     fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
@@ -728,7 +728,7 @@ pub trait TypedValue: Sized + 'static {
     /// * kwargs: if provided, the `**kwargs` argument.
     fn call(
         &self,
-        _call_stack: &CallStack,
+        _call_stack: &mut CallStack,
         _type_values: TypeValues,
         _positional: Vec<Value>,
         _named: LinkedHashMap<String, Value>,
@@ -1135,7 +1135,7 @@ impl Value {
 
     pub fn call(
         &self,
-        call_stack: &CallStack,
+        call_stack: &mut CallStack,
         type_values: TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,


### PR DESCRIPTION
Previously CallStack was copied for each function invocation.  Now
shared `&mut CallStack` is passed through evaluation, `CallStack`
object is created once per module evaluation.