### PR TITLE
Remove REPL --ast option

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -16,17 +16,12 @@
 
 extern crate structopt;
 
-use codemap::CodeMap;
-use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use starlark::eval::interactive::{eval, eval_file, EvalError};
-use starlark::eval::module::Module;
 use starlark::stdlib::global_environment_for_repl_and_tests;
 use starlark::syntax::dialect::Dialect;
-use starlark::syntax::parser::{parse, parse_file};
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
 use std::process::exit;
-use std::sync::{Arc, Mutex};
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
@@ -39,9 +34,6 @@ const EXIT_CODE_FAILURE: i32 = 2;
     global_settings(&[AppSettings::ColoredHelp]),
 )]
 pub struct Opt {
-    #[structopt(short = "a", long, help = "Parse and print AST instead of evaluating.")]
-    ast: bool,
-
     #[structopt(
         short = "b",
         long,
@@ -75,7 +67,6 @@ fn main() {
     let opt = Opt::from_args();
 
     let command = opt.command;
-    let ast = opt.ast;
 
     let (mut global, mut type_values) = global_environment_for_repl_and_tests();
 
@@ -89,50 +80,27 @@ fn main() {
     };
     let free_args_empty = opt.files.is_empty();
     for i in opt.files.into_iter() {
-        if ast {
-            let codemap = Arc::new(Mutex::new(CodeMap::new()));
-            maybe_print_ast_or_exit(parse_file(&codemap, &i, dialect), &codemap);
-        } else {
-            maybe_print_or_exit(eval_file(
-                &i,
-                dialect,
-                &mut global.child(&i),
-                &type_values,
-                global.clone(),
-            ));
-        }
+        maybe_print_or_exit(eval_file(
+            &i,
+            dialect,
+            &mut global.child(&i),
+            &type_values,
+            global.clone(),
+        ));
     }
     if opt.repl || (free_args_empty && command.is_none()) {
         println!("Welcome to Starlark REPL, press Ctrl+D to exit.");
-        repl(&mut global, &type_values, dialect, ast);
+        repl(&mut global, &type_values, dialect);
     }
     if let Some(command) = command {
-        let path = "[command flag]";
-        if ast {
-            let codemap = Arc::new(Mutex::new(CodeMap::new()));
-            maybe_print_ast_or_exit(parse(&codemap, path, &command, dialect), &codemap);
-        } else {
-            maybe_print_or_exit(eval(
-                "[command flag]",
-                &command,
-                dialect,
-                &mut global.child("[command flag]"),
-                &type_values,
-                global.clone(),
-            ));
-        }
-    }
-}
-
-fn maybe_print_ast_or_exit(result: Result<Module, Diagnostic>, codemap: &Arc<Mutex<CodeMap>>) {
-    match result {
-        Ok(ast) => {
-            println!("{:#?}", ast);
-        }
-        Err(diagnostic) => {
-            Emitter::stderr(ColorConfig::Auto, Some(&*codemap.lock().unwrap())).emit(&[diagnostic]);
-            exit(EXIT_CODE_FAILURE);
-        }
+        maybe_print_or_exit(eval(
+            "[command flag]",
+            &command,
+            dialect,
+            &mut global.child("[command flag]"),
+            &type_values,
+            global.clone(),
+        ));
     }
 }
 


### PR DESCRIPTION
All known parsing problems are fixed now, so this option is not
very useful.

On the other hand now we have `inspect` function which also helps
in problem diagnostics.