### PR TITLE
Make unsupported operation error an enum

### DIFF
--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -50,6 +50,7 @@ use crate::values::context::EvaluationContextEnvironmentModule;
 use crate::values::context::IndexedGlobals;
 use crate::values::context::IndexedLocals;
 use crate::values::dict::Dictionary;
+use crate::values::error::UnsupportedOperation;
 use crate::values::error::ValueError;
 use crate::values::function::FunctionParameter;
 use crate::values::function::FunctionSignature;
@@ -245,7 +246,7 @@ fn eval_bin_op(op: BinOp, l: Value, r: Value) -> Result<Value, ValueError> {
         BinOp::Division => {
             // No types currently support / so always error.
             return Err(ValueError::OperationNotSupported {
-                op: "/".to_string(),
+                op: UnsupportedOperation::Div,
                 left: l.get_type().to_string(),
                 right: Some(r.get_type().to_string()),
             });

--- a/starlark/src/stdlib/structs.rs
+++ b/starlark/src/stdlib/structs.rs
@@ -14,6 +14,7 @@
 
 //! Implementation of `struct` function.
 
+use crate::values::error::UnsupportedOperation;
 use crate::values::error::ValueError;
 use crate::values::string::rc::RcString;
 use crate::values::*;
@@ -79,7 +80,7 @@ impl TypedValue for StarlarkStruct {
         match self.fields.get(attribute) {
             Some(v) => Ok(v.clone()),
             None => Err(ValueError::OperationNotSupported {
-                op: attribute.to_owned(),
+                op: UnsupportedOperation::GetAttr(attribute.to_owned()),
                 left: self.to_repr(),
                 right: None,
             }),

--- a/starlark/src/values/error.rs
+++ b/starlark/src/values/error.rs
@@ -19,6 +19,7 @@ use crate::values::string::interpolation::StringInterpolationError;
 use crate::values::*;
 use codemap::Span;
 use codemap_diagnostic::{Diagnostic, SpanLabel, SpanStyle};
+use std::fmt;
 
 // TODO: move that code in some common error code list?
 // CV prefix = Critical Value expression
@@ -41,12 +42,62 @@ pub const INTERPOLATION_UNEXPECTED_EOF_CLOSING_PAREN: &str = "CV17";
 pub const INTERPOLATION_UNEXPECTED_EOF_PERCENT: &str = "CV18";
 pub const INTERPOLATION_UNKNOWN_SPECIFIER: &str = "CV19";
 
+/// Value used in diagnostics
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum UnsupportedOperation {
+    Compare,
+    ToInt,
+    Call,
+    At,
+    SetAt,
+    Slice,
+    Len,
+    GetAttr(String),
+    HasAttr,
+    SetAttr(String),
+    Dir,
+    In,
+    Plus,
+    Minus,
+    Mul,
+    Div,
+    FloorDiv,
+    Percent,
+    Pipe,
+}
+
+impl fmt::Display for UnsupportedOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnsupportedOperation::Compare => write!(f, "compare"),
+            UnsupportedOperation::ToInt => write!(f, "int()"),
+            UnsupportedOperation::Call => write!(f, "call()"),
+            UnsupportedOperation::At => write!(f, "[]"),
+            UnsupportedOperation::SetAt => write!(f, "[] ="),
+            UnsupportedOperation::Slice => write!(f, "[::]"),
+            UnsupportedOperation::Len => write!(f, "len()"),
+            UnsupportedOperation::GetAttr(attr) => write!(f, ".{}", attr),
+            UnsupportedOperation::HasAttr => write!(f, "has_attr()"),
+            UnsupportedOperation::SetAttr(attr) => write!(f, ".{} =", attr),
+            UnsupportedOperation::Dir => write!(f, "dir()"),
+            UnsupportedOperation::In => write!(f, "in"),
+            UnsupportedOperation::Plus => write!(f, "+"),
+            UnsupportedOperation::Minus => write!(f, "-"),
+            UnsupportedOperation::Mul => write!(f, "*"),
+            UnsupportedOperation::Div => write!(f, "/"),
+            UnsupportedOperation::FloorDiv => write!(f, "//"),
+            UnsupportedOperation::Percent => write!(f, "%"),
+            UnsupportedOperation::Pipe => write!(f, "|"),
+        }
+    }
+}
+
 /// Error that can be returned by function from the `TypedValue` trait,
 #[derive(Clone, Debug)]
 pub enum ValueError {
     /// The operation is not supported for this type.
     OperationNotSupported {
-        op: String,
+        op: UnsupportedOperation,
         left: String,
         right: Option<String>,
     },


### PR DESCRIPTION
Mainly to avoid allocations.

Also make `get_attr` error consistent across impls.