### PR TITLE
Mute lalrpop generated code warnings

### DIFF
--- a/starlark/src/syntax/mod.rs
+++ b/starlark/src/syntax/mod.rs
@@ -27,6 +27,7 @@ pub mod dialect;
 #[doc(hidden)]
 pub mod lexer;
 
+#[allow(unused_parens)] // lalrpop generated code includes unused parens
 mod grammar {
     include!(concat!(env!("OUT_DIR"), "/syntax/grammar.rs"));
 }


### PR DESCRIPTION
Without this diff build output is a thousands of messages like:

```
warning: unnecessary parentheses around block return value
     --> /Users/nga/devel/left/starlark-rust/target/debug/build/
             starlark-3876cc87384f3fe3/out/syntax/grammar.rs:25158:5
      |
25158 |     (__0)
      |     ^^^^^ help: remove these parentheses
```