### PR TITLE
Next attempt to implement GC

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -78,9 +78,8 @@ fn main() {
     let ast = opt.ast;
 
     let (mut global, mut type_values) = global_environment_with_extensions();
-
     print_function(&mut global, &mut type_values);
-    global.freeze();
+    global.freeze(true);
 
     let dialect = if opt.build_file {
         Dialect::Build

--- a/starlark-test/benches/rust-benches/list_append.sky
+++ b/starlark-test/benches/rust-benches/list_append.sky
@@ -1,0 +1,8 @@
+def bench():
+    x = list(range(1000))
+    r = []
+    for i in range(1000):
+        # This is `O(len(x))` if we do descendants checking
+        # and constant if we do GC
+        r.append(x)
+    return r

--- a/starlark-test/tests/go-testcases/misc.sky
+++ b/starlark-test/tests/go-testcases/misc.sky
@@ -55,23 +55,23 @@ list < {}     ###  compare not supported for types function and dict
 # cyclic data structures
 
 cyclic = [1, 2, 3] # list cycle
-cyclic[1] = cyclic  ### Unsupported recursive data structure
+cyclic[1] = cyclic
 ---
 cyclic2 = [1, 2, 3]
-cyclic2[1] = cyclic2  ### Unsupported recursive data structure
+cyclic2[1] = cyclic2
 ---
 
 cyclic3 = [1, [2, 3]] # list-list cycle
-cyclic3[1][0] = cyclic3  ### Unsupported recursive data structure
+cyclic3[1][0] = cyclic3
 ---
 cyclic4 = {"x": 1}
-cyclic4["x"] = cyclic4  ### Unsupported recursive data structure
+cyclic4["x"] = cyclic4
 ---
 cyclic5 = [0, {"x": 1}] # list-dict cycle
-cyclic5[1]["x"] = cyclic5  ### Unsupported recursive data structure
+cyclic5[1]["x"] = cyclic5
 ---
 cyclic6 = [0, {"x": 1}]
-cyclic6[1]["x"] = cyclic6  ### Unsupported recursive data structure
+cyclic6[1]["x"] = cyclic6
 ---
 # was a parse error:
 assert_eq(("ababab"[2:]).replace("b", "c"), "acac")

--- a/starlark/examples/starlark-simple-cli.rs
+++ b/starlark/examples/starlark-simple-cli.rs
@@ -35,7 +35,7 @@ pub fn simple_evaluation(starlark_input: &String) -> Result<String, String> {
     // Create a new global environment populated with the stdlib.
     let (global_env, type_values) = global_environment();
     // Extra symbols can be added to the global environment before freezing if desired.
-    global_env.freeze();
+    global_env.freeze(true);
     // Create our own local copy of the global environment.
     let mut env = global_env.child("simple-cli");
 

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -37,19 +37,23 @@ use crate::syntax::ast::Expr;
 use crate::syntax::ast::Parameter;
 use crate::syntax::ast::Statement;
 use crate::values::error::ValueError;
+use crate::values::function;
 use crate::values::function::FunctionParameter;
 use crate::values::function::FunctionSignature;
 use crate::values::function::FunctionType;
 use crate::values::function::StrOrRepr;
 use crate::values::none::NoneType;
-use crate::values::{function, Immutable, TypedValue, Value, ValueResult};
+use crate::values::ImmutableNoValues;
+use crate::values::TypedValue;
+use crate::values::Value;
+use crate::values::ValueResult;
 use codemap::{CodeMap, Spanned};
 use codemap_diagnostic::Diagnostic;
 use linked_hash_map::LinkedHashMap;
 use std::convert::TryInto;
 use std::fmt;
-use std::iter;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 #[derive(Debug, Clone)]
 pub(crate) enum ParameterCompiled {
@@ -58,6 +62,7 @@ pub(crate) enum ParameterCompiled {
     Args(AstString),
     KWArgs(AstString),
 }
+
 pub(crate) type AstParameterCompiled = Spanned<ParameterCompiled>;
 
 impl ParameterCompiled {
@@ -195,15 +200,9 @@ impl Def {
 }
 
 impl TypedValue for Def {
-    type Holder = Immutable<Def>;
+    type Holder = ImmutableNoValues<Def>;
 
     const TYPE: &'static str = "function";
-
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(iter::empty())
-    }
 
     fn to_str_impl(&self, buf: &mut String) -> fmt::Result {
         function::str_impl(buf, &self.function_type, &self.signature, StrOrRepr::Str)

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -36,6 +36,7 @@ use crate::eval::module::Module;
 use crate::eval::stmt::AstStatementCompiled;
 use crate::eval::stmt::BlockCompiled;
 use crate::eval::stmt::StatementCompiled;
+use crate::gc;
 use crate::syntax::ast::BinOp;
 use crate::syntax::ast::*;
 use crate::syntax::dialect::Dialect;
@@ -859,6 +860,7 @@ fn eval_module(
     map: Arc<Mutex<CodeMap>>,
     file_loader: Rc<dyn FileLoader>,
 ) -> EvalResult {
+    let _g = gc::push_env(&env);
     let mut call_stack = CallStack::default();
     let mut context = EvaluationContext {
         env: EvaluationContextEnvironment::Module(env.clone(), file_loader),

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -59,7 +59,7 @@ impl FileLoader for SimpleFileLoader {
         ) {
             return Err(EvalException::DiagnosedError(d));
         }
-        env.freeze();
+        env.freeze(true);
         self.map
             .lock()
             .unwrap()

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -44,10 +44,11 @@ a == [1, 2, 0] and b == [1, 2, 0]
 
 #[test]
 fn recursive_list() {
-    starlark_fail!(
+    starlark_ok!(
         r#"
 cyclic = [1, 2, 3]
 cyclic[1] = cyclic
+cyclic[1][1][1][1][1][2] == 3
 "#
     )
 }
@@ -166,7 +167,7 @@ def f(): return x
                 type_values,
             )
             .unwrap();
-            env.freeze();
+            env.freeze(true);
             Ok(env)
         }
     }

--- a/starlark/src/gc/mod.rs
+++ b/starlark/src/gc/mod.rs
@@ -1,0 +1,301 @@
+// Copyright 2018 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Garbage collector.
+
+use crate::environment::Environment;
+use crate::environment::TypeValues;
+use crate::values::DataPtr;
+use crate::values::ValueGcStrong;
+use crate::values::ValueGcWeak;
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::env;
+use std::fmt;
+use std::mem;
+use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Once;
+use std::time::Instant;
+
+static INIT_VERBOSE_ONCE: Once = Once::new();
+static VERBOSE: AtomicBool = AtomicBool::new(false);
+
+/// Should GC be verbose?
+fn verbose() -> bool {
+    INIT_VERBOSE_ONCE.call_once(|| {
+        VERBOSE.store(
+            env::var("STARLARK_RUST_GC_VERBOSE").is_ok(),
+            Ordering::Relaxed,
+        )
+    });
+    VERBOSE.load(Ordering::Relaxed)
+}
+
+/// Make GC verbose (or not).
+///
+/// Override the value of `STARLARK_RUST_GC_VERBOSE` envrionment variable.
+pub fn set_verbose(verbose: bool) {
+    VERBOSE.store(verbose, Ordering::Relaxed);
+}
+
+thread_local! {
+    /// Thread-local heap which is used to register newly created `Value` objects.
+    static HEAP: Cell<Option<Heap>> = Cell::new(None);
+}
+
+struct HeapContent {
+    /// name is for debugging
+    name: String,
+    /// Print statistics to stderr when on
+    verbose: bool,
+    /// All objects known to this heap, including unreachable
+    known_objects: Vec<ValueGcWeak>,
+    /// Number of object survived collection of weak references
+    last_weak_gc_survivors: usize,
+}
+
+/// Known objects for the environment.
+/// There's exactly one `Heap` exists for each `Environment`.
+#[derive(Clone, Debug)]
+pub struct Heap(Rc<RefCell<HeapContent>>);
+
+impl Heap {
+    pub(crate) fn new(name: &str) -> Heap {
+        Heap(Rc::new(RefCell::new(HeapContent {
+            name: name.to_owned(),
+            verbose: verbose(),
+            known_objects: Vec::new(),
+            last_weak_gc_survivors: 0,
+        })))
+    }
+}
+
+impl HeapContent {
+    fn gc(&mut self, roots: &Environment, reason: &str) {
+        let start = if self.verbose {
+            Some(Instant::now())
+        } else {
+            None
+        };
+
+        if self.verbose {
+            eprintln!("GC {} start because {}", self.name, reason);
+        }
+
+        // Upgrade known objects to strong reference
+        // * to obtain data pointers
+        // * to collect them
+        let known_objects: Vec<ValueGcStrong> = mem::replace(&mut self.known_objects, Vec::new())
+            .into_iter()
+            .flat_map(|v| v.upgrade())
+            .collect();
+
+        // Pointers to all objects known to this heap
+        let known_object_ptrs: HashSet<DataPtr> =
+            known_objects.iter().map(ValueGcStrong::data_ptr).collect();
+
+        // GC roots
+        let root_objects = roots.roots();
+
+        // Mark phase
+
+        // Objects reachable from roots
+        let mut alive: HashSet<DataPtr> = HashSet::new();
+
+        let mut queue = root_objects;
+        while let Some(object) = queue.pop() {
+            // Already seen the object
+            if !alive.insert(object.data_ptr()) {
+                continue;
+            }
+
+            object.visit_links(&mut |link| {
+                let link = match link.to_gc_strong() {
+                    Some(link) => link,
+                    None => {
+                        // GC doesn't care about ints or strings
+                        return;
+                    }
+                };
+
+                if !known_object_ptrs.contains(&link.data_ptr()) {
+                    // Object from another heap
+                    return;
+                }
+
+                queue.push(link);
+            });
+        }
+
+        // Sweep phase
+
+        let mut new_known_objects = Vec::new();
+        for object in known_objects {
+            if !alive.contains(&object.data_ptr()) {
+                object.gc();
+            } else {
+                new_known_objects.push(object.downgrade());
+            }
+        }
+        self.known_objects = new_known_objects;
+
+        if let Some(start) = start {
+            eprintln!("GC {} took {}us", self.name, start.elapsed().as_micros());
+        }
+    }
+
+    fn gc_on_drop(&mut self) {
+        if self.verbose {
+            eprintln!(
+                "GC {} on drop for {} objects...",
+                self.name,
+                self.known_objects.len()
+            );
+        }
+        for object in mem::replace(&mut self.known_objects, Vec::new()) {
+            let object = match object.upgrade() {
+                Some(object) => object,
+                None => continue,
+            };
+            object.gc();
+        }
+        if self.verbose {
+            eprintln!("GC {} on drop done", self.name);
+        }
+    }
+
+    /// Clean-up weak object references, not a proper GC.
+    fn gc_weak(&mut self, reason: &str) {
+        if self.verbose {
+            eprintln!(
+                "light GC {} because {} for {} weak references...",
+                self.name,
+                reason,
+                self.known_objects.len()
+            );
+        }
+        self.known_objects.retain(ValueGcWeak::is_alive);
+        self.last_weak_gc_survivors = self.known_objects.len();
+        if self.verbose {
+            eprintln!(
+                "light GC {} because {} survived {} objects",
+                self.name,
+                reason,
+                self.known_objects.len()
+            );
+        }
+    }
+
+    fn gc_weak_if_needed(&mut self) {
+        // Do GC only if number of object is twice as previously alive
+        // to keep this operation constant
+        if self.known_objects.len() >= 17
+            && self.known_objects.len() >= self.last_weak_gc_survivors * 2
+        {
+            self.gc_weak("register");
+        }
+    }
+
+    fn register(&mut self, object: ValueGcWeak) {
+        self.gc_weak_if_needed();
+        self.known_objects.push(object);
+    }
+}
+
+impl fmt::Debug for HeapContent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("HeapContent")
+            .field("name", &self.name)
+            .field("verbose", &self.verbose)
+            .field("objects", &self.known_objects.len())
+            .field("last_weak_gc_survivors", &self.last_weak_gc_survivors)
+            .finish()
+    }
+}
+
+impl Drop for HeapContent {
+    fn drop(&mut self) {
+        self.gc_on_drop();
+    }
+}
+
+impl Heap {
+    pub fn gc(&self, roots: &Environment, reason: &str) {
+        self.0.borrow_mut().gc(roots, reason)
+    }
+
+    pub fn gc_weak(&self, reason: &str) {
+        self.0.borrow_mut().gc_weak(reason);
+    }
+}
+
+pub(crate) fn register(object: ValueGcWeak) {
+    with_heap(|heap| {
+        heap.0.borrow_mut().register(object);
+    });
+}
+
+struct SetOnDrop(Option<Heap>);
+
+impl Drop for SetOnDrop {
+    fn drop(&mut self) {
+        HEAP.with(|cell| cell.set(mem::replace(&mut self.0, None)));
+    }
+}
+
+/// Panics if thread-local heap is not set
+fn with_heap<F, R>(f: F) -> R
+where
+    F: FnOnce(&Heap) -> R,
+{
+    HEAP.with(|cell| {
+        let heap = cell.replace(None);
+        let set_on_drop = SetOnDrop(heap);
+        let heap = set_on_drop.0.as_ref().expect("thread-local GC is not set");
+        f(heap)
+    })
+}
+
+fn _heap() -> Option<Heap> {
+    HEAP.with(|cell| {
+        let heap = cell.replace(None);
+        let set_on_drop = SetOnDrop(heap);
+        set_on_drop.0.clone()
+    })
+}
+
+/// Will reset previous environment on drop.
+#[must_use]
+pub struct HeapGuard(SetOnDrop);
+
+/// Set a thread-local environment which is used for registration
+/// of newly created values. Returned value restores previous heap value on drop.
+pub fn push_env(env: &Environment) -> HeapGuard {
+    let old_heap = HEAP.with(|cell| cell.replace(Some(env.heap())));
+    HeapGuard(SetOnDrop(old_heap))
+}
+
+/// Set a thread-local environment which is used for registration
+/// of newly created values. Returned value restores previous heap value on drop.
+#[doc(hidden)] // used only from macros
+pub fn push_type_values(type_values: &TypeValues) -> HeapGuard {
+    let old_heap = HEAP.with(|cell| cell.replace(Some(type_values.heap())));
+    HeapGuard(SetOnDrop(old_heap))
+}
+
+#[cfg(test)]
+mod tests;

--- a/starlark/src/gc/tests.rs
+++ b/starlark/src/gc/tests.rs
@@ -1,0 +1,269 @@
+use crate::environment::Environment;
+use crate::gc;
+use crate::values::list::List;
+use crate::values::ImmutableNoValues;
+use crate::values::TypedValue;
+use crate::values::Value;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+/// A value which increments a counter on drop
+#[derive(Default)]
+struct DropCanary {
+    drop_count: Arc<AtomicUsize>,
+}
+
+impl TypedValue for DropCanary {
+    type Holder = ImmutableNoValues<Self>;
+    const TYPE: &'static str = "canary";
+}
+
+impl Drop for DropCanary {
+    fn drop(&mut self) {
+        if gc::verbose() {
+            eprintln!("canary drop");
+        }
+        self.drop_count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn immutable_no_values() {
+    let env = Environment::new("test");
+    let _g = gc::push_env(&env);
+
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+
+    // immutable values without references are not recorded in heap
+    Value::new(1);
+
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+}
+
+#[test]
+fn immutable_with_values() {
+    let env = Environment::new("test");
+    let _g = gc::push_env(&env);
+
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+
+    // immutable values with possible references are recorded in heap
+    Value::from((10, "true"));
+
+    assert_eq!(1, env.heap().0.borrow().known_objects.len());
+    // object is recorded, but it is already destroyed
+    assert!(env.heap().0.borrow().known_objects[0].upgrade().is_none());
+
+    // explicitly call GC
+    env.heap().gc(&env, "explicit");
+
+    // and the object is gone
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+}
+
+#[test]
+fn register_clears_old_weaks() {
+    let env = Environment::new("test");
+    let _g = gc::push_env(&env);
+
+    for _ in 0..1000 {
+        // create a new list, which immediately becomes a weak reference
+        Value::from(Vec::<Value>::new());
+        assert!(env.heap().0.borrow().known_objects.len() < 50);
+    }
+}
+
+#[test]
+fn cycle_is_cleared() {
+    let env = Environment::new("test");
+    let _g = gc::push_env(&env);
+
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+
+    let list = Value::from(Vec::<Value>::new());
+    // it is cyclic list now
+    list.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(list.clone());
+
+    assert_eq!(1, env.heap().0.borrow().known_objects.len());
+
+    // keep a week reference to test later
+    let list = {
+        let list = list;
+        list.to_gc_strong().unwrap().downgrade()
+    };
+
+    // heap still contains this object as alive because it references itself
+    assert!(env.heap().0.borrow().known_objects[0]
+        .clone()
+        .upgrade()
+        .is_some());
+
+    env.heap().gc(&env, "explicit");
+
+    // list is gone
+    assert_eq!(0, env.heap().0.borrow().known_objects.len());
+    // it is actually gone
+    assert!(list.upgrade().is_none());
+}
+
+#[test]
+fn list_in_tuple_is_dropped_after_freeze() {
+    // ```
+    // l = []
+    // l.append(l)
+    // global.t = (l,)
+    // ```
+    // Global variable is immutable, but holds a mutable object with cycles.
+    // Test that object is dropped.
+
+    let env = Environment::new("test");
+    let g = gc::push_env(&env);
+
+    let drop_canary = DropCanary::default();
+    let drop_count = drop_canary.drop_count.clone();
+
+    let l = List::new();
+    l.downcast_mut::<List>().unwrap().unwrap().push(l.clone());
+    l.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(Value::new(drop_canary));
+
+    let t = Value::from((l,));
+    env.set("t", t).unwrap();
+
+    env.freeze(true);
+
+    assert_eq!(0, drop_count.load(Ordering::SeqCst));
+    drop(env);
+    drop(g);
+    assert_eq!(1, drop_count.load(Ordering::SeqCst));
+}
+
+#[test]
+fn list_in_tuple_is_dropped_without_freeze() {
+    // This scenario:
+    // ```
+    // l = []
+    // l.append(l)
+    // global.t = (l,)
+    // ```
+    // Global variable is immutable, but holds a mutable object with cycles.
+    // Test that object is dropped.
+
+    let env = Environment::new("test");
+    let g = gc::push_env(&env);
+
+    let drop_canary = DropCanary::default();
+    let drop_count = drop_canary.drop_count.clone();
+
+    let l = List::new();
+    l.downcast_mut::<List>().unwrap().unwrap().push(l.clone());
+    l.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(Value::new(drop_canary));
+
+    let t = Value::from((l,));
+    env.set("t", t).unwrap();
+
+    assert_eq!(0, drop_count.load(Ordering::SeqCst));
+    drop(env);
+    drop(g);
+    assert_eq!(1, drop_count.load(Ordering::SeqCst));
+}
+
+#[test]
+fn imported_value_is_not_collected() {
+    let parent = Environment::new("parent");
+    let g = gc::push_env(&parent);
+
+    let l = List::new();
+    l.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(Value::from(17));
+    parent.set("l", l).unwrap();
+
+    drop(g);
+
+    // `.child` does `freeze` which does GC
+    let child = parent.child("child");
+
+    // Parent still contains original list
+    assert_eq!("[17]", parent.get("l").unwrap().to_str());
+
+    child.set("l", parent.get("l").unwrap()).unwrap();
+    // Do GC in child
+    child.freeze(true);
+
+    // Parent and child still contain original list
+    assert_eq!("[17]", parent.get("l").unwrap().to_str());
+    assert_eq!("[17]", child.get("l").unwrap().to_str());
+
+    drop(child);
+    // Parent value is not collected
+    assert_eq!("[17]", parent.get("l").unwrap().to_str());
+}
+
+#[test]
+fn child_env_prevents_parent_drop() {
+    let parent = Environment::new("parent");
+    let g = gc::push_env(&parent);
+
+    let l = List::new();
+    l.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(Value::from(19));
+    parent.set("l", l).unwrap();
+
+    drop(g);
+
+    let child = parent.child("child");
+    child.set("l", parent.get("l").unwrap()).unwrap();
+
+    // Even if we no longer have a reference to parent,
+    // child content has a reference, so `l` is not collected
+    drop(parent);
+    assert_eq!("[19]", child.get("l").unwrap().to_str());
+}
+
+#[test]
+fn freeze_without_gc() {
+    // This scenario:
+    // ```
+    // l = []
+    // l.append(l)
+    // global.t = (l,)
+    // ```
+    let env = Environment::new("test");
+    let g = gc::push_env(&env);
+
+    let drop_canary = DropCanary::default();
+    let drop_count = drop_canary.drop_count.clone();
+
+    let l = List::new();
+    l.downcast_mut::<List>().unwrap().unwrap().push(l.clone());
+    l.downcast_mut::<List>()
+        .unwrap()
+        .unwrap()
+        .push(Value::new(drop_canary));
+
+    let t = Value::from((l,));
+    env.set("t", t).unwrap();
+
+    // Freeze without GC
+    env.freeze(false);
+
+    // `t` and `l`
+    assert_eq!(2, env.heap().0.borrow_mut().known_objects.len());
+
+    drop(g);
+    drop(env);
+    assert_eq!(1, drop_count.load(Ordering::SeqCst));
+}

--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -82,4 +82,5 @@ pub mod values;
 pub mod eval;
 #[macro_use]
 pub mod stdlib;
+pub mod gc;
 pub mod linked_hash_set;

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -49,7 +49,7 @@ starlark_module! {global =>
     /// ```
     list.append(this, el, /) {
         let mut this = this.downcast_mut::<List>()?.unwrap();
-        this.push(el)?;
+        this.push(el);
         Ok(Value::new(NoneType::None))
     }
 

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -345,6 +345,8 @@ macro_rules! starlark_module {
 
         #[doc(hidden)]
         pub fn $name(env: &mut $crate::environment::Environment, type_values: &mut $crate::environment::TypeValues) {
+            // Thread-local env is needed to register default value objects
+            let _g = $crate::gc::push_type_values(type_values);
             starlark_signatures!{ env, type_values,
                 $($t)*
             }

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -123,6 +123,7 @@ impl<T: TryParamConvertFromValue> TryParamConvertFromValue for EitherValueOrNone
 
 #[cfg(test)]
 mod test {
+    use crate::gc;
     use crate::starlark_fun;
     use crate::starlark_module;
     use crate::starlark_parse_param_type;
@@ -148,9 +149,9 @@ mod test {
     fn test_simple() {
         let (mut env, mut type_values) = global_environment();
         global(&mut env, &mut type_values);
-        env.freeze();
 
         let mut child = env.child("my");
+        let _g = gc::push_env(&child);
 
         let r = eval(
             &Arc::new(Mutex::new(CodeMap::new())),

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -972,7 +972,7 @@ pub fn global_environment_with_extensions() -> (Environment, TypeValues) {
 pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     let (env, type_values) = global_environment_with_extensions();
-    let mut test_env = env.freeze().child("test");
+    let mut test_env = env.child("test");
     match eval(
         &map,
         "<test>",
@@ -1002,7 +1002,7 @@ pub mod tests {
     pub fn starlark_default_fail(snippet: &str) -> Result<bool, Diagnostic> {
         let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
         let (env, type_values) = global_environment();
-        let mut env = env.freeze().child("test");
+        let mut env = env.child("test");
         match eval(
             &map,
             "<test>",

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -1336,6 +1336,8 @@ mod tests {
     use super::super::starlark_default;
     use super::super::tests::starlark_default_fail;
     use super::*;
+    use crate::environment::Environment;
+    use crate::gc;
     use crate::values::dict;
 
     macro_rules! starlark_ok {
@@ -1348,6 +1350,9 @@ mod tests {
 
     #[test]
     fn test_format_capture() {
+        let env = Environment::new("test");
+        let _g = gc::push_env(&env);
+
         let args = Value::from(vec!["1", "2", "3"]);
         let mut kwargs = dict::Dictionary::new();
         let it = args.iter().unwrap();

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -28,10 +28,10 @@ pub struct StarlarkStruct {
 impl TypedValue for StarlarkStruct {
     type Holder = Immutable<StarlarkStruct>;
 
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(self.fields.values().cloned())
+    fn visit_links(&self, visitor: &mut dyn FnMut(&Value)) {
+        for v in self.fields.values() {
+            visitor(v);
+        }
     }
 
     fn to_repr_impl(&self, buf: &mut String) -> fmt::Result {

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -18,7 +18,6 @@ use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
 use std::fmt;
-use std::iter;
 
 impl From<bool> for Value {
     fn from(b: bool) -> Self {
@@ -28,7 +27,7 @@ impl From<bool> for Value {
 
 /// Define the bool type
 impl TypedValue for bool {
-    type Holder = Immutable<Self>;
+    type Holder = ImmutableNoValues<Self>;
     const TYPE: &'static str = "bool";
 
     fn new_value(self) -> Value {
@@ -46,12 +45,6 @@ impl TypedValue for bool {
     }
     fn get_hash(&self) -> Result<u64, ValueError> {
         Ok(self.to_int().unwrap() as u64)
-    }
-
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(iter::empty())
     }
 
     fn equals(&self, other: &bool) -> Result<bool, ValueError> {

--- a/starlark/src/values/cell/error.rs
+++ b/starlark/src/values/cell/error.rs
@@ -14,13 +14,16 @@
 
 //! Cell-related errors.
 
+use crate::values::cell::header::FrozenState;
 use std::fmt;
 
 /// Error when borrow failed.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ObjectBorrowError {
-    /// Can only fail if object is mutably borrowed
-    BorrowedMut,
+    /// Borrowed mutably
+    BorrowedMut(FrozenState),
+    /// Object is garbage-collected
+    Collected,
 }
 
 /// Object cannot be mutably borrowed.
@@ -33,9 +36,11 @@ pub enum ObjectBorrowMutError {
     /// Object is frozen for iteration
     FrozenForIteration,
     /// Object is already mutably borrowed
-    BorrowedMut,
+    BorrowedMut(FrozenState),
     /// Object is borrowed
-    Borrowed,
+    Borrowed(FrozenState),
+    /// Object is garbage-collected
+    Collected,
 }
 
 impl fmt::Display for ObjectBorrowMutError {
@@ -46,8 +51,12 @@ impl fmt::Display for ObjectBorrowMutError {
             ObjectBorrowMutError::FrozenForIteration => {
                 write!(f, "Cannot mutate an iterable while iterating")
             }
-            ObjectBorrowMutError::BorrowedMut => write!(f, "Borrowed mutably"),
-            ObjectBorrowMutError::Borrowed => write!(f, "Borrowed"),
+            ObjectBorrowMutError::BorrowedMut(FrozenState::No) => write!(f, "Borrowed mutably"),
+            ObjectBorrowMutError::BorrowedMut(FrozenState::Yes) => {
+                write!(f, "Frozen and borrowed mutably")
+            }
+            ObjectBorrowMutError::Borrowed(..) => write!(f, "Borrowed"),
+            ObjectBorrowMutError::Collected => write!(f, "Garbage-collected"),
         }
     }
 }

--- a/starlark/src/values/cell/mod.rs
+++ b/starlark/src/values/cell/mod.rs
@@ -42,11 +42,11 @@ impl<'b, T: ?Sized + 'b> ObjectRef<'b, T> {
         }
     }
 
-    /// A reference to immutable value
-    pub fn immutable(value: &T) -> ObjectRef<T> {
+    /// A reference to immutable frozen value
+    pub fn immutable_frozen(value: &T) -> ObjectRef<T> {
         ObjectRef {
             value,
-            borrow: ObjectBorrowRef::immutable(),
+            borrow: ObjectBorrowRef::immutable_frozen(),
         }
     }
 
@@ -164,10 +164,12 @@ impl<T: ?Sized> ObjectCell<T> {
 
     /// Mark value as frozen.
     ///
+    /// Return `true` if the object was not frozen before.
+    ///
     /// # Panics
     ///
     /// If value is borrowed.
-    pub fn freeze(&self) {
-        self.header.freeze();
+    pub fn freeze(&self) -> bool {
+        self.header.freeze()
     }
 }

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -76,9 +76,7 @@ impl Dictionary {
     }
 
     pub fn insert(&mut self, key: Value, value: Value) -> Result<(), ValueError> {
-        let key = key.clone_for_container(self)?;
         let key = HashedValue::new(key)?;
-        let value = value.clone_for_container(self)?;
         self.content.insert(key, value);
         Ok(())
     }
@@ -132,15 +130,15 @@ impl<T1: Into<Value> + Hash + Eq + Clone, T2: Into<Value> + Eq + Clone>
 impl TypedValue for Dictionary {
     type Holder = Mutable<Dictionary>;
 
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        // XXX: We cannot freeze the key because they are immutable in rust, is it important?
-        Box::new(
-            self.content
-                .iter()
-                .flat_map(|(k, v)| vec![k.get_value().clone(), v.clone()].into_iter()),
-        )
+    fn gc(&mut self) {
+        self.content.clear();
+    }
+
+    fn visit_links(&self, visitor: &mut dyn FnMut(&Value)) {
+        for (k, v) in &self.content {
+            visitor(k.get_value());
+            visitor(v);
+        }
     }
 
     fn to_repr_impl(&self, buf: &mut String) -> fmt::Result {
@@ -202,7 +200,6 @@ impl TypedValue for Dictionary {
 
     fn set_at(&mut self, index: Value, new_value: Value) -> Result<(), ValueError> {
         let index_key = HashedValue::new(index)?;
-        let new_value = new_value.clone_for_container(self)?;
         {
             if let Some(x) = self.content.get_mut(&index_key) {
                 *x = new_value;
@@ -260,9 +257,14 @@ impl<T1: Into<Value> + Eq + Hash + Clone, T2: Into<Value> + Eq + Clone>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::environment::Environment;
+    use crate::gc;
 
     #[test]
     fn test_mutate_dict() {
+        let env = Environment::new("test");
+        let _g = gc::push_env(&env);
+
         let mut map = LinkedHashMap::<HashedValue, Value>::new();
         map.insert(HashedValue::new(Value::from(1)).unwrap(), Value::from(2));
         map.insert(HashedValue::new(Value::from(2)).unwrap(), Value::from(4));
@@ -272,28 +274,5 @@ mod tests {
         assert_eq!("{1: 2, 2: 3}", d.to_str());
         d.set_at(Value::from((3, 4)), Value::from(5)).unwrap();
         assert_eq!("{1: 2, 2: 3, (3, 4): 5}", d.to_str());
-    }
-
-    #[test]
-    fn test_is_descendant() {
-        let mut map = LinkedHashMap::<HashedValue, Value>::new();
-        map.insert(HashedValue::new(Value::from(1)).unwrap(), Value::from(2));
-        map.insert(HashedValue::new(Value::from(2)).unwrap(), Value::from(4));
-        let v1 = Value::try_from(map.clone()).unwrap();
-        map.insert(HashedValue::new(Value::from(3)).unwrap(), v1.clone());
-        let v2 = Value::try_from(map.clone()).unwrap();
-        map.insert(HashedValue::new(Value::from(3)).unwrap(), v2.clone());
-        let v3 = Value::try_from(map).unwrap();
-        assert!(v3.is_descendant_value(&v2));
-        assert!(v3.is_descendant_value(&v1));
-        assert!(v3.is_descendant_value(&v3));
-
-        assert!(v2.is_descendant_value(&v1));
-        assert!(v2.is_descendant_value(&v2));
-        assert!(!v2.is_descendant_value(&v3));
-
-        assert!(v1.is_descendant_value(&v1));
-        assert!(!v1.is_descendant_value(&v2));
-        assert!(!v1.is_descendant_value(&v3));
     }
 }

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -18,7 +18,6 @@ use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
 use std::fmt;
-use std::iter;
 
 // A convenient macro for testing and documentation.
 #[macro_export]
@@ -81,7 +80,7 @@ where
 
 /// Define the int type
 impl TypedValue for i64 {
-    type Holder = Immutable<Self>;
+    type Holder = ImmutableNoValues<Self>;
     const TYPE: &'static str = "int";
 
     fn new_value(self) -> Value {
@@ -159,12 +158,6 @@ impl TypedValue for i64 {
                 None => Err(ValueError::IntegerOverflow),
             }
         })
-    }
-
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(iter::empty())
     }
 
     fn compare(&self, other: &i64) -> Result<Ordering, ValueError> {

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -18,7 +18,6 @@ use crate::values::error::ValueError;
 use crate::values::*;
 use std::cmp::Ordering;
 use std::fmt;
-use std::iter;
 
 /// Define the NoneType type
 #[derive(Debug, Clone, Copy)]
@@ -28,7 +27,7 @@ pub enum NoneType {
 
 /// Define the NoneType type
 impl TypedValue for NoneType {
-    type Holder = Immutable<Self>;
+    type Holder = ImmutableNoValues<Self>;
     const TYPE: &'static str = "NoneType";
 
     fn new_value(self) -> Value {
@@ -40,12 +39,6 @@ impl TypedValue for NoneType {
     }
     fn compare(&self, _other: &NoneType) -> Result<Ordering, ValueError> {
         Ok(Ordering::Equal)
-    }
-
-    fn values_for_descendant_check_and_freeze<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = Value> + 'a> {
-        Box::new(iter::empty())
     }
 
     fn to_repr_impl(&self, buf: &mut String) -> fmt::Result {

--- a/starlark/src/values/range.rs
+++ b/starlark/src/values/range.rs
@@ -15,10 +15,12 @@
 //! `range()` builtin implementation
 
 use crate::values::iter::TypedIterable;
-use crate::values::{Immutable, TypedValue, Value, ValueError};
+use crate::values::ImmutableNoValues;
+use crate::values::TypedValue;
+use crate::values::Value;
+use crate::values::ValueError;
 use std::fmt;
 use std::fmt::Write as _;
-use std::iter;
 use std::mem;
 use std::num::NonZeroI64;
 
@@ -197,11 +199,7 @@ impl TypedValue for Range {
         }
     }
 
-    type Holder = Immutable<Range>;
-
-    fn values_for_descendant_check_and_freeze(&self) -> Box<dyn Iterator<Item = Value>> {
-        Box::new(iter::empty())
-    }
+    type Holder = ImmutableNoValues<Range>;
 }
 
 /// For tests

--- a/starlark/src/values/string/interpolation.rs
+++ b/starlark/src/values/string/interpolation.rs
@@ -346,12 +346,17 @@ impl ArgsFormat {
 
 #[cfg(test)]
 mod test {
+    use crate::environment::Environment;
+    use crate::gc;
     use crate::values::Value;
     use std::collections::HashMap;
     use std::convert::TryFrom;
 
     #[test]
     fn test_string_interpolation() {
+        let env = Environment::new("test");
+        let _g = gc::push_env(&env);
+
         // "Hello %s, your score is %d" % ("Bob", 75) == "Hello Bob, your score is 75"
         assert_eq!(
             Value::from("Hello %s, your score is %d")


### PR DESCRIPTION
This PR depends on freeze change (#233).

This is the description from the second commit.

This is a much simpler version of GC.

Major differences between this implementation and the previous attempt:
* GC is environment-local now (each environment tracks own objects)
* GC is only performed once at freeze

However, these options dramatically increase the number of possible
trade-offs in the implementation (if we need to keep GC low overhead),
so I choose to not do GC at all until environment freezes.  More
granular GC can be added later if necessary.

Objects are still reference counted, so additional memory overhead
occurs only if cycles are actually created, and unreachable objects
released when the environment is frozen. Which is an acceptable trade-off
given the typical use case os Starlark: short-lived scripts.

A detailed explanation of how the algorithm works:

Each `Environment` has an associated `Heap` object, there's 1-1
mapping between them.

Previously each object was either mutable or immutable (it was
a field in `TypedValue`). Now there are three kinds of objects:
* immutable without links (strings)
* immutable with links (tuples)
* mutable with links (lists, sets, ...)

Each time `Value` with links is created, a weak reference is registered
in the lists of known objects.

`gc_weak` is invoked when too many new objects registered to check
if some weak references can be removed because objects were dropped
by refcounter:

```
struct Heap {
    known_objects: Vec<ValueWeak>,
}

impl Heap {
    fn register(&mut self, object: ValueWeak) {
        if self.known_objects.len() >= 2 * self.last_weak_gc_survivors {
            self.gc_weak();
        }
        self.known_objects.push(object);
    }

    fn gc_weak(&mut self) {
        self.known_objects.retain(ValueWeak::is_alive);
    }
}
```

When the environment is frozen, full GC is invoked. GC takes roots from
Environments (global variables, but not variables from the parent
environments or imported variables), traverses the object graph but
only within objects known to the current environment (see above), and
creates a set of alive objects. GC algorithm sketch is:

```
impl Heap {
    fn gc(&mut self, env: Environment) {
        // take globals from the environment,
        // but not imported and not from parents
        let roots = env.roots();

        let mut alive_objects = HashSet::new();
        let mut queue = roots;
        while let Some(object) = queue.pop() {
            // stop traversing when:
            // * object was not created in this environment
            // * object does not have links (e. g. string)
            if !self.objects.contains(object) {
                continue;
            }

            // mark object as alive
            if !alive_objects.insert(object) {
                // is already marked, skip it
                continue;
            }

            queue.extend(object.get_links());
        }

        for object in self.known_objects {
            if object in alive {
                // keep it
            } else {
                // break cycle
                object.gc();
                remove from self.known_objects
            }
        }
    }
}
```

Finally when `Environment` is dropped, for all known objects `gc`
function is invoked to break links cycles.