### PR TITLE
Freeze objects at most once

### DIFF
--- a/starlark/src/values/cell/mod.rs
+++ b/starlark/src/values/cell/mod.rs
@@ -42,11 +42,11 @@ impl<'b, T: ?Sized + 'b> ObjectRef<'b, T> {
         }
     }
 
-    /// A reference to immutable value
-    pub fn immutable(value: &T) -> ObjectRef<T> {
+    /// A reference to immutable frozen value
+    pub fn immutable_frozen(value: &T) -> ObjectRef<T> {
         ObjectRef {
             value,
-            borrow: ObjectBorrowRef::immutable(),
+            borrow: ObjectBorrowRef::immutable_frozen(),
         }
     }
 
@@ -164,10 +164,12 @@ impl<T: ?Sized> ObjectCell<T> {
 
     /// Mark value as frozen.
     ///
+    /// Return `true` if the object was not frozen before.
+    ///
     /// # Panics
     ///
     /// If value is borrowed.
-    pub fn freeze(&self) {
-        self.header.freeze();
+    pub fn freeze(&self) -> bool {
+        self.header.freeze()
     }
 }


### PR DESCRIPTION
`freeze` operation is no-op now if object (mutable or immutable)
is already frozen. This might speed-up a little freezing globals
sharing the same data, e. g. this:

```
X = list(range(10000))
Y = X
```

Immutable objects now have a separate "frozen" flag, so tuples are
immutable but not frozen at creation.

"Frozen" flag now means that neither object itself, nor objects
reachable from this object can be modified. Which is a helpful
property to eventually implement cross-thread environment sharing.