### PR TITLE
use std::path::Path for file paths

### DIFF
--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -21,7 +21,7 @@ use starlark::stdlib::global_environment_for_repl_and_tests;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
@@ -60,8 +60,8 @@ pub struct Opt {
     )]
     repl: bool,
 
-    #[structopt(name = "FILE", help = "Files to interpret")]
-    files: Vec<String>,
+    #[structopt(name = "FILE", help = "Files to interpret", parse(from_os_str))]
+    files: Vec<PathBuf>,
 }
 
 fn main() {
@@ -82,9 +82,9 @@ fn main() {
     let free_args_empty = opt.files.is_empty();
     for i in opt.files.into_iter() {
         maybe_print_or_exit(eval_file(
-            Path::new(&i),
+            &i,
             dialect,
-            &mut global.child(&i),
+            &mut global.child(i.to_string_lossy().as_ref()),
             &type_values,
             global.clone(),
         ));

--- a/starlark-repl/bin/starlark-rust.rs
+++ b/starlark-repl/bin/starlark-rust.rs
@@ -21,6 +21,7 @@ use starlark::stdlib::global_environment_for_repl_and_tests;
 use starlark::syntax::dialect::Dialect;
 use starlark::values::Value;
 use starlark_repl::{print_function, repl};
+use std::path::Path;
 use std::process::exit;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
@@ -81,7 +82,7 @@ fn main() {
     let free_args_empty = opt.files.is_empty();
     for i in opt.files.into_iter() {
         maybe_print_or_exit(eval_file(
-            &i,
+            Path::new(&i),
             dialect,
             &mut global.child(&i),
             &type_values,
@@ -94,7 +95,7 @@ fn main() {
     }
     if let Some(command) = command {
         maybe_print_or_exit(eval(
-            "[command flag]",
+            Path::new("[command flag]"),
             &command,
             dialect,
             &mut global.child("[command flag]"),

--- a/starlark-repl/src/lib.rs
+++ b/starlark-repl/src/lib.rs
@@ -51,12 +51,12 @@ use starlark::syntax::lexer::{BufferedLexer, LexerIntoIter, LexerItem};
 use starlark::values::none::NoneType;
 use starlark::values::Value;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 fn print_eval<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: Arc<Mutex<codemap::CodeMap>>,
-    filename: &str,
+    filename: &Path,
     content: &str,
     lexer: T2,
     dialect: Dialect,
@@ -158,7 +158,7 @@ pub fn repl(global_environment: &mut Environment, type_values: &TypeValues, dial
             reader.add_history(hist);
             print_eval(
                 map.clone(),
-                &format!("<{}>", n),
+                Path::new(&format!("<{}>", n)),
                 &content,
                 lexer,
                 dialect,

--- a/starlark-test/build.rs
+++ b/starlark-test/build.rs
@@ -88,7 +88,8 @@ fn format_test_content(path: &Path) -> String {
             r#"
 #[test]
 fn test_{}_{}() {{
-    do_conformance_test("{}", {:?})
+    use std::path::Path;
+    do_conformance_test(Path::new("{}"), {:?})
 }}
 "#,
             test_name,

--- a/starlark-test/src/lib.rs
+++ b/starlark-test/src/lib.rs
@@ -113,9 +113,7 @@ struct HashMapFileLoader {
 
 impl FileLoader for HashMapFileLoader {
     fn load(&self, path: &Path, type_values: &TypeValues) -> Result<Environment, EvalException> {
-        let mut env = self
-            .parent
-            .child(path.to_string_lossy().to_string().as_str());
+        let mut env = self.parent.child(path.to_string_lossy().as_ref());
         let content = match self.files.get(path) {
             Some(content) => content,
             None => {
@@ -176,7 +174,7 @@ def assert_(cond, msg="assertion failed"):
         path,
         build,
         starlark::syntax::dialect::Dialect::Bzl,
-        &mut prelude.child(path.to_string_lossy().to_string().as_str()),
+        &mut prelude.child(path.to_string_lossy().as_ref()),
         &type_values,
         &HashMapFileLoader {
             parent: prelude.clone(),
@@ -200,8 +198,10 @@ def assert_(cond, msg="assertion failed"):
                 io::stderr()
                     .write_all(
                         &format!(
-                            "Expected error '{}' at {:?}:{}, got success",
-                            err, path, offset
+                            "Expected error '{}' at {}:{}, got success",
+                            err,
+                            path.display(),
+                            offset
                         )
                         .into_bytes(),
                     )

--- a/starlark/examples/starlark-simple-cli.rs
+++ b/starlark/examples/starlark-simple-cli.rs
@@ -23,6 +23,7 @@ extern crate codemap_diagnostic;
 extern crate starlark;
 
 use std::io::{self, Read};
+use std::path::Path;
 use std::process::exit;
 use std::sync::{Arc, Mutex};
 
@@ -46,7 +47,7 @@ pub fn simple_evaluation(starlark_input: &String) -> Result<String, String> {
     // We don't have a filename since we're not reading from a file, so call it "stdin".
     let result = eval(
         &map,
-        "stdin",
+        Path::new("stdin"),
         &starlark_input,
         Dialect::Bzl,
         &mut env,

--- a/starlark/src/eval/interactive.rs
+++ b/starlark/src/eval/interactive.rs
@@ -19,6 +19,7 @@ use crate::syntax::dialect::Dialect;
 use crate::values::Value;
 use codemap::CodeMap;
 use codemap_diagnostic::{ColorConfig, Diagnostic, Emitter};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 pub struct EvalError {
@@ -46,7 +47,7 @@ impl EvalError {
 /// * dialect: starlark language dialect
 /// * env: the environment to mutate during the evaluation
 pub fn eval(
-    path: &str,
+    path: &Path,
     content: &str,
     dialect: Dialect,
     env: &mut Environment,
@@ -80,7 +81,7 @@ pub fn eval(
 /// * dialect: Starlark language dialect
 /// * env: the environment to mutate during the evaluation
 pub fn eval_file(
-    path: &str,
+    path: &Path,
     dialect: Dialect,
     env: &mut Environment,
     type_values: &TypeValues,

--- a/starlark/src/eval/mod.rs
+++ b/starlark/src/eval/mod.rs
@@ -63,6 +63,7 @@ use codemap::{CodeMap, Span, Spanned};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use linked_hash_map::LinkedHashMap;
 use std::cmp::Ordering;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 fn eval_vector<E: EvaluationContextEnvironment>(
@@ -220,7 +221,7 @@ impl Into<Diagnostic> for EvalException {
 /// A trait for loading file using the load statement path.
 pub trait FileLoader {
     /// Open the file given by the load statement `path`.
-    fn load(&self, path: &str, type_values: &TypeValues) -> Result<Environment, EvalException>;
+    fn load(&self, path: &Path, type_values: &TypeValues) -> Result<Environment, EvalException>;
 }
 
 fn eval_un_op(op: UnOp, v: Value) -> Result<Value, ValueError> {
@@ -725,7 +726,7 @@ fn eval_stmt<E: EvaluationContextEnvironment>(
                 .env
                 .assert_module_env()
                 .loader
-                .load(name, context.type_values)?;
+                .load(Path::new(name.as_str()), context.type_values)?;
             loadenv.freeze();
             for &(ref new_name, ref orig_name) in v.iter() {
                 t(
@@ -788,7 +789,7 @@ fn eval_module(
 /// * file_loader: the [`FileLoader`] to react to `load()` statements.
 pub fn eval_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: &Arc<Mutex<CodeMap>>,
-    filename: &str,
+    filename: &Path,
     content: &str,
     dialect: Dialect,
     lexer: T2,
@@ -822,7 +823,7 @@ pub fn eval_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
 /// * file_loader: the [`FileLoader`] to react to `load()` statements.
 pub fn eval(
     map: &Arc<Mutex<CodeMap>>,
-    path: &str,
+    path: &Path,
     content: &str,
     build: Dialect,
     env: &mut Environment,
@@ -854,7 +855,7 @@ pub fn eval(
 /// * file_loader: the [`FileLoader`] to react to `load()` statements.
 pub fn eval_file(
     map: &Arc<Mutex<CodeMap>>,
-    path: &str,
+    path: &Path,
     build: Dialect,
     env: &mut Environment,
     type_values: &TypeValues,

--- a/starlark/src/eval/noload.rs
+++ b/starlark/src/eval/noload.rs
@@ -21,13 +21,14 @@ use crate::syntax::dialect::Dialect;
 use crate::values::Value;
 use codemap::CodeMap;
 use codemap_diagnostic::{Diagnostic, Level};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 /// File loader which returns error unconditionally.
 pub struct NoLoadFileLoader;
 
 impl FileLoader for NoLoadFileLoader {
-    fn load(&self, _path: &str, _: &TypeValues) -> Result<Environment, EvalException> {
+    fn load(&self, _path: &Path, _: &TypeValues) -> Result<Environment, EvalException> {
         Err(EvalException::DiagnosedError(Diagnostic {
             level: Level::Error,
             message: "ErrorFileLoader does not support loading".to_owned(),
@@ -52,7 +53,7 @@ impl FileLoader for NoLoadFileLoader {
 /// * global: the environment used to resolve type values
 pub fn eval(
     map: &Arc<Mutex<CodeMap>>,
-    path: &str,
+    path: &Path,
     content: &str,
     dialect: Dialect,
     env: &mut Environment,

--- a/starlark/src/eval/simple.rs
+++ b/starlark/src/eval/simple.rs
@@ -49,9 +49,7 @@ impl FileLoader for SimpleFileLoader {
                 return Ok(lock.get(path).unwrap().clone());
             }
         } // Release the lock
-        let mut env = self
-            .parent_env
-            .child(path.to_string_lossy().to_string().as_str());
+        let mut env = self.parent_env.child(path.to_string_lossy().as_ref());
         if let Err(d) = super::eval_file(
             &self.codemap,
             path,

--- a/starlark/src/stdlib/inspect.rs
+++ b/starlark/src/stdlib/inspect.rs
@@ -45,6 +45,7 @@ mod test {
     use crate::values::TypedValue;
     use crate::values::Value;
     use std::iter;
+    use std::path::Path;
 
     #[test]
     fn inspect() {
@@ -69,7 +70,7 @@ mod test {
         env.set("ti", Value::new(TestInspectable {})).unwrap();
         let custom = noload::eval(
             &Default::default(),
-            "test.sky",
+            Path::new("test.sky"),
             "inspect(ti).custom",
             Dialect::Bzl,
             &mut env,

--- a/starlark/src/stdlib/macros/param.rs
+++ b/starlark/src/stdlib/macros/param.rs
@@ -135,6 +135,7 @@ mod test {
     use crate::syntax::dialect::Dialect;
     use crate::values::Value;
     use codemap::CodeMap;
+    use std::path::Path;
     use std::sync::{Arc, Mutex};
 
     starlark_module! { global =>
@@ -154,7 +155,7 @@ mod test {
 
         let r = eval(
             &Arc::new(Mutex::new(CodeMap::new())),
-            "test_simple.star",
+            Path::new("test_simple.star"),
             "cc_binary(name='star', srcs=['a.cc', 'b.cc'])",
             Dialect::Build,
             &mut child,

--- a/starlark/src/stdlib/mod.rs
+++ b/starlark/src/stdlib/mod.rs
@@ -19,6 +19,7 @@ use linked_hash_map::LinkedHashMap;
 use std;
 use std::cmp::Ordering;
 use std::num::NonZeroI64;
+use std::path::Path;
 use std::sync;
 
 use crate::environment::{Environment, TypeValues};
@@ -983,7 +984,7 @@ pub fn starlark_default(snippet: &str) -> Result<bool, Diagnostic> {
     let mut test_env = env.freeze().child("test");
     match eval(
         &map,
-        "<test>",
+        Path::new("<test>"),
         snippet,
         Dialect::Bzl,
         &mut test_env,
@@ -1004,6 +1005,7 @@ pub mod tests {
     use crate::eval::noload::eval;
     use codemap::CodeMap;
     use codemap_diagnostic::Diagnostic;
+    use std::path::Path;
     use std::sync;
 
     pub fn starlark_default_fail(snippet: &str) -> Result<bool, Diagnostic> {
@@ -1012,7 +1014,7 @@ pub mod tests {
         let mut env = env.freeze().child("test");
         match eval(
             &map,
-            "<test>",
+            Path::new("<test>"),
             snippet,
             Dialect::Bzl,
             &mut env,

--- a/starlark/src/syntax/grammar_tests.rs
+++ b/starlark/src/syntax/grammar_tests.rs
@@ -226,9 +226,11 @@ fn smoke_test() {
     let paths = fs::read_dir(d.as_path()).unwrap();
     for p in paths {
         let path_entry = p.unwrap().path();
-        if path_entry.ends_with(".bzl") {
-            if let Result::Err(err) = parse_file(&map, &path_entry, Dialect::Bzl) {
-                diagnostics.push(err);
+        if let Some(ext) = path_entry.extension() {
+            if ext.to_string_lossy().ends_with(".bzl") {
+                if let Result::Err(err) = parse_file(&map, &path_entry, Dialect::Bzl) {
+                    diagnostics.push(err);
+                }
             }
         }
     }

--- a/starlark/src/syntax/grammar_tests.rs
+++ b/starlark/src/syntax/grammar_tests.rs
@@ -227,7 +227,7 @@ fn smoke_test() {
     for p in paths {
         let path_entry = p.unwrap().path();
         if let Some(ext) = path_entry.extension() {
-            if ext.to_string_lossy().ends_with(".bzl") {
+            if ext.to_string_lossy() == "bzl" {
                 if let Result::Err(err) = parse_file(&map, &path_entry, Dialect::Bzl) {
                     diagnostics.push(err);
                 }

--- a/starlark/src/syntax/grammar_tests.rs
+++ b/starlark/src/syntax/grammar_tests.rs
@@ -226,9 +226,8 @@ fn smoke_test() {
     let paths = fs::read_dir(d.as_path()).unwrap();
     for p in paths {
         let path_entry = p.unwrap().path();
-        let path = path_entry.to_str().unwrap();
-        if path.ends_with(".bzl") {
-            if let Result::Err(err) = parse_file(&map, path, Dialect::Bzl) {
+        if path_entry.ends_with(".bzl") {
+            if let Result::Err(err) = parse_file(&map, &path_entry, Dialect::Bzl) {
                 diagnostics.push(err);
             }
         }

--- a/starlark/src/syntax/parser.rs
+++ b/starlark/src/syntax/parser.rs
@@ -20,6 +20,7 @@ use codemap::{CodeMap, Span};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::eval::module::Module;
@@ -166,7 +167,7 @@ macro_rules! iotry {
 #[doc(hidden)]
 pub fn parse_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     map: &Arc<Mutex<CodeMap>>,
-    filename: &str,
+    filename: &Path,
     content: &str,
     dialect: Dialect,
     lexer: T2,
@@ -174,7 +175,7 @@ pub fn parse_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
     let filespan = {
         map.lock()
             .unwrap()
-            .add_file(filename.to_string(), content.to_string())
+            .add_file(filename.to_string_lossy().to_string(), content.to_string())
             .span
     };
     match {
@@ -199,7 +200,7 @@ pub fn parse_lexer<T1: Iterator<Item = LexerItem>, T2: LexerIntoIter<T1>>(
 #[doc(hidden)]
 pub fn parse(
     map: &Arc<Mutex<CodeMap>>,
-    filename: &str,
+    filename: &Path,
     content: &str,
     dialect: Dialect,
 ) -> Result<Module, Diagnostic> {
@@ -222,7 +223,7 @@ pub fn parse(
 #[doc(hidden)]
 pub fn parse_file(
     map: &Arc<Mutex<CodeMap>>,
-    path: &str,
+    path: &Path,
     dialect: Dialect,
 ) -> Result<Module, Diagnostic> {
     let mut content = String::new();

--- a/starlark/src/testutil.rs
+++ b/starlark/src/testutil.rs
@@ -19,6 +19,7 @@ use crate::eval;
 use crate::syntax::dialect::Dialect;
 use codemap::CodeMap;
 use codemap_diagnostic::Diagnostic;
+use std::path::Path;
 use std::sync;
 
 /// Execute a starlark snippet with the passed environment.
@@ -28,7 +29,15 @@ pub fn starlark_no_diagnostic(
     type_values: &TypeValues,
 ) -> Result<bool, Diagnostic> {
     let map = sync::Arc::new(sync::Mutex::new(CodeMap::new()));
-    Ok(eval::noload::eval(&map, "<test>", snippet, Dialect::Bzl, env, type_values)?.to_bool())
+    Ok(eval::noload::eval(
+        &map,
+        Path::new("<test>"),
+        snippet,
+        Dialect::Bzl,
+        env,
+        type_values,
+    )?
+    .to_bool())
 }
 
 /// A simple macro to execute a Starlark snippet and fails if the last statement is false.


### PR DESCRIPTION
this should not only simplify working with path types from the rust stdlib itself, but also brings in the possibility of adding in files with non-utf8 paths, since rust strings require full utf-8 characters only.

there are a couple places which this does not touch, and most notably where a 'lossy' conversion is performed from non-utf8 paths:

  - environment name, this was using a string already, and i don't think it makes sense for every environment name to be a path.
  - when passing to codemaps, intersestingly this crate also suffers from the "paths/filenames are str" idiom, which means they only support utf-8 filenames. ideally this is fixed, but that should be fixed in the upstream crate, for now, do a best effort lossy conversion.

and to be completely clear a "lossy" conversion is simply using utf-8 where possible and for anything non utf-8 replacing it with the utf8 "REPLACEMENT_CHAR" or `�`.

fixes #274 