### PR TITLE
Merge starlark_ok! and starlark_fail! macros

### DIFF
--- a/starlark/src/eval/tests.rs
+++ b/starlark/src/eval/tests.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::environment::{Environment, TypeValues};
+use crate::environment::Environment;
+use crate::environment::TypeValues;
+use crate::eval::eval;
 use crate::eval::testutil::starlark_no_diagnostic;
-use crate::eval::{eval, testutil, EvalException, FileLoader};
+use crate::eval::EvalException;
+use crate::eval::FileLoader;
 use crate::eval::{noload, RECURSION_ERROR_CODE};
 use crate::syntax::dialect::Dialect;
 use crate::values::Value;

--- a/starlark/src/eval/testutil.rs
+++ b/starlark/src/eval/testutil.rs
@@ -16,40 +16,10 @@
 use crate::environment;
 use crate::environment::TypeValues;
 use crate::eval;
-use crate::eval::noload;
 use crate::syntax::dialect::Dialect;
 use codemap::CodeMap;
-use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
+use codemap_diagnostic::Diagnostic;
 use std::sync;
-
-/// Execute a starlark snippet with an empty environment.
-pub fn starlark_empty(snippet: &str) -> Result<bool, Diagnostic> {
-    let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    let mut env = environment::Environment::new("test");
-    match noload::eval(
-        &map,
-        "<test>",
-        snippet,
-        Dialect::Bzl,
-        &mut env,
-        &TypeValues::default(),
-    ) {
-        Ok(v) => Ok(v.to_bool()),
-        Err(d) => {
-            Emitter::stderr(ColorConfig::Always, Some(&map.lock().unwrap())).emit(&[d.clone()]);
-            Err(d)
-        }
-    }
-}
-
-/// Execute a starlark snippet with an empty environment.
-pub fn starlark_empty_no_diagnostic(snippet: &str) -> Result<bool, Diagnostic> {
-    starlark_no_diagnostic(
-        &mut environment::Environment::new("test"),
-        snippet,
-        &TypeValues::default(),
-    )
-}
 
 /// Execute a starlark snippet with the passed environment.
 pub fn starlark_no_diagnostic(
@@ -89,10 +59,10 @@ macro_rules! starlark_fail_fn {
 
 /// A simple macro to execute a Starlark snippet and fails if the last statement is false.
 macro_rules! starlark_ok {
-    ($($t:expr),+) => (starlark_ok_fn!(testutil::starlark_empty, $($t),+))
+    ($($t:expr),+) => (starlark_ok_fn!($crate::stdlib::starlark_default, $($t),+))
 }
 
 /// Test that the execution of a starlark code raise an error
 macro_rules! starlark_fail {
-    ($($t:expr),+) => (starlark_fail_fn!(testutil::starlark_empty_no_diagnostic, $($t),+))
+    ($($t:expr),+) => (starlark_fail_fn!($crate::stdlib::tests::starlark_default_fail, $($t),+))
 }

--- a/starlark/src/stdlib/dict.rs
+++ b/starlark/src/stdlib/dict.rs
@@ -350,17 +350,7 @@ starlark_module! {global =>
 
 #[cfg(test)]
 mod tests {
-    use super::super::starlark_default;
-    use super::super::tests::starlark_default_fail;
     use super::*;
-
-    macro_rules! starlark_ok {
-        ($($t:expr),+) => (starlark_ok_fn!(starlark_default, $($t),+))
-    }
-
-    macro_rules! starlark_fail {
-        ($($t:expr),+) => (starlark_fail_fn!(starlark_default_fail, $($t),+))
-    }
 
     #[test]
     fn test_clear() {

--- a/starlark/src/stdlib/list.rs
+++ b/starlark/src/stdlib/list.rs
@@ -251,17 +251,7 @@ starlark_module! {global =>
 
 #[cfg(test)]
 mod tests {
-    use super::super::starlark_default;
-    use super::super::tests::starlark_default_fail;
     use super::LIST_REMOVE_ELEMENT_NOT_FOUND_ERROR_CODE;
-
-    macro_rules! starlark_ok {
-        ($($t:expr),+) => (starlark_ok_fn!(starlark_default, $($t),+))
-    }
-
-    macro_rules! starlark_fail {
-        ($($t:expr),+) => (starlark_fail_fn!(starlark_default_fail, $($t),+))
-    }
 
     #[test]
     fn test_append() {

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -992,7 +992,6 @@ pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
 #[cfg(test)]
 pub mod tests {
     use super::global_environment;
-    use super::starlark_default;
     use super::Dialect;
     use crate::eval::noload::eval;
     use codemap::CodeMap;
@@ -1014,16 +1013,6 @@ pub mod tests {
             Ok(v) => Ok(v.to_bool()),
             Err(d) => Err(d),
         }
-    }
-
-    /// A simple macro to execute a Starlark snippet and fails if the last statement is false.
-    macro_rules! starlark_ok {
-        ($($t:expr),+) => (starlark_ok_fn!(starlark_default, $($t),+))
-    }
-
-    /// Test that the execution of a starlark code raise an error
-    macro_rules! starlark_fail {
-        ($($t:expr),+) => (starlark_fail_fn!(starlark_default_fail, $($t),+))
     }
 
     #[test]

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -1333,18 +1333,8 @@ starlark_module! {global =>
 
 #[cfg(test)]
 mod tests {
-    use super::super::starlark_default;
-    use super::super::tests::starlark_default_fail;
     use super::*;
     use crate::values::dict;
-
-    macro_rules! starlark_ok {
-        ($($t:expr),+) => (starlark_ok_fn!(starlark_default, $($t),+))
-    }
-
-    macro_rules! starlark_fail {
-        ($($t:expr),+) => (starlark_fail_fn!(starlark_default_fail, $($t),+))
-    }
 
     #[test]
     fn test_format_capture() {


### PR DESCRIPTION
Note some `starlark_ok!` macros worked with empty environment while
others worked with default environment.  Now all macros work with
default environment. This is needed because certain operations like
integer addition will soon stop to work with empty environment.

Alternatively if we still need test with empty environment, we
should still merge macros, but create distinct names for macros
with and without default environment.