### PR TITLE
Use ObjectCell for freezing-borrowing Environment

### DIFF
--- a/starlark/src/values/cell/header.rs
+++ b/starlark/src/values/cell/header.rs
@@ -138,6 +138,7 @@ static IMMUTABLE_FROZEN_OBJECT_HEADER: ObjectHeaderInStaticField =
         state: Cell::new(IMMUTABLE_FLAG | FROZEN_FLAG),
     });
 
+#[derive(Clone)]
 pub(crate) struct ObjectHeader {
     state: Cell<usize>,
 }
@@ -149,6 +150,15 @@ impl ObjectHeader {
 
     fn set_decoded(&self, state: ObjectState) {
         self.state.set(state.encode());
+    }
+
+    /// True iff object was mutable and now is frozen.
+    /// (Return `false` for immutable).
+    pub fn is_mutable_frozen(&self) -> bool {
+        match self.get_decoded() {
+            ObjectState::MutableFrozen => true,
+            _ => false,
+        }
     }
 
     /// Create new object header for mutable object

--- a/starlark/src/values/mod.rs
+++ b/starlark/src/values/mod.rs
@@ -1240,7 +1240,7 @@ impl Value {
 
 // Submodules
 pub mod boolean;
-mod cell;
+pub(crate) mod cell;
 pub mod context;
 pub mod dict;
 pub mod error;


### PR DESCRIPTION
`Environment` borrowing-freezing logic is very similar to `Value`,
so use the same `ObjectCell` implementation for `Environment`.