### PR TITLE
ValueOther helper type

### DIFF
--- a/starlark/src/eval/def.rs
+++ b/starlark/src/eval/def.rs
@@ -41,13 +41,18 @@ use crate::syntax::ast::Parameter;
 use crate::syntax::ast::Statement;
 use crate::values::context::EvaluationContextEnvironmentLocal;
 use crate::values::error::ValueError;
+use crate::values::function;
 use crate::values::function::FunctionParameter;
 use crate::values::function::FunctionSignature;
 use crate::values::function::FunctionType;
 use crate::values::function::StrOrRepr;
 use crate::values::inspect::Inspectable;
 use crate::values::none::NoneType;
-use crate::values::{function, Immutable, TypedValue, Value, ValueResult};
+use crate::values::Immutable;
+use crate::values::TypedValue;
+use crate::values::Value;
+use crate::values::ValueOther;
+use crate::values::ValueResult;
 use codemap::{CodeMap, Spanned};
 use codemap_diagnostic::Diagnostic;
 use linked_hash_map::LinkedHashMap;
@@ -205,11 +210,11 @@ impl Def {
         stmt: DefCompiled,
         map: Arc<Mutex<CodeMap>>,
         env: Environment,
-    ) -> Value {
+    ) -> ValueOther<Def> {
         // This can be implemented by delegating to `Function::new`,
         // but having a separate type allows slight more efficient implementation
         // and optimizations in the future.
-        Value::new(Def {
+        ValueOther::new(Def {
             function_type: FunctionType::Def(stmt.name.node.clone(), module),
             signature,
             stmt,

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -522,14 +522,15 @@ fn eval_expr<E: EvaluationContextEnvironment>(
             Ok(Value::from(r))
         }
         ExprCompiled::Dict(ref v) => {
-            let mut r = dict::Dictionary::new();
+            let r = dict::Dictionary::new();
             for s in v.iter() {
                 t(
-                    r.set_at(eval_expr(&s.0, context)?, eval_expr(&s.1, context)?),
+                    r.borrow_mut()
+                        .set_at(eval_expr(&s.0, context)?, eval_expr(&s.1, context)?),
                     expr,
                 )?
             }
-            Ok(r)
+            Ok(r.into())
         }
         ExprCompiled::Set(ref v) => {
             let mut values = Vec::with_capacity(v.len());
@@ -715,10 +716,10 @@ fn eval_stmt<E: EvaluationContextEnvironment>(
             t(
                 context
                     .env
-                    .set_global(stmt.slot, &stmt.name.node, f.clone()),
+                    .set_global(stmt.slot, &stmt.name.node, f.clone().into()),
                 &stmt.name,
             )?;
-            Ok(f)
+            Ok(f.into())
         }
         StatementCompiled::Load(ref name, ref v) => {
             let loadenv = context

--- a/starlark/src/linked_hash_set/value.rs
+++ b/starlark/src/linked_hash_set/value.rs
@@ -29,8 +29,8 @@ pub(crate) struct Set {
 }
 
 impl Set {
-    pub fn _empty() -> Value {
-        Value::new(Set::default())
+    pub fn _new() -> ValueOther<Set> {
+        ValueOther::default()
     }
 
     pub fn from<V: Into<Value>>(values: Vec<V>) -> Result<Value, ValueError> {

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -236,13 +236,13 @@ starlark_module! {global_functions =>
     /// # )").unwrap());
     /// ```
     dict(?a, /, **kwargs) {
-        let mut map = Dictionary::new();
+        let map = Dictionary::new();
         if let Some(a) = a {
             match a.get_type() {
                 "dict" => {
                     for k in &a.iter()? {
                         let v = a.at(k.clone())?;
-                        map.set_at(k, v)?;
+                        map.borrow_mut().set_at(k, v)?;
                     }
                 },
                 _ => {
@@ -262,7 +262,7 @@ starlark_module! {global_functions =>
                                         "Non-pair element in first argument".to_owned()
                                     );
                                 }
-                                map.set_at(first.unwrap(), second.unwrap())?;
+                                map.borrow_mut().set_at(first.unwrap(), second.unwrap())?;
                            }
                            Err(..) =>
                                starlark_err!(
@@ -279,9 +279,9 @@ starlark_module! {global_functions =>
            }
        }
        for (k, v) in kwargs {
-           map.set_at(k.into(), v)?;
+           map.borrow_mut().set_at(k.into(), v)?;
        }
-       Ok(map)
+       Ok(map.into())
     }
 
     /// [dir](

--- a/starlark/src/stdlib/string.rs
+++ b/starlark/src/stdlib/string.rs
@@ -1339,7 +1339,7 @@ mod tests {
     #[test]
     fn test_format_capture() {
         let args = Value::from(vec!["1", "2", "3"]);
-        let mut kwargs = dict::Dictionary::new();
+        let mut kwargs: Value = dict::Dictionary::new().into();
         let it = args.iter().unwrap();
         let mut it = it.iter();
         let mut captured_by_index = false;

--- a/starlark/src/values/boolean.rs
+++ b/starlark/src/values/boolean.rs
@@ -32,6 +32,8 @@ impl TypedValue for bool {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "bool";
 
+    const INLINE: bool = true;
+
     fn new_value(self) -> Value {
         Value(ValueInner::Bool(self))
     }

--- a/starlark/src/values/dict.rs
+++ b/starlark/src/values/dict.rs
@@ -30,14 +30,14 @@ pub struct Dictionary {
 }
 
 impl Dictionary {
-    pub fn new_typed() -> Dictionary {
+    pub(crate) fn new_typed() -> Dictionary {
         Dictionary {
             content: LinkedHashMap::new(),
         }
     }
 
-    pub fn new() -> Value {
-        Value::new(Dictionary::new_typed())
+    pub(crate) fn new() -> ValueOther<Dictionary> {
+        ValueOther::default()
     }
 
     pub fn get_content(&self) -> &LinkedHashMap<HashedValue, Value> {

--- a/starlark/src/values/int.rs
+++ b/starlark/src/values/int.rs
@@ -88,6 +88,8 @@ impl TypedValue for i64 {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "int";
 
+    const INLINE: bool = true;
+
     fn new_value(self) -> Value {
         Value(ValueInner::Int(self))
     }

--- a/starlark/src/values/list.rs
+++ b/starlark/src/values/list.rs
@@ -41,12 +41,6 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
 }
 
 impl List {
-    pub fn new() -> Value {
-        Value::new(List {
-            content: Vec::new(),
-        })
-    }
-
     pub fn push(&mut self, value: Value) -> Result<(), ValueError> {
         let value = value.clone_for_container(self)?;
         self.content.push(value);

--- a/starlark/src/values/none.rs
+++ b/starlark/src/values/none.rs
@@ -32,6 +32,8 @@ impl TypedValue for NoneType {
     type Holder = Immutable<Self>;
     const TYPE: &'static str = "NoneType";
 
+    const INLINE: bool = true;
+
     fn new_value(self) -> Value {
         Value(ValueInner::None(self))
     }


### PR DESCRIPTION
Similar to `Value`, but
* parameterized by content type
* cannot store by value, only in `Rc`
* cannot store primitive types int, bool, NoneType

Needed to implement constant propagation (#220).