### PR TITLE
RcString

### DIFF
--- a/starlark-test/benches/rust-benches/named_args.sky
+++ b/starlark-test/benches/rust-benches/named_args.sky
@@ -1,0 +1,16 @@
+def takes_named_args(**kwargs):
+    return len(kwargs)
+
+def bench():
+    return takes_named_args(
+        a0=0,
+        a1=1,
+        a2=2,
+        a3=3,
+        a4=4,
+        a5=5,
+        a6=6,
+        a7=7,
+        a8=8,
+        a9=9,
+    )

--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -48,12 +48,14 @@ use crate::values::function::FunctionType;
 use crate::values::function::StrOrRepr;
 use crate::values::inspect::Inspectable;
 use crate::values::none::NoneType;
+use crate::values::string::rc::RcString;
 use crate::values::Immutable;
 use crate::values::TypedValue;
 use crate::values::Value;
 use crate::values::ValueOther;
 use crate::values::ValueResult;
-use codemap::{CodeMap, Spanned};
+use codemap::CodeMap;
+use codemap::Spanned;
 use codemap_diagnostic::Diagnostic;
 use linked_hash_map::LinkedHashMap;
 use std::convert::TryInto;
@@ -186,7 +188,7 @@ impl DefCompiled {
 
 impl Inspectable for DefCompiled {
     fn inspect(&self) -> Value {
-        let mut fields = LinkedHashMap::<String, Value>::new();
+        let mut fields = LinkedHashMap::<RcString, Value>::new();
         fields.insert("name".into(), self.name.node.clone().into());
         fields.insert("locals".into(), self.locals.inspect());
         fields.insert("suite".into(), self.suite.inspect());
@@ -205,7 +207,7 @@ pub(crate) struct Def {
 
 impl Def {
     pub fn new(
-        module: String,
+        module: RcString,
         signature: FunctionSignature,
         stmt: DefCompiled,
         map: Arc<Mutex<CodeMap>>,
@@ -248,7 +250,7 @@ impl TypedValue for Def {
         call_stack: &mut CallStack,
         type_values: &TypeValues,
         positional: Vec<Value>,
-        named: LinkedHashMap<String, Value>,
+        named: LinkedHashMap<RcString, Value>,
         args: Option<Value>,
         kwargs: Option<Value>,
     ) -> ValueResult {
@@ -315,7 +317,7 @@ impl TypedValue for Def {
     }
 
     fn inspect_custom(&self) -> Value {
-        let mut fields = LinkedHashMap::<String, Value>::new();
+        let mut fields = LinkedHashMap::<RcString, Value>::new();
         fields.insert("captured_env".into(), self.captured_env.name().into());
         fields.insert("stmt".into(), self.stmt.inspect());
         Value::new(StarlarkStruct::new(fields))

--- a/starlark/src/eval/globals.rs
+++ b/starlark/src/eval/globals.rs
@@ -16,6 +16,7 @@
 
 use crate::stdlib::structs::StarlarkStruct;
 use crate::values::inspect::Inspectable;
+use crate::values::string::rc::RcString;
 use crate::values::Value;
 use linked_hash_map::LinkedHashMap;
 use std::collections::HashMap;
@@ -42,7 +43,7 @@ impl Globals {
 
 impl Inspectable for Globals {
     fn inspect(&self) -> Value {
-        let mut fields = LinkedHashMap::<String, Value>::new();
+        let mut fields = LinkedHashMap::<RcString, Value>::new();
         fields.insert("name_to_index".into(), self.name_to_index.inspect());
         Value::new(StarlarkStruct::new(fields))
     }

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -55,6 +55,7 @@ use crate::values::function::FunctionParameter;
 use crate::values::function::FunctionSignature;
 use crate::values::function::WrappedMethod;
 use crate::values::none::NoneType;
+use crate::values::string::rc::RcString;
 use crate::values::*;
 use codemap::{CodeMap, Span, Spanned};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
@@ -360,7 +361,7 @@ fn eval_dot<E: EvaluationContextEnvironment>(
 }
 
 enum TransformedExpr {
-    Dot(Value, String, Span),
+    Dot(Value, RcString, Span),
     ArrayIndirection(Value, Value, Span),
     Slot(usize, AstString),
 }

--- a/starlark/src/stdlib/macros/mod.rs
+++ b/starlark/src/stdlib/macros/mod.rs
@@ -92,7 +92,7 @@ macro_rules! starlark_parse_param_type {
         ::std::vec::Vec<$crate::values::Value>
     };
     (**) => {
-        ::linked_hash_map::LinkedHashMap<::std::string::String, $crate::values::Value>
+        ::linked_hash_map::LinkedHashMap<$crate::values::string::rc::RcString, $crate::values::Value>
     };
 }
 
@@ -203,7 +203,7 @@ macro_rules! starlark_signatures {
             #[allow(unused_mut)]
             let mut signature = $crate::stdlib::macros::signature::SignatureBuilder::default();
             starlark_signature!(signature $($signature)*);
-            $env.set(name, $crate::values::function::NativeFunction::new(name.to_owned(), $name, signature.build())).unwrap();
+            $env.set(name, $crate::values::function::NativeFunction::new(name.into(), $name, signature.build())).unwrap();
         }
         $(starlark_signatures!{ $env, $type_values,
             $($rest)+
@@ -216,7 +216,7 @@ macro_rules! starlark_signatures {
             let mut signature = $crate::stdlib::macros::signature::SignatureBuilder::default();
             starlark_signature!(signature $($signature)*);
             $type_values.add_type_value(stringify!($ty), name,
-                $crate::values::function::NativeFunction::new(name.to_owned(), $name, signature.build()));
+                $crate::values::function::NativeFunction::new(name.into(), $name, signature.build()));
         }
         $(starlark_signatures!{ $env, $type_values,
             $($rest)+
@@ -263,7 +263,7 @@ macro_rules! starlark_signatures {
 ///     // Parameter can be any type which implements `TryParamConvertFromValue`.
 ///     // When parameter type is not specified, it is defaulted to `Value`
 ///     // for regular parameters, `Vec<Value>` for `*args`
-///     // and `LinkedHashMap<String, Value>` for `**kwargs`.
+///     // and `LinkedHashMap<RcString, Value>` for `**kwargs`.
 ///     sqr(x: i64) {
 ///         Ok(Value::new(x * x))
 ///     }

--- a/starlark/src/stdlib/macros/signature.rs
+++ b/starlark/src/stdlib/macros/signature.rs
@@ -29,29 +29,26 @@ pub struct SignatureBuilder {
 
 impl SignatureBuilder {
     pub fn push_normal(&mut self, name: &str) {
-        self.params.push(FunctionParameter::Normal(name.to_owned()));
+        self.params.push(FunctionParameter::Normal(name.into()));
     }
 
     pub fn push_optional(&mut self, name: &str) {
-        self.params
-            .push(FunctionParameter::Optional(name.to_owned()));
+        self.params.push(FunctionParameter::Optional(name.into()));
     }
 
     pub fn push_with_default_value<V: Into<Value>>(&mut self, name: &str, default_value: V) {
         self.params.push(FunctionParameter::WithDefaultValue(
-            name.to_owned(),
+            name.into(),
             default_value.into(),
         ));
     }
 
     pub fn push_kwargs(&mut self, name: &str) {
-        self.params
-            .push(FunctionParameter::KWArgsDict(name.to_owned()));
+        self.params.push(FunctionParameter::KWArgsDict(name.into()));
     }
 
     pub fn push_args(&mut self, name: &str) {
-        self.params
-            .push(FunctionParameter::ArgsArray(name.to_owned()));
+        self.params.push(FunctionParameter::ArgsArray(name.into()));
     }
     pub fn push_slash(&mut self) {
         assert!(self.positional_count.is_none());

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -15,6 +15,7 @@
 //! Implementation of `struct` function.
 
 use crate::values::error::ValueError;
+use crate::values::string::rc::RcString;
 use crate::values::*;
 use linked_hash_map::LinkedHashMap;
 use std::fmt;
@@ -22,11 +23,11 @@ use std::fmt::Write as _;
 
 /// `struct()` implementation.
 pub struct StarlarkStruct {
-    fields: LinkedHashMap<String, Value>,
+    fields: LinkedHashMap<RcString, Value>,
 }
 
 impl StarlarkStruct {
-    pub(crate) fn new(fields: LinkedHashMap<String, Value>) -> StarlarkStruct {
+    pub(crate) fn new(fields: LinkedHashMap<RcString, Value>) -> StarlarkStruct {
         StarlarkStruct { fields }
     }
 }
@@ -89,7 +90,7 @@ impl TypedValue for StarlarkStruct {
         Ok(self.fields.contains_key(attribute))
     }
 
-    fn dir_attr(&self) -> Result<Vec<String>, ValueError> {
+    fn dir_attr(&self) -> Result<Vec<RcString>, ValueError> {
         Ok(self.fields.keys().cloned().collect())
     }
 }

--- a/starlark/src/values/cell/mod.rs
+++ b/starlark/src/values/cell/mod.rs
@@ -166,7 +166,7 @@ impl<T> ObjectCell<T> {
         }
     }
 
-    pub fn new_immutable_frozen(value: T) -> ObjectCell<T> {
+    pub fn _new_immutable_frozen(value: T) -> ObjectCell<T> {
         ObjectCell {
             header: ObjectHeader::immutable_frozen(),
             value: UnsafeCell::new(value),

--- a/starlark/src/values/string/mod.rs
+++ b/starlark/src/values/string/mod.rs
@@ -22,22 +22,18 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 pub mod interpolation;
+pub mod rc;
 
-use crate::values::cell::ObjectCell;
 use crate::values::frozen::FrozenOnCreation;
 use crate::values::slice_indices::convert_slice_indices;
+use crate::values::string::rc::RcString;
 use std::fmt;
 use std::iter;
-use std::rc::Rc;
 
 impl TypedValue for String {
     type Holder = Immutable<String>;
 
-    fn new_value(self) -> Value {
-        Value(ValueInner::Other(Rc::new(ValueHolder {
-            value: ObjectCell::new_immutable_frozen(self),
-        })))
-    }
+    const INLINE: bool = true;
 
     fn values_for_descendant_check_and_freeze<'a>(
         &'a self,
@@ -59,6 +55,11 @@ impl TypedValue for String {
     }
 
     const TYPE: &'static str = "string";
+
+    fn new_value(self) -> Value {
+        Value(ValueInner::String(RcString::from(self)))
+    }
+
     fn to_bool(&self) -> bool {
         !self.is_empty()
     }

--- a/starlark/src/values/string/rc.rs
+++ b/starlark/src/values/string/rc.rs
@@ -1,0 +1,126 @@
+// Copyright 2019 The Starlark in Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Refcounted string,
+
+use crate::values::inspect::Inspectable;
+use crate::values::Value;
+use crate::values::ValueInner;
+use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
+use std::{fmt, ops};
+
+/// Refcounted string.
+///
+/// Newtype to avoid rewriting a lot of code when implementation changes.
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone)]
+// Note `None` is empty string and `Some("")` is not permitted,
+// otherwise derives won't work correctly
+pub struct RcString(Option<Rc<String>>);
+
+impl Borrow<str> for RcString {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+/// Note `Hash` must be compatible with [`str`], otherwise
+/// `HashMap` query by `str` won't work correctly.
+impl Hash for RcString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
+}
+
+impl ops::Deref for RcString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+static EMPTY_STRING: String = String::new();
+
+impl RcString {
+    /// Useful for downcasting
+    pub(crate) fn as_string(&self) -> &String {
+        match &self.0 {
+            Some(s) => s,
+            None => &EMPTY_STRING,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.as_string().as_str()
+    }
+}
+
+impl fmt::Display for RcString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Debug for RcString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.as_str(), f)
+    }
+}
+
+impl<I: Into<String>> From<I> for RcString {
+    fn from(s: I) -> Self {
+        let s = s.into();
+        if s.is_empty() {
+            RcString(None)
+        } else {
+            RcString(Some(Rc::new(s)))
+        }
+    }
+}
+
+impl From<RcString> for Value {
+    fn from(s: RcString) -> Self {
+        Value(ValueInner::String(s))
+    }
+}
+
+impl Inspectable for RcString {
+    fn inspect(&self) -> Value {
+        Value::from(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::values::string::rc::RcString;
+    use std::borrow::Borrow;
+
+    #[test]
+    fn eq() {
+        assert_eq!(RcString::from("ab"), RcString::from("ab"))
+    }
+
+    #[test]
+    fn from() {
+        assert_eq!("ab", format!("{}", RcString::from("ab")));
+        assert_eq!("ab", format!("{}", RcString::from("ab".to_owned())));
+    }
+
+    #[test]
+    fn borrow() {
+        assert_eq!("ab", Borrow::<str>::borrow(&RcString::from("ab")));
+    }
+}


### PR DESCRIPTION
Use `RcString` (which is a `Option<Rc<String>>`) instead of `String`.

It is `Option<Rc<String>>` not `Rc<String>` to avoid allocation for empty strings.

We copy strings for named arguments, and refcounting is much faster than memory allocation.

It could be `Rc<str>`:
* we will have to allocate-copy when converting from `String`
* `TypedValue` need to be implemented to `Rc<str>`, not `String` because `TypedValue` required sized types. So downcast to `String` have to be replaced with downcast to `RcString`
* `Rc<str>` is slightly faster because one indirection instead of two
* anyway, this can be changed later

Benchmark:

```
def takes_named_args(**kwargs):
    return len(kwargs)

def bench():
    return takes_named_args(
        a0=0,
        a1=1,
        a2=2,
        a3=3,
        a4=4,
        a5=5,
        a6=6,
        a7=7,
        a8=8,
        a9=9,
    )
```

Becomes about 30% faster.

@cjhopman pointed to this issue.