### PR TITLE
Refactor binop

### DIFF
--- a/starlark/src/eval/expr.rs
+++ b/starlark/src/eval/expr.rs
@@ -89,6 +89,8 @@ pub(crate) enum ExprCompiled {
     Not(AstExprCompiled),
     Minus(AstExprCompiled),
     Plus(AstExprCompiled),
+    And(AstExprCompiled, AstExprCompiled),
+    Or(AstExprCompiled, AstExprCompiled),
     Op(BinOp, AstExprCompiled, AstExprCompiled),
     If(AstExprCompiled, AstExprCompiled, AstExprCompiled), // Order: condition, v1, v2 <=> v1 if condition else v2
     List(Vec<AstExprCompiled>),
@@ -169,6 +171,12 @@ impl ExprCompiled {
                 Expr::Not(e) => ExprCompiled::Not(Self::compile(e, compiler)?),
                 Expr::Plus(e) => ExprCompiled::Plus(Self::compile(e, compiler)?),
                 Expr::Minus(e) => ExprCompiled::Minus(Self::compile(e, compiler)?),
+                Expr::And(lhs, rhs) => {
+                    ExprCompiled::And(Self::compile(lhs, compiler)?, Self::compile(rhs, compiler)?)
+                }
+                Expr::Or(lhs, rhs) => {
+                    ExprCompiled::Or(Self::compile(lhs, compiler)?, Self::compile(rhs, compiler)?)
+                }
                 Expr::Op(op, lhs, rhs) => ExprCompiled::Op(
                     op,
                     Self::compile(lhs, compiler)?,

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -277,13 +277,13 @@ IfTest: AstExpr = {
 // Binary operators
 OrTest: AstExpr = {
     <l:@L> <e1:AndTest> "or" <e2:OrTest> <r:@R>
-        => Expr::Op(BinOp::Or, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::Or(e1, e2).to_ast(file_span.subspan(l, r)),
     AndTest,
 };
 
 AndTest: AstExpr =  {
     <l:@L> <e1:NotTest> "and" <e2:AndTest> <r:@R>
-        => Expr::Op(BinOp::And, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::And(e1, e2).to_ast(file_span.subspan(l, r)),
     NotTest,
 };
 


### PR DESCRIPTION
* Introduce separate `Expr::And` and `Expr::Op` because the logical evaluation
  is lazy unlike all other binary operators
* extract `eval_bin_op` function
* inline `eval_compare` and `eval_equals`

The net result is:

```
4 files changed, 58 insertions(+), 97 deletions(-)
```

This change will also help to implement constant propagation.