### PR TITLE
Remove Error::description calls

### DIFF
--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -18,7 +18,6 @@ use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
 use linked_hash_map::LinkedHashMap;
 use std;
 use std::cmp::Ordering;
-use std::error::Error;
 use std::num::NonZeroI64;
 use std::sync;
 
@@ -474,7 +473,7 @@ starlark_module! {global_functions =>
                         "{} is not a valid number in base {}: {}",
                         a.to_repr(),
                         base,
-                        x.description(),
+                        x,
                     ),
                     format!("Not a base {} integer", base)
                 ),

--- a/starlark/src/syntax/parser.rs
+++ b/starlark/src/syntax/parser.rs
@@ -18,7 +18,6 @@ use super::grammar::{BuildFileParser, StarlarkParser};
 use super::lexer::{Lexer, LexerError, LexerIntoIter, LexerItem, Token};
 use codemap::{CodeMap, Span};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::sync::{Arc, Mutex};
@@ -145,7 +144,7 @@ macro_rules! iotry {
             Err(err) => {
                 return Err(Diagnostic {
                     level: Level::Error,
-                    message: format!("IOError: {}", err.description()),
+                    message: format!("IOError: {}", err),
                     code: Some(IO_ERROR_CODE.to_owned()),
                     spans: vec![],
                 });


### PR DESCRIPTION
`Error::description` is deprecated in stable Rust.