### PR TITLE
Constant propagation into function scope

### DIFF
--- a/starlark-test/benches/rust-benches/globals.sky
+++ b/starlark-test/benches/rust-benches/globals.sky
@@ -1,0 +1,15 @@
+my_module = struct(
+    const = 17,
+    more_consts = (True, None, 19)
+)
+
+d = {
+    "a": 23,
+}
+
+def bench():
+    return (
+        my_module.const,
+        my_module.more_consts[2],
+        d["a"],
+    )

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -162,7 +162,7 @@ impl Environment {
     /// Freeze the environment, all its value will become immutable after that
     pub fn freeze(&self) -> &Self {
         if !self.env.get_header_copy().is_mutable_frozen() {
-            self.env.borrow_mut().freeze();
+            self.env.borrow().freeze_values();
             self.env.freeze();
         }
         self
@@ -237,10 +237,8 @@ impl Environment {
 }
 
 impl EnvironmentContent {
-    /// Create a new child environment
-    /// Freeze the environment, all its value will become immutable after that
-    pub fn freeze(&mut self) {
-        for v in self.variables.values_mut() {
+    fn freeze_values(&self) {
+        for v in self.variables.values() {
             v.freeze();
         }
     }

--- a/starlark/src/environment/mod.rs
+++ b/starlark/src/environment/mod.rs
@@ -238,6 +238,12 @@ impl Environment {
 
 impl EnvironmentContent {
     fn freeze_values(&self) {
+        // Must optimize before freeze, because it's not possible
+        // to borrow mutably after freeze.
+        for d in &self.defs {
+            d.borrow_mut().optimize_on_freeze();
+        }
+
         for v in self.variables.values() {
             v.freeze();
         }

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -205,6 +205,12 @@ pub(crate) struct Def {
     stmt: DefCompiled,
 }
 
+impl fmt::Debug for Def {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Def").field("...", &"...").finish()
+    }
+}
+
 impl Def {
     pub fn new(
         module: RcString,

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -14,7 +14,19 @@
 
 //! Implementation of `def`.
 
-use crate::environment::{Environment, TypeValues};
+use std::convert::TryInto;
+use std::fmt;
+use std::iter;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use codemap::CodeMap;
+use codemap::Spanned;
+use codemap_diagnostic::Diagnostic;
+use linked_hash_map::LinkedHashMap;
+
+use crate::environment::Environment;
+use crate::environment::TypeValues;
 use crate::eval::call_stack::CallStack;
 use crate::eval::compiler::LocalCompiler;
 use crate::eval::eval_block;
@@ -49,19 +61,11 @@ use crate::values::function::StrOrRepr;
 use crate::values::inspect::Inspectable;
 use crate::values::none::NoneType;
 use crate::values::string::rc::RcString;
-use crate::values::Immutable;
+use crate::values::Mutable;
 use crate::values::TypedValue;
 use crate::values::Value;
 use crate::values::ValueOther;
 use crate::values::ValueResult;
-use codemap::CodeMap;
-use codemap::Spanned;
-use codemap_diagnostic::Diagnostic;
-use linked_hash_map::LinkedHashMap;
-use std::convert::TryInto;
-use std::fmt;
-use std::iter;
-use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub(crate) enum ParameterCompiled {
@@ -70,6 +74,7 @@ pub(crate) enum ParameterCompiled {
     Args(AstString),
     KWArgs(AstString),
 }
+
 pub(crate) type AstParameterCompiled = Spanned<ParameterCompiled>;
 
 impl ParameterCompiled {
@@ -230,10 +235,15 @@ impl Def {
             map,
         })
     }
+
+    pub fn optimize_on_freeze(&mut self) {
+        // TODO: optimize
+    }
 }
 
 impl TypedValue for Def {
-    type Holder = Immutable<Def>;
+    /// Must be mutable to be able to [optimize on free](Def::optimize_on_freeze).
+    type Holder = Mutable<Def>;
 
     const TYPE: &'static str = "function";
 

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -17,6 +17,7 @@
 use std::convert::TryInto;
 use std::fmt;
 use std::iter;
+use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -202,8 +203,15 @@ impl DefCompiled {
         }
     }
 
+    fn optimize_on_freeze(&mut self, captured_env: &Environment) {
+        self.suite = BlockCompiled::optimize_on_freeze(
+            mem::replace(&mut self.suite, BlockCompiled::default()),
+            captured_env,
+        );
+    }
+
     pub(crate) fn fmt_for_test(&self, f: &mut dyn fmt::Write, tab: &str) -> fmt::Result {
-        write!(f, "{}def {}(", tab, self.name.node)?;
+        write!(f, "def {}(", self.name.node)?;
         for (i, p) in self.params.iter().enumerate() {
             if i != 0 {
                 write!(f, ", ")?;
@@ -261,7 +269,7 @@ impl Def {
     }
 
     pub fn optimize_on_freeze(&mut self) {
-        // TODO: optimize
+        self.stmt.optimize_on_freeze(&self.captured_env);
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/starlark/src/eval/stmt.rs
+++ b/starlark/src/eval/stmt.rs
@@ -83,7 +83,11 @@ impl StatementCompiled {
                 }
                 StatementCompiled::Expression(expr) => {
                     let expr = ExprCompiled::optimize_on_freeze(expr, captured_env);
-                    StatementCompiled::Expression(expr)
+                    if let Ok(_) = expr.node.pure() {
+                        return Vec::new();
+                    } else {
+                        StatementCompiled::Expression(expr)
+                    }
                 }
                 StatementCompiled::IfElse(cond, then_block, else_block) => {
                     let then_block = BlockCompiled::optimize_on_freeze(then_block, captured_env);
@@ -383,6 +387,19 @@ L = {}
 def f():
   for x in L:
     return 1
+",
+            "\
+def f():
+",
+        );
+    }
+
+    #[test]
+    fn prune_statement_expr() {
+        test_optimize_on_freeze(
+            "\
+def f():
+  1
 ",
             "\
 def f():

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -120,6 +120,7 @@ impl From<Set> for Value {
 
 impl TypedValue for Set {
     type Holder = Mutable<Set>;
+    const PURE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -34,6 +34,7 @@ impl StarlarkStruct {
 
 impl TypedValue for StarlarkStruct {
     type Holder = Immutable<StarlarkStruct>;
+    const PURE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,

--- a/starlark/src/syntax/ast.rs
+++ b/starlark/src/syntax/ast.rs
@@ -15,6 +15,7 @@
 //! AST for parsed starlark files.
 
 use super::lexer;
+use crate::eval::expr::AssignTargetExprCompiled;
 use crate::eval::locals::LocalsBuilder;
 use crate::syntax::fmt::comma_separated_fmt;
 use crate::syntax::fmt::fmt_string_literal;
@@ -169,6 +170,31 @@ pub enum AssignTargetExpr {
     Subtargets(Vec<AstAssignTargetExpr>),
 }
 to_ast_trait!(AssignTargetExpr, AstAssignTargetExpr);
+
+impl fmt::Display for AssignTargetExprCompiled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AssignTargetExprCompiled::Dot(object, field) => {
+                write!(f, "{}.{}", object.node, field.node)
+            }
+            AssignTargetExprCompiled::ArrayIndirection(array, index) => {
+                write!(f, "{}[{}]", array.node, index.node)
+            }
+            AssignTargetExprCompiled::Name(n) => write!(f, "{}", n.name),
+            AssignTargetExprCompiled::Subtargets(subtargets) => {
+                write!(f, "[")?;
+                for (i, s) in subtargets.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                        s.node.fmt(f)?;
+                    }
+                }
+                write!(f, "]")?;
+                Ok(())
+            }
+        }
+    }
+}
 
 /// `x` in `x += a`
 #[doc(hidden)]

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -31,6 +31,7 @@ impl From<bool> for Value {
 impl TypedValue for bool {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "bool";
+    const PURE: bool = true;
 
     const INLINE: bool = true;
 

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -131,6 +131,7 @@ impl<T1: Into<Value> + Hash + Eq + Clone, T2: Into<Value> + Eq + Clone>
 /// Define the Dictionary type
 impl TypedValue for Dictionary {
     type Holder = Mutable<Dictionary>;
+    const PURE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,

--- a/starlark/src/values/frozen.rs
+++ b/starlark/src/values/frozen.rs
@@ -47,6 +47,12 @@ impl FrozenValue {
         }
     }
 
+    /// Freeze a value.
+    pub fn freeze(value: Value) -> FrozenValue {
+        value.freeze();
+        FrozenValue(value)
+    }
+
     /// Get a reference to a [`Value`] held inside this.
     pub fn get_ref(&self) -> &Value {
         &self.0

--- a/starlark/src/values/frozen.rs
+++ b/starlark/src/values/frozen.rs
@@ -16,6 +16,7 @@
 
 use crate::values::TypedValue;
 use crate::values::Value;
+use std::fmt;
 
 /// Marker trait for types which are frozen on creation.
 ///
@@ -30,6 +31,12 @@ pub trait FrozenOnCreation {}
 /// [`Value`] wrapper which asserts the value is frozen.
 #[derive(Clone, Debug)]
 pub(crate) struct FrozenValue(Value);
+
+impl fmt::Display for FrozenValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
 
 impl FrozenValue {
     pub fn new(value: Value) -> Result<FrozenValue, ()> {

--- a/starlark/src/values/frozen.rs
+++ b/starlark/src/values/frozen.rs
@@ -46,6 +46,11 @@ impl FrozenValue {
             Err(())
         }
     }
+
+    /// Get a reference to a [`Value`] held inside this.
+    pub fn get_ref(&self) -> &Value {
+        &self.0
+    }
 }
 
 impl From<FrozenValue> for Value {

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -87,6 +87,7 @@ where
 impl TypedValue for i64 {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "int";
+    const PURE: bool = true;
 
     const INLINE: bool = true;
 

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -97,6 +97,7 @@ impl List {
 
 impl TypedValue for List {
     type Holder = Mutable<List>;
+    const PURE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -370,7 +370,7 @@ impl<T: TypedValue> TypedValueDyn for T {
 
     /// Freezes the current value.
     fn freeze_dyn(&self) {
-        for mut value in self.values_for_descendant_check_and_freeze() {
+        for value in self.values_for_descendant_check_and_freeze() {
             value.freeze();
         }
     }
@@ -1160,7 +1160,7 @@ impl Value {
         self.value_holder().is_pure_dyn()
     }
 
-    pub fn freeze(&mut self) {
+    pub fn freeze(&self) {
         match &self.0 {
             ValueInner::Other(rc) => {
                 if rc.value.freeze() {

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1339,6 +1339,10 @@ impl PartialEq for Value {
 impl Eq for Value {}
 
 impl Value {
+    pub(crate) fn is<T: TypedValue>(&self) -> bool {
+        self.value_holder().as_any_ref().is::<T>()
+    }
+
     /// Get a reference to underlying data or `None`
     /// if contained object has different type than requested.
     ///

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1159,7 +1159,7 @@ impl Value {
     pub(crate) fn is_pure(&self) -> bool {
         self.value_holder().is_pure_dyn()
     }
-    
+
     pub fn freeze(&mut self) {
         match &self.0 {
             ValueInner::Other(rc) => {

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -31,6 +31,7 @@ pub enum NoneType {
 impl TypedValue for NoneType {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "NoneType";
+    const PURE: bool = true;
 
     const INLINE: bool = true;
 

--- a/starlark/src/values/range.rs
+++ b/starlark/src/values/range.rs
@@ -56,6 +56,7 @@ impl Iterator for RangeIterator {
 
 impl TypedValue for Range {
     const TYPE: &'static str = "range";
+    const PURE: bool = true;
 
     fn to_repr_impl(&self, buf: &mut String) -> fmt::Result {
         if self.step.get() != 1 {

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -32,6 +32,7 @@ use std::iter;
 
 impl TypedValue for String {
     type Holder = Immutable<String>;
+    const PURE: bool = true;
 
     const INLINE: bool = true;
 

--- a/starlark/src/values/tuple.rs
+++ b/starlark/src/values/tuple.rs
@@ -256,6 +256,7 @@ impl<
 
 impl TypedValue for Tuple {
     type Holder = Immutable<Tuple>;
+    const PURE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,


### PR DESCRIPTION
This PR implements constant propagation into a function.

This function:

```
X = 5

def y():
    return X
```

is replaced with:

```
def y():
    return 5
```

During the freeze of the environment.

Global constants are propagated into function body, but also
certain expressions are evaluated at freeze time, for example:
* `True and right` is replaced with `right`
* `["x"][0]` is replaced with `"x"`
* `struct(x = 1).x` is replaced with `1`
* and so on

The simple benchmark included in this PR becomes about 4x faster,
because all `bench` function body becomes a constant.

Future work in this area:
* implement constant evaluation for more expression types
  (for example, binary operations like `2 + 3` are not evaluated)
* implement constant evaluation for pure native functions
  (e. g. `str` or `tuple`)
* implement constant evaluation of certain `def` functions
* remove global variable index from functions (introduced in previous PR)
  at freeze time