### PR TITLE
inspect function

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -20,7 +20,7 @@ use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::interactive::{eval, eval_file, EvalError};
 use starlark::eval::module::Module;
-use starlark::stdlib::global_environment_with_extensions;
+use starlark::stdlib::global_environment_for_repl_and_tests;
 use starlark::syntax::dialect::Dialect;
 use starlark::syntax::parser::{parse, parse_file};
 use starlark::values::Value;
@@ -77,7 +77,7 @@ fn main() {
     let command = opt.command;
     let ast = opt.ast;
 
-    let (mut global, mut type_values) = global_environment_with_extensions();
+    let (mut global, mut type_values) = global_environment_for_repl_and_tests();
 
     print_function(&mut global, &mut type_values);
     global.freeze();

--- a/starlark-test/src/lib.rs
+++ b/starlark-test/src/lib.rs
@@ -32,7 +32,7 @@ use starlark::eval::eval;
 use starlark::eval::noload;
 use starlark::eval::EvalException;
 use starlark::eval::FileLoader;
-use starlark::stdlib::global_environment_with_extensions;
+use starlark::stdlib::global_environment_for_repl_and_tests;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::error::ValueError;
 use std::collections::HashMap;
@@ -139,7 +139,7 @@ impl FileLoader for HashMapFileLoader {
 
 pub fn do_conformance_test(path: &str, content: &str) {
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let (global, type_values) = global_environment_with_extensions();
+    let (global, type_values) = global_environment_for_repl_and_tests();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     noload::eval(
@@ -231,7 +231,7 @@ pub fn do_bench(bencher: &mut Bencher, path: &str) {
     drop(file);
 
     let map = Arc::new(Mutex::new(CodeMap::new()));
-    let (global, type_values) = global_environment_with_extensions();
+    let (global, type_values) = global_environment_for_repl_and_tests();
     global.freeze();
     let mut prelude = global.child("PRELUDE");
     noload::eval(

--- a/starlark-test/tests/rust-testcases/inspect.sky
+++ b/starlark-test/tests/rust-testcases/inspect.sky
@@ -1,0 +1,2 @@
+a = ""
+assert_("String" in inspect(a).rust_type_name)

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -30,6 +30,7 @@ use crate::eval::EvaluationContext;
 use crate::eval::EvaluationContextEnvironment;
 use crate::eval::IndexedGlobals;
 use crate::eval::IndexedLocals;
+use crate::stdlib::structs::StarlarkStruct;
 use crate::syntax::ast::AssignTargetExpr;
 use crate::syntax::ast::AstParameter;
 use crate::syntax::ast::AstStatement;
@@ -44,6 +45,7 @@ use crate::values::function::FunctionParameter;
 use crate::values::function::FunctionSignature;
 use crate::values::function::FunctionType;
 use crate::values::function::StrOrRepr;
+use crate::values::inspect::Inspectable;
 use crate::values::none::NoneType;
 use crate::values::{function, Immutable, TypedValue, Value, ValueResult};
 use codemap::{CodeMap, Spanned};
@@ -177,6 +179,16 @@ impl DefCompiled {
     }
 }
 
+impl Inspectable for DefCompiled {
+    fn inspect(&self) -> Value {
+        let mut fields = LinkedHashMap::<String, Value>::new();
+        fields.insert("name".into(), self.name.node.clone().into());
+        fields.insert("locals".into(), self.locals.inspect());
+        fields.insert("suite".into(), self.suite.inspect());
+        Value::new(StarlarkStruct::new(fields))
+    }
+}
+
 /// Starlark function internal representation and implementation of [`TypedValue`].
 pub(crate) struct Def {
     signature: FunctionSignature,
@@ -295,5 +307,12 @@ impl TypedValue for Def {
             Err(x) => Err(ValueError::DiagnosedError(x.into())),
             Ok(..) => Ok(Value::new(NoneType::None)),
         }
+    }
+
+    fn inspect_custom(&self) -> Value {
+        let mut fields = LinkedHashMap::<String, Value>::new();
+        fields.insert("captured_env".into(), self.captured_env.name().into());
+        fields.insert("stmt".into(), self.stmt.inspect());
+        Value::new(StarlarkStruct::new(fields))
     }
 }

--- a/starlark/src/eval/globals.rs
+++ b/starlark/src/eval/globals.rs
@@ -14,6 +14,10 @@
 
 //! Utilities to work with scope global variables.
 
+use crate::stdlib::structs::StarlarkStruct;
+use crate::values::inspect::Inspectable;
+use crate::values::Value;
+use linked_hash_map::LinkedHashMap;
 use std::collections::HashMap;
 
 #[derive(Default, Debug, Clone)]
@@ -33,5 +37,13 @@ impl Globals {
     /// Return the number of global variable slots
     pub fn len(&self) -> usize {
         self.name_to_index.len()
+    }
+}
+
+impl Inspectable for Globals {
+    fn inspect(&self) -> Value {
+        let mut fields = LinkedHashMap::<String, Value>::new();
+        fields.insert("name_to_index".into(), self.name_to_index.inspect());
+        Value::new(StarlarkStruct::new(fields))
     }
 }

--- a/starlark/src/stdlib/inspect.rs
+++ b/starlark/src/stdlib/inspect.rs
@@ -1,0 +1,84 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of `inspect` builtin.
+
+use crate::values::Value;
+
+starlark_module! { global =>
+    /// Return some internals about the value.
+    ///
+    /// This function is to be used for debugging only, it's format is not specified,
+    /// and may change any time.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use starlark::stdlib::starlark_default;
+    /// # assert!(starlark_default("
+    /// a = []
+    /// 'List' in inspect(a).rust_type_name
+    /// # ").unwrap());
+    /// ```
+    inspect(value, /) {
+        Ok(Value::new(value.inspect()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::eval::noload;
+    use crate::stdlib::global_environment_for_repl_and_tests;
+    use crate::syntax::dialect::Dialect;
+    use crate::values::Immutable;
+    use crate::values::TypedValue;
+    use crate::values::Value;
+    use std::iter;
+
+    #[test]
+    fn inspect() {
+        struct TestInspectable {}
+
+        impl TypedValue for TestInspectable {
+            type Holder = Immutable<Self>;
+            const TYPE: &'static str = "test_inspectable";
+
+            fn values_for_descendant_check_and_freeze<'a>(
+                &'a self,
+            ) -> Box<dyn Iterator<Item = Value>> {
+                Box::new(iter::empty())
+            }
+
+            fn inspect_custom(&self) -> Value {
+                Value::from("test test")
+            }
+        }
+
+        let (mut env, type_values) = global_environment_for_repl_and_tests();
+        env.set("ti", Value::new(TestInspectable {})).unwrap();
+        let custom = noload::eval(
+            &Default::default(),
+            "test.sky",
+            "inspect(ti).custom",
+            Dialect::Bzl,
+            &mut env,
+            &type_values,
+        )
+        .unwrap();
+        assert_eq!(
+            "test test",
+            custom.downcast_ref::<String>().unwrap().as_str()
+        );
+    }
+}

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -44,6 +44,7 @@ const USER_FAILURE_ERROR_CODE: &str = "CR99";
 #[macro_use]
 pub mod macros;
 pub mod dict;
+mod inspect;
 pub mod list;
 pub mod string;
 pub mod structs;
@@ -966,12 +967,20 @@ pub fn global_environment_with_extensions() -> (Environment, TypeValues) {
     (env, type_values)
 }
 
+/// Default global environment with functions usable in test and REPL.
+pub fn global_environment_for_repl_and_tests() -> (Environment, TypeValues) {
+    let (mut env, mut type_values) = global_environment_with_extensions();
+    // TODO: do not add to global context
+    inspect::global(&mut env, &mut type_values);
+    (env, type_values)
+}
+
 /// Execute a starlark snippet with the default environment for test and return the truth value
 /// of the last statement. Used for tests and documentation tests.
 #[doc(hidden)]
 pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    let (env, type_values) = global_environment_with_extensions();
+    let (env, type_values) = global_environment_for_repl_and_tests();
     let mut test_env = env.freeze().child("test");
     match eval(
         &map,

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -25,6 +25,12 @@ pub struct StarlarkStruct {
     fields: LinkedHashMap<String, Value>,
 }
 
+impl StarlarkStruct {
+    pub(crate) fn new(fields: LinkedHashMap<String, Value>) -> StarlarkStruct {
+        StarlarkStruct { fields }
+    }
+}
+
 impl TypedValue for StarlarkStruct {
     type Holder = Immutable<StarlarkStruct>;
 
@@ -109,8 +115,6 @@ starlark_module! { global =>
     /// # )").unwrap());
     /// ```
     struct_(**kwargs) {
-        Ok(Value::new(StarlarkStruct {
-            fields: kwargs
-        }))
+        Ok(Value::new(StarlarkStruct::new(kwargs)))
     }
 }

--- a/starlark/src/values/cell/header.rs
+++ b/starlark/src/values/cell/header.rs
@@ -138,6 +138,7 @@ static IMMUTABLE_FROZEN_OBJECT_HEADER: ObjectHeaderInStaticField =
         state: Cell::new(IMMUTABLE_FLAG | FROZEN_FLAG),
     });
 
+#[derive(Clone)]
 pub(crate) struct ObjectHeader {
     state: Cell<usize>,
 }
@@ -252,6 +253,12 @@ impl ObjectHeader {
                 self.set_decoded(ObjectState::Borrowed(0, false));
             }
         }
+    }
+}
+
+impl fmt::Debug for ObjectHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.get_decoded(), f)
     }
 }
 

--- a/starlark/src/values/cell/mod.rs
+++ b/starlark/src/values/cell/mod.rs
@@ -191,4 +191,9 @@ impl<T: ?Sized> ObjectCell<T> {
     pub fn freeze(&self) -> bool {
         self.header.freeze()
     }
+
+    /// Get a copy of object header.
+    pub fn get_header(&self) -> ObjectHeader {
+        self.header.clone()
+    }
 }

--- a/starlark/src/values/inspect.rs
+++ b/starlark/src/values/inspect.rs
@@ -1,0 +1,121 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility for easier implementation of `inspect`.
+
+use crate::values::dict::Dictionary;
+use crate::values::none::NoneType;
+use crate::values::Value;
+use codemap::Spanned;
+use std::collections::HashMap;
+
+/// Convert "inspectable" to a Starlark value.
+///
+/// Somewhat similar to `Value::from`, but also works with other types
+/// which are not supposed to converted to `Value` implicitly.
+pub(crate) trait Inspectable {
+    fn inspect(&self) -> Value;
+}
+
+impl<A: Inspectable> Inspectable for &'_ A {
+    fn inspect(&self) -> Value {
+        (**self).inspect()
+    }
+}
+
+impl Inspectable for usize {
+    fn inspect(&self) -> Value {
+        Value::from(*self)
+    }
+}
+
+impl Inspectable for String {
+    fn inspect(&self) -> Value {
+        Value::from(self.as_str())
+    }
+}
+
+impl<A: Inspectable> Inspectable for Box<A> {
+    fn inspect(&self) -> Value {
+        (**self).inspect()
+    }
+}
+
+impl<A: Inspectable> Inspectable for Option<A> {
+    fn inspect(&self) -> Value {
+        match self {
+            None => Value::new(NoneType::None),
+            Some(v) => (v.inspect(),).into(),
+        }
+    }
+}
+
+impl<V: Inspectable> Inspectable for Vec<V> {
+    fn inspect(&self) -> Value {
+        Value::from(self.iter().map(V::inspect).collect::<Vec<_>>())
+    }
+}
+
+impl<A: Inspectable, B: Inspectable> Inspectable for (A, B) {
+    fn inspect(&self) -> Value {
+        Value::from((self.0.inspect(), self.1.inspect()))
+    }
+}
+
+impl<A: Inspectable, B: Inspectable, C: Inspectable> Inspectable for (A, B, C) {
+    fn inspect(&self) -> Value {
+        Value::from((self.0.inspect(), self.1.inspect(), self.2.inspect()))
+    }
+}
+
+impl<A: Inspectable, B: Inspectable, C: Inspectable, D: Inspectable> Inspectable for (A, B, C, D) {
+    fn inspect(&self) -> Value {
+        Value::from((
+            self.0.inspect(),
+            self.1.inspect(),
+            self.2.inspect(),
+            self.3.inspect(),
+        ))
+    }
+}
+
+impl<A: Inspectable, B: Inspectable, C: Inspectable, D: Inspectable, E: Inspectable> Inspectable
+    for (A, B, C, D, E)
+{
+    fn inspect(&self) -> Value {
+        Value::from((
+            self.0.inspect(),
+            self.1.inspect(),
+            self.2.inspect(),
+            self.3.inspect(),
+            self.4.inspect(),
+        ))
+    }
+}
+
+impl<K: Inspectable, V: Inspectable> Inspectable for HashMap<K, V> {
+    fn inspect(&self) -> Value {
+        let mut map = Dictionary::new_typed();
+        for (k, v) in self {
+            map.insert(k.inspect(), v.inspect()).unwrap();
+        }
+        Value::new(map)
+    }
+}
+
+impl<A: Inspectable> Inspectable for Spanned<A> {
+    fn inspect(&self) -> Value {
+        self.node.inspect()
+    }
+}

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -58,6 +58,9 @@ from_int!(u16, i64);
 from_int!(u32, i64);
 // TODO: check for overflow
 from_int!(u64, i64);
+// TODO: check for overflow
+from_int!(usize, i64);
+from_int!(isize, i64);
 
 impl From<i64> for Value {
     fn from(v: i64) -> Self {


### PR DESCRIPTION
Return some information about the value e. g. mutability.

For `def` return ast as Starlark object tree. E. g. `a.sky`:

```
def foo():
    a = str(17)
    return a

def print_foo():
    print("mutability   = {}".format(inspect(foo).mutability))
    print("captured_env = {}".format(inspect(foo).custom.captured_env))
    print("locals       = {}".format(inspect(foo).custom.stmt.locals))
    print("stmts:")
    for stmt in inspect(foo).custom.stmt.suite:
        print(stmt)

print_foo()
```

`cargo run -- ./a.sky`:

```
mutability   = ImmutableMutability
captured_env = ./a.sky
locals       = struct(count=1, locals=struct(name_to_slot={"a": 0}, nested_scopes=[]))
stmts:
("assign", (("name", ("slot", (0, "a"))), ("call", (("name", ("global", "str")), [("int_literal", 17)], [], None, None))))
("return", (("name", ("slot", (0, "a"))),))
```

This function can be helpful to debug certain interpreter changes,
in particular, constant propagation from #220.