### PR TITLE
Store * and + operator implementations in TypeValues

### DIFF
--- a/starlark-test/tests/go-testcases/list.sky
+++ b/starlark-test/tests/go-testcases/list.sky
@@ -39,9 +39,9 @@ f2()  ### Out of bound
 # list + list
 assert_eq([1, 2, 3] + [3, 4, 5], [1, 2, 3, 3, 4, 5])
 ---
-[1, 2] + (3, 4)  ### Type of parameters mismatch
+[1, 2] + (3, 4)  ### + not supported for types list and tuple
 ---
-(1, 2) + [3, 4]  ### Type of parameters mismatch
+(1, 2) + [3, 4]  ### + not supported for types tuple and list
 ---
 
 # list * int,  int * list
@@ -133,7 +133,7 @@ f4()
 def f5():
   x = []
   x += 1
-f5()  ### Type of parameters mismatch
+f5()  ### + not supported for types list and int
 ---
 
 # append

--- a/starlark-test/tests/rust-testcases/bool.sky
+++ b/starlark-test/tests/rust-testcases/bool.sky
@@ -1,7 +1,7 @@
 # Boolean tests
 
-True + 9223372036854775807   ###  Type of parameters mismatch
+True + 9223372036854775807   ###  + not supported for types bool and int
 ---
-[] * True                    ###  Type of parameters mismatch
+[] * True                    ###  * not supported for types list and bool
 ---
-() * False                   ###  Type of parameters mismatch
+() * False                   ###  * not supported for types tuple and bool

--- a/starlark-test/tests/rust-testcases/regression.sky
+++ b/starlark-test/tests/rust-testcases/regression.sky
@@ -1,5 +1,5 @@
 # Regression for https://github.com/google/starlark-rust/issues/10
-"abc" * True  ### Type of parameters mismatch
+"abc" * True  ###  * not supported for types string and bool
 ---
 # Make sure int * string works as well as string * int
 assert_eq(3 * "abc", "abcabcabc")

--- a/starlark/src/environment/bin_op.rs
+++ b/starlark/src/environment/bin_op.rs
@@ -1,0 +1,101 @@
+use crate::values::cell::ObjectRef;
+use crate::values::error::ValueError;
+use crate::values::TypedValue;
+use crate::values::Value;
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::fmt;
+
+/// Define certain global binary operators.
+///
+/// Most custom type operations are defined using virtual functions on [`Value`],
+/// e. g. unary plus or equals.
+///
+/// However, for certain type the operation may be defined by RHS, e. g.
+/// multiplication `integer * collection` should be defined for collection
+/// type, not for collection type, i. e. for RHS, not LHS.
+///
+/// Python to solve this riddle allows overriding `__mul__` on LHS or `__rmul__` or RHS,
+/// and `__rmul__` is used when `__mul__` is not defined.
+///
+/// Starlark-rust could use the same approach, but instead certain binary operations
+/// are stored in [`TypeValues`] object similarly to type-defined methods.
+#[derive(Eq, PartialEq, Hash, Clone, Copy)]
+pub enum CustomBinOp {
+    Addition,
+    Multiplication,
+}
+
+impl fmt::Display for CustomBinOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                CustomBinOp::Addition => "+",
+                CustomBinOp::Multiplication => "*",
+            }
+        )
+    }
+}
+
+/// Global registry of certain binary operators.
+#[derive(Default)]
+pub(crate) struct BinOpRegistry {
+    bin_ops: HashMap<
+        (TypeId, TypeId, CustomBinOp),
+        Box<dyn Fn(&Value, &Value) -> Result<Value, ValueError>>,
+    >,
+}
+
+impl BinOpRegistry {
+    /// Register a binary operator for a pair of types.
+    pub fn register_bin_op<
+        A: TypedValue,
+        B: TypedValue,
+        R: Into<Value>,
+        F: Fn(&A, &B) -> Result<R, ValueError> + 'static,
+    >(
+        &mut self,
+        bin_op: CustomBinOp,
+        f: F,
+    ) {
+        let prev = self.bin_ops.insert(
+            (TypeId::of::<A>(), TypeId::of::<B>(), bin_op),
+            Box::new(move |l, r| {
+                let l: ObjectRef<A> = l.downcast_ref().unwrap();
+                let r: ObjectRef<B> = r.downcast_ref().unwrap();
+                f(&*l, &*r).map(R::into)
+            }),
+        );
+        assert!(
+            prev.is_none(),
+            "Cannot register operation {} for {} and {} again",
+            bin_op,
+            A::TYPE,
+            B::TYPE
+        );
+    }
+
+    /// Eval previously registered bin op
+    pub fn eval_bin_op(
+        &self,
+        bin_op: CustomBinOp,
+        l: &Value,
+        r: &Value,
+    ) -> Result<Value, ValueError> {
+        let lt = l.get_type_id();
+        let rt = r.get_type_id();
+        let f = match self.bin_ops.get(&(lt, rt, bin_op)) {
+            Some(f) => f,
+            None => {
+                return Err(ValueError::OperationNotSupported {
+                    op: format!("{}", bin_op),
+                    left: l.get_type().to_string(),
+                    right: Some(r.get_type().to_string()),
+                });
+            }
+        };
+        f(l, r)
+    }
+}

--- a/starlark/src/linked_hash_set/mod.rs
+++ b/starlark/src/linked_hash_set/mod.rs
@@ -1,4 +1,5 @@
-use crate::environment::{Environment, TypeValues};
+use crate::environment::Environment;
+use crate::environment::TypeValues;
 
 pub(crate) mod set_impl;
 mod stdlib;
@@ -7,5 +8,8 @@ pub(crate) mod value;
 /// Include `set` constructor and set functions in environment.
 pub fn global(env: &mut Environment, type_values: &mut TypeValues) {
     self::stdlib::global(env, type_values);
+
     env.with_set_constructor(Box::new(crate::linked_hash_set::value::Set::from));
+
+    value::global(type_values);
 }

--- a/starlark/src/values/string/interpolation.rs
+++ b/starlark/src/values/string/interpolation.rs
@@ -308,7 +308,7 @@ impl ArgsFormat {
         Ok(result)
     }
 
-    pub fn format(self, other: Value) -> Result<String, ValueError> {
+    pub fn format(self, other: &Value) -> Result<String, ValueError> {
         let mut r = self.init;
         let other_iter;
         let mut arg_iter: Box<dyn Iterator<Item = Value>> = if self.positional_count > 1 {
@@ -355,7 +355,7 @@ mod test {
         // "Hello %s, your score is %d" % ("Bob", 75) == "Hello Bob, your score is 75"
         assert_eq!(
             Value::from("Hello %s, your score is %d")
-                .percent(Value::from(("Bob", 75)))
+                .percent(&Value::from(("Bob", 75)))
                 .unwrap(),
             Value::from("Hello Bob, your score is 75")
         );
@@ -363,7 +363,7 @@ mod test {
         // "%d %o %x %c" % (65, 65, 65, 65) == "65 101 41 A"
         assert_eq!(
             Value::from("%d %o %x %c")
-                .percent(Value::from((65, 65, 65, 65)))
+                .percent(&Value::from((65, 65, 65, 65)))
                 .unwrap(),
             Value::from("65 101 41 A")
         );
@@ -377,7 +377,7 @@ mod test {
             .unwrap();
         assert_eq!(
             Value::from("%(greeting)s, %(audience)s")
-                .percent(d)
+                .percent(&d)
                 .unwrap(),
             Value::from("Hello, world")
         );
@@ -388,11 +388,11 @@ mod test {
         let mut d = Value::try_from(HashMap::<String, Value>::new()).unwrap();
         d.set_at(Value::from("a"), Value::from(1)).unwrap();
         assert_eq!(
-            Value::from("%s%(a)%").percent(d.clone()).unwrap(),
+            Value::from("%s%(a)%").percent(&d).unwrap(),
             Value::from("{\"a\": 1}%")
         );
         assert_eq!(
-            Value::from("%s%(a)s").percent(d.clone()).unwrap(),
+            Value::from("%s%(a)s").percent(&d).unwrap(),
             Value::from("{\"a\": 1}1")
         );
     }


### PR DESCRIPTION
Certain operations like `+` or `*` cannot be defined on LHS.

For example to be able to embed Starlark in Bazel, implementation
should be able to override `+` for list and select types:

```
[] + select({...})
```

To solve this issue Python types define a pair of operators, for
plus it is `__add__` and `__radd__`. Former is called on LHS, and
if it is not defined, `__radd__` is used on RHS.

We could do the same, but alternatively we can store operator
implementations for each type pair in `TypeValues` object, this way
operators become symmetrical between LHS and RHS.

This diff implements storing `+` and `*` in `TypeValues`, the rest
operators (including unary operators) are still implemented as
virtual functions of `TypedValue`.