### PR TITLE
Add module support to test framework

### DIFF
--- a/starlark-test/tests/rust-testcases/module.sky
+++ b/starlark-test/tests/rust-testcases/module.sky
@@ -1,0 +1,11 @@
+# file: util.bzl
+
+def add_one(x):
+    return x + 1
+
+# file: main.sky
+
+load("util.bzl", "add_one")
+
+assert_eq(5, add_one(4))
+


### PR DESCRIPTION
Values imported from other `.bzl` files may behave differently, so
add the ability to test this behavior in integration tests.

Module test looks like this now:

```
# file: util.bzl
def add_one(x):
    return x + 1

# file: main.sky
load("util.bzl", "add_one")

assert_eq(5, add_one(4))
```