### PR TITLE
Disconnect TypeValues from Environment

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -77,7 +77,9 @@ fn main() {
     let command = opt.command;
     let ast = opt.ast;
 
-    let global = print_function(global_environment_with_extensions());
+    let (mut global, mut type_values) = global_environment_with_extensions();
+
+    print_function(&mut global, &mut type_values);
     global.freeze();
 
     let dialect = if opt.build_file {
@@ -95,13 +97,14 @@ fn main() {
                 &i,
                 dialect,
                 &mut global.child(&i),
+                &type_values,
                 global.clone(),
             ));
         }
     }
     if opt.repl || (free_args_empty && command.is_none()) {
         println!("Welcome to Starlark REPL, press Ctrl+D to exit.");
-        repl(&global, dialect, ast);
+        repl(&mut global, &type_values, dialect, ast);
     }
     if let Some(command) = command {
         let path = "[command flag]";
@@ -114,6 +117,7 @@ fn main() {
                 &command,
                 dialect,
                 &mut global.child("[command flag]"),
+                &type_values,
                 global.clone(),
             ));
         }

--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -62,6 +62,7 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     lexer: T2,
     dialect: Dialect,
     env: &mut Environment,
+    type_values: &TypeValues,
     file_loader_env: Environment,
     ast: bool,
 ) {
@@ -80,7 +81,7 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             dialect,
             lexer,
             env,
-            TypeValues::new(file_loader_env.clone()),
+            type_values,
             SimpleFileLoader::new(&map.clone(), file_loader_env),
         ) {
             Ok(v) => {
@@ -125,7 +126,12 @@ starlark_module! {print_function =>
 /// * global_environment: the parent enviroment for the loop.
 /// * dialect: Starlark language dialect.
 /// * ast: print AST instead of evaluating.
-pub fn repl(global_environment: &Environment, dialect: Dialect, ast: bool) {
+pub fn repl(
+    global_environment: &mut Environment,
+    type_values: &TypeValues,
+    dialect: Dialect,
+    ast: bool,
+) {
     let map = Arc::new(Mutex::new(codemap::CodeMap::new()));
     let reader = Interface::new("Starlark").unwrap();
     let mut env = global_environment.child("repl");
@@ -173,6 +179,7 @@ pub fn repl(global_environment: &Environment, dialect: Dialect, ast: bool) {
                 lexer,
                 dialect,
                 &mut env,
+                type_values,
                 global_environment.clone(),
                 ast,
             )

--- a/starlark/examples/starlark-simple-cli.rs
+++ b/starlark/examples/starlark-simple-cli.rs
@@ -33,7 +33,7 @@ use starlark::syntax::dialect::Dialect;
 
 pub fn simple_evaluation(starlark_input: &String) -> Result<String, String> {
     // Create a new global environment populated with the stdlib.
-    let global_env = global_environment();
+    let (global_env, type_values) = global_environment();
     // Extra symbols can be added to the global environment before freezing if desired.
     global_env.freeze();
     // Create our own local copy of the global environment.
@@ -50,6 +50,7 @@ pub fn simple_evaluation(starlark_input: &String) -> Result<String, String> {
         &starlark_input,
         Dialect::Bzl,
         &mut env,
+        &type_values,
         global_env.clone(),
     );
 

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -216,7 +216,7 @@ impl TypedValue for Def {
     fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -14,7 +14,7 @@
 
 //! Defines very basic versions of the evaluation functions that are suitable for interactive use:
 //! they output diagnostic to stderr and the result value to stdout.
-use crate::environment::Environment;
+use crate::environment::{Environment, TypeValues};
 use crate::syntax::dialect::Dialect;
 use crate::values::Value;
 use codemap::CodeMap;
@@ -50,11 +50,20 @@ pub fn eval(
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
+    type_values: &TypeValues,
     file_loader_env: Environment,
 ) -> Result<Option<Value>, EvalError> {
     let map = Arc::new(Mutex::new(CodeMap::new()));
     transform_result(
-        super::simple::eval(&map, path, content, dialect, env, file_loader_env),
+        super::simple::eval(
+            &map,
+            path,
+            content,
+            dialect,
+            env,
+            type_values,
+            file_loader_env,
+        ),
         map,
     )
 }
@@ -74,11 +83,12 @@ pub fn eval_file(
     path: &str,
     dialect: Dialect,
     env: &mut Environment,
+    type_values: &TypeValues,
     file_loader_env: Environment,
 ) -> Result<Option<Value>, EvalError> {
     let map = Arc::new(Mutex::new(CodeMap::new()));
     transform_result(
-        super::simple::eval_file(&map, path, dialect, env, file_loader_env),
+        super::simple::eval_file(&map, path, dialect, env, type_values, file_loader_env),
         map,
     )
 }

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -211,7 +211,7 @@ impl Into<Diagnostic> for EvalException {
 /// A trait for loading file using the load statement path.
 pub trait FileLoader: 'static {
     /// Open the file given by the load statement `path`.
-    fn load(&self, path: &str) -> Result<Environment, EvalException>;
+    fn load(&self, path: &str, type_values: &TypeValues) -> Result<Environment, EvalException>;
 }
 
 /// Starlark `def` or comprehension local variables
@@ -333,7 +333,7 @@ pub(crate) struct EvaluationContext<'a> {
     // Locals and captured context.
     env: EvaluationContextEnvironment<'a>,
     // Globals used to resolve type values, provided by the caller.
-    type_values: TypeValues,
+    type_values: &'a TypeValues,
     call_stack: &'a mut CallStack,
     map: Arc<Mutex<CodeMap>>,
 }
@@ -431,7 +431,7 @@ fn eval_call<'a>(
         let r = t(
             eval_expr(e, context)?.call(
                 context.call_stack,
-                context.type_values.clone(),
+                context.type_values,
                 npos,
                 nnamed,
                 nargs,
@@ -556,7 +556,7 @@ fn eval_expr_local(
             context.env.assert_module_env().clone(),
             IndexedLocals::new(locals),
         ),
-        type_values: context.type_values.clone(),
+        type_values: context.type_values,
         map: context.map.clone(),
     };
     eval_expr(expr, &mut ctx)
@@ -879,7 +879,7 @@ fn eval_stmt(stmt: &AstStatementCompiled, context: &mut EvaluationContext) -> Ev
             Ok(f)
         }
         StatementCompiled::Load(ref name, ref v) => {
-            let loadenv = context.env.loader().load(name)?;
+            let loadenv = context.env.loader().load(name, context.type_values)?;
             for &(ref new_name, ref orig_name) in v.iter() {
                 t(
                     context.env.assert_module_env().import_symbol(
@@ -906,7 +906,7 @@ fn eval_block(block: &BlockCompiled, context: &mut EvaluationContext) -> EvalRes
 fn eval_module(
     module: &Module,
     env: &mut Environment,
-    type_values: TypeValues,
+    type_values: &TypeValues,
     map: Arc<Mutex<CodeMap>>,
     file_loader: Rc<dyn FileLoader>,
 ) -> EvalResult {
@@ -943,7 +943,7 @@ pub fn eval_lexer<
     dialect: Dialect,
     lexer: T2,
     env: &mut Environment,
-    type_values: TypeValues,
+    type_values: &TypeValues,
     file_loader: T3,
 ) -> Result<Value, Diagnostic> {
     match eval_module(
@@ -976,7 +976,7 @@ pub fn eval<T: FileLoader + 'static>(
     content: &str,
     build: Dialect,
     env: &mut Environment,
-    type_values: TypeValues,
+    type_values: &TypeValues,
     file_loader: T,
 ) -> Result<Value, Diagnostic> {
     match eval_module(
@@ -1007,7 +1007,7 @@ pub fn eval_file<T: FileLoader + 'static>(
     path: &str,
     build: Dialect,
     env: &mut Environment,
-    type_values: TypeValues,
+    type_values: &TypeValues,
     file_loader: T,
 ) -> Result<Value, Diagnostic> {
     match eval_module(

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -27,7 +27,7 @@ use std::sync::{Arc, Mutex};
 pub struct NoLoadFileLoader;
 
 impl FileLoader for NoLoadFileLoader {
-    fn load(&self, _path: &str) -> Result<Environment, EvalException> {
+    fn load(&self, _path: &str, _: &TypeValues) -> Result<Environment, EvalException> {
         Err(EvalException::DiagnosedError(Diagnostic {
             level: Level::Error,
             message: "ErrorFileLoader does not support loading".to_owned(),
@@ -56,7 +56,7 @@ pub fn eval(
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
-    type_values: TypeValues,
+    type_values: &TypeValues,
 ) -> Result<Value, Diagnostic> {
     super::eval(
         map,

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -41,7 +41,7 @@ impl SimpleFileLoader {
 }
 
 impl FileLoader for SimpleFileLoader {
-    fn load(&self, path: &str) -> Result<Environment, EvalException> {
+    fn load(&self, path: &str, type_values: &TypeValues) -> Result<Environment, EvalException> {
         {
             let lock = self.map.lock().unwrap();
             if lock.contains_key(path) {
@@ -54,7 +54,7 @@ impl FileLoader for SimpleFileLoader {
             path,
             Dialect::Bzl,
             &mut env,
-            TypeValues::new(self.parent_env.clone()),
+            type_values,
             self.clone(),
         ) {
             return Err(EvalException::DiagnosedError(d));
@@ -86,6 +86,7 @@ pub fn eval(
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
+    type_values: &TypeValues,
     file_loader_env: Environment,
 ) -> Result<Value, Diagnostic> {
     super::eval(
@@ -94,7 +95,7 @@ pub fn eval(
         content,
         dialect,
         env,
-        TypeValues::new(file_loader_env.clone()),
+        type_values,
         SimpleFileLoader::new(map, file_loader_env),
     )
 }
@@ -115,6 +116,7 @@ pub fn eval_file(
     path: &str,
     build: Dialect,
     env: &mut Environment,
+    type_values: &TypeValues,
     file_loader_env: Environment,
 ) -> Result<Value, Diagnostic> {
     super::eval_file(
@@ -122,7 +124,7 @@ pub fn eval_file(
         path,
         build,
         env,
-        TypeValues::new(file_loader_env.clone()),
+        type_values,
         SimpleFileLoader::new(map, file_loader_env),
     )
 }

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -32,7 +32,7 @@ pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
         snippet,
         Dialect::Bzl,
         &mut env,
-        environment::TypeValues::new(environment::Environment::new("empty")),
+        &TypeValues::default(),
     ) {
         Ok(v) => Ok(v.to_bool()),
         Err(d) => {
@@ -47,7 +47,7 @@ pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
     starlark_no_diagnostic(
         &mut environment::Environment::new("test"),
         snippet,
-        TypeValues::new(environment::Environment::new("no-type-values")),
+        &TypeValues::default(),
     )
 }
 
@@ -55,7 +55,7 @@ pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
 pub fn starlark_no_diagnostic(
     env: &mut environment::Environment,
     snippet: &str,
-    type_values: environment::TypeValues,
+    type_values: &TypeValues,
 ) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
     Ok(eval::noload::eval(&map, "<test>", snippet, Dialect::Bzl, env, type_values)?.to_bool())

--- a/starlark/src/linked_hash_set/mod.rs
+++ b/starlark/src/linked_hash_set/mod.rs
@@ -1,12 +1,11 @@
-use crate::environment::Environment;
+use crate::environment::{Environment, TypeValues};
 
 pub(crate) mod set_impl;
 mod stdlib;
 pub(crate) mod value;
 
 /// Include `set` constructor and set functions in environment.
-pub fn global(env: Environment) -> Environment {
-    let env = stdlib::global(env);
+pub fn global(env: &mut Environment, type_values: &mut TypeValues) {
+    self::stdlib::global(env, type_values);
     env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
-    env
 }

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -130,7 +130,6 @@ mod test {
     use crate::starlark_signature_extraction;
     use crate::starlark_signatures;
 
-    use crate::environment::TypeValues;
     use crate::eval::noload::eval;
     use crate::stdlib::global_environment;
     use crate::syntax::dialect::Dialect;
@@ -147,8 +146,8 @@ mod test {
 
     #[test]
     fn test_simple() {
-        let env = global_environment();
-        let env = global(env);
+        let (mut env, mut type_values) = global_environment();
+        global(&mut env, &mut type_values);
         env.freeze();
 
         let mut child = env.child("my");
@@ -159,7 +158,7 @@ mod test {
             "cc_binary(name='star', srcs=['a.cc', 'b.cc'])",
             Dialect::Build,
             &mut child,
-            TypeValues::new(env),
+            &type_values,
         )
         .unwrap();
 

--- a/starlark/src/values/function.rs
+++ b/starlark/src/values/function.rs
@@ -166,7 +166,7 @@ pub struct NativeFunction {
     /// Pointer to a native function.
     /// Note it is a function pointer, not `Box<Fn(...)>`
     /// to avoid generic instantiation and allocation for each native function.
-    function: fn(&mut CallStack, TypeValues, ParameterParser) -> ValueResult,
+    function: fn(&mut CallStack, &TypeValues, ParameterParser) -> ValueResult,
     signature: FunctionSignature,
     function_type: FunctionType,
 }
@@ -254,7 +254,7 @@ impl From<FunctionError> for ValueError {
 impl NativeFunction {
     pub fn new(
         name: String,
-        function: fn(&mut CallStack, TypeValues, ParameterParser) -> ValueResult,
+        function: fn(&mut CallStack, &TypeValues, ParameterParser) -> ValueResult,
         signature: FunctionSignature,
     ) -> Value {
         Value::new(NativeFunction {
@@ -511,7 +511,7 @@ impl TypedValue for NativeFunction {
     fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
@@ -554,7 +554,7 @@ impl TypedValue for WrappedMethod {
     fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -365,7 +365,7 @@ impl<T: TypedValue> ValueHolderDyn for ValueHolder<T> {
     fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
@@ -535,7 +535,7 @@ trait ValueHolderDyn {
     fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,
@@ -729,7 +729,7 @@ pub trait TypedValue: Sized + 'static {
     fn call(
         &self,
         _call_stack: &mut CallStack,
-        _type_values: TypeValues,
+        _type_values: &TypeValues,
         _positional: Vec<Value>,
         _named: LinkedHashMap<String, Value>,
         _args: Option<Value>,
@@ -1136,7 +1136,7 @@ impl Value {
     pub fn call(
         &self,
         call_stack: &mut CallStack,
-        type_values: TypeValues,
+        type_values: &TypeValues,
         positional: Vec<Value>,
         named: LinkedHashMap<String, Value>,
         args: Option<Value>,


### PR DESCRIPTION
`TypeValues` are quite different from `Environment`:
* `TypeValues` are "global" while multiple `Environment` can coexist in the same run
* `TypeValues` can be only initialized using Rust code

This commit splits `TypeValues` from `Environment` completely.

Client code becomes somewhat more verbose now, but I think that's
fine, because it makes disctinction between these two "environment"
more clear.

For example, it makes no sense to store `TypeValues` in the environment
created by `load` statement, because these `TypeValues` are neither
read nor written.

A little bonus is that `TypeValues` no longer require refcell-locking
to work with, and `TypeValues` lookup no longer walks to parent
environment (because there's no parent environment in `TypeValues`).