### PR TITLE
Fix recursive iteration

### DIFF
--- a/starlark-test/tests/rust-testcases/freeze.sky
+++ b/starlark-test/tests/rust-testcases/freeze.sky
@@ -1,0 +1,24 @@
+def two_iterations():
+    l = [1]
+    for x in l:
+        # Second freeze of `l` must not fail
+        for y in l:
+            pass
+
+    # Assert successfully unfrozen after two iterations
+    l.append(2)
+
+two_iterations()
+
+---
+
+def mutate_after_second_in_first():
+    l = [1]
+    for x in l:
+        for y in l:
+            pass
+
+        # Test second iteration does not unfreeze
+        l.append(2)  ###  Cannot mutate an iterable while iterating
+
+mutate_after_second_in_first()


### PR DESCRIPTION
Fix this test case:

```
def f():
    l = [1]
    for x in l:
        for y in l:
            pass
f()
```

Panicked as `already frozen` before this commit.