### PR TITLE
UnOp enum

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -37,6 +37,7 @@ use crate::eval::stmt::AstStatementCompiled;
 use crate::eval::stmt::BlockCompiled;
 use crate::eval::stmt::StatementCompiled;
 use crate::syntax::ast::BinOp;
+use crate::syntax::ast::UnOp;
 use crate::syntax::ast::*;
 use crate::syntax::dialect::Dialect;
 use crate::syntax::errors::SyntaxError;
@@ -481,8 +482,8 @@ fn eval_expr<E: EvaluationContextEnvironment>(
         ExprCompiled::Name(ref name) => t(context.env.get(&name.node), name),
         ExprCompiled::Value(ref v) => Ok(v.clone()),
         ExprCompiled::Not(ref s) => Ok(Value::new(!eval_expr(s, context)?.to_bool())),
-        ExprCompiled::Minus(ref s) => t(eval_expr(s, context)?.minus(), expr),
-        ExprCompiled::Plus(ref s) => t(eval_expr(s, context)?.plus(), expr),
+        ExprCompiled::UnOp(UnOp::Minus, ref s) => t(eval_expr(s, context)?.minus(), expr),
+        ExprCompiled::UnOp(UnOp::Plus, ref s) => t(eval_expr(s, context)?.plus(), expr),
         ExprCompiled::Or(ref l, ref r) => {
             let l = eval_expr(l, context)?;
             Ok(if l.to_bool() {
@@ -499,7 +500,7 @@ fn eval_expr<E: EvaluationContextEnvironment>(
                 eval_expr(r, context)?
             })
         }
-        ExprCompiled::Op(op, ref l, ref r) => eval_bin_op(expr, op, l, r, context),
+        ExprCompiled::BinOp(op, ref l, ref r) => eval_bin_op(expr, op, l, r, context),
         ExprCompiled::If(ref cond, ref v1, ref v2) => {
             if eval_expr(cond, context)?.to_bool() {
                 eval_expr(v1, context)

--- a/starlark/src/syntax/grammar.lalrpop
+++ b/starlark/src/syntax/grammar.lalrpop
@@ -179,7 +179,7 @@ TestList: AstExpr = L<Test>;
 
 PipedExpr: AstExpr = {
     <l:@L> <e1:ArithExpr> "|" <e2:PipedExpr> <r:@R>
-      => Expr::Op(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
+      => Expr::BinOp(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
     ArithExpr
 };
 
@@ -295,57 +295,57 @@ NotTest: AstExpr = {
 
 CompTest: AstExpr = {
     <l:@L> <e1:Expr> "==" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::EqualsTo, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::EqualsTo, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> "!=" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::Different, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Different, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> "<" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::LowerThan, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::LowerThan, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> ">" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::GreaterThan, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::GreaterThan, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> "<=" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::LowerOrEqual, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::LowerOrEqual, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> ">=" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::GreaterOrEqual, e1, e2)
+        => Expr::BinOp(BinOp::GreaterOrEqual, e1, e2)
                       .to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> "in" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::In, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::In, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:Expr> "not in" <e2:CompTest> <r:@R>
-        => Expr::Op(BinOp::NotIn, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::NotIn, e1, e2).to_ast(file_span.subspan(l, r)),
     Expr
 };
 
 Expr: AstExpr = {
     <l:@L> <e1:ArithExpr> "|" <e2:Expr> <r:@R>
-        => Expr::Op(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Pipe, e1, e2).to_ast(file_span.subspan(l, r)),
     ArithExpr,
 };
 
 ArithExpr: AstExpr = {
     <l:@L> <e1:ArithExpr> "+" <e2:ProductExpr> <r:@R>
-        => Expr::Op(BinOp::Addition, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Addition, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:ArithExpr> "-" <e2:ProductExpr> <r:@R>
-        => Expr::Op(BinOp::Substraction, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Substraction, e1, e2).to_ast(file_span.subspan(l, r)),
     ProductExpr,
 };
 
 ProductExpr: AstExpr = {
     <l:@L> <e1:ProductExpr> "*" <e2:FactorExpr> <r:@R>
-        => Expr::Op(BinOp::Multiplication, e1, e2)
+        => Expr::BinOp(BinOp::Multiplication, e1, e2)
             .to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:ProductExpr> "%" <e2:FactorExpr> <r:@R>
-        => Expr::Op(BinOp::Percent, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Percent, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:ProductExpr> "/" <e2:FactorExpr> <r:@R>
-        => Expr::Op(BinOp::Division, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::Division, e1, e2).to_ast(file_span.subspan(l, r)),
     <l:@L> <e1:ProductExpr> "//" <e2:FactorExpr> <r:@R>
-        => Expr::Op(BinOp::FloorDivision, e1, e2).to_ast(file_span.subspan(l, r)),
+        => Expr::BinOp(BinOp::FloorDivision, e1, e2).to_ast(file_span.subspan(l, r)),
     FactorExpr
 };
 
 FactorExpr: AstExpr = {
     <l:@L> "+" <e:FactorExpr> <r:@R>
-        => Expr::Plus(e).to_ast(file_span.subspan(l, r)),
+        => Expr::UnOp(UnOp::Plus, e).to_ast(file_span.subspan(l, r)),
     <l:@L> "-" <e:FactorExpr> <r:@R>
-        => Expr::Minus(e).to_ast(file_span.subspan(l, r)),
+        => Expr::UnOp(UnOp::Minus, e).to_ast(file_span.subspan(l, r)),
     PrimaryExpr
 };
 


### PR DESCRIPTION
Similar to `BinOp` enum.

To reduce some repetitive code.