### PR TITLE
Don't use reference counting for file loader

### DIFF
--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -82,7 +82,7 @@ fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
             lexer,
             env,
             type_values,
-            SimpleFileLoader::new(&map.clone(), file_loader_env),
+            &SimpleFileLoader::new(&map.clone(), file_loader_env),
         ) {
             Ok(v) => {
                 if v.get_type() != "NoneType" {

--- a/starlark-test/src/lib.rs
+++ b/starlark-test/src/lib.rs
@@ -131,7 +131,7 @@ impl FileLoader for HashMapFileLoader {
             Dialect::Bzl,
             &mut env,
             type_values,
-            self.clone(),
+            self,
         )?;
         Ok(env)
     }
@@ -175,7 +175,7 @@ def assert_(cond, msg="assertion failed"):
         starlark::syntax::dialect::Dialect::Bzl,
         &mut prelude.child(path),
         &type_values,
-        HashMapFileLoader {
+        &HashMapFileLoader {
             parent: prelude.clone(),
             files: test.files.clone(),
             map: map.clone(),

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -65,6 +65,6 @@ pub fn eval(
         dialect,
         env,
         type_values,
-        NoLoadFileLoader,
+        &NoLoadFileLoader,
     )
 }

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -55,7 +55,7 @@ impl FileLoader for SimpleFileLoader {
             Dialect::Bzl,
             &mut env,
             type_values,
-            self.clone(),
+            self,
         ) {
             return Err(EvalException::DiagnosedError(d));
         }
@@ -96,7 +96,7 @@ pub fn eval(
         dialect,
         env,
         type_values,
-        SimpleFileLoader::new(map, file_loader_env),
+        &SimpleFileLoader::new(map, file_loader_env),
     )
 }
 
@@ -125,6 +125,6 @@ pub fn eval_file(
         build,
         env,
         type_values,
-        SimpleFileLoader::new(map, file_loader_env),
+        &SimpleFileLoader::new(map, file_loader_env),
     )
 }

--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -183,7 +183,7 @@ def f(): return x
             Dialect::Build,
             &mut env,
             &TypeValues::default(),
-            TestContextCapturedFileLoader {}
+            &TestContextCapturedFileLoader {}
         )
         .unwrap()
     );
@@ -239,7 +239,7 @@ fn test_type_values_are_imported_from_caller() {
         Dialect::Bzl,
         &mut env,
         &type_values,
-        MyFileLoader {},
+        &MyFileLoader {},
     )
     .unwrap();
 


### PR DESCRIPTION
Passing around the `FileLoader` as an `Rc` is not needed since the loader lives for a very well defined lifetime, and it additionally forces the `FileLoader` to be `'static`, which ended up being a problem for my use-case where I want to use a scoped loader.

This PR replaces the `Rc` with a normal reference.  This is an API-breaking change.