### PR TITLE
update lalrpop

### DIFF
--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -22,12 +22,12 @@ travis-ci = { repository = "google/starlark-rust", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [build-dependencies]
-lalrpop = "0.16.0"
+lalrpop = "0.19.2"
 
 [dependencies]
 codemap = "0.1.1"
 codemap-diagnostic = "0.1.1"
-lalrpop-util = "0.16.0"
+lalrpop-util = "0.19.2"
 linked-hash-map = "0.5.1"
 
 [lib]


### PR DESCRIPTION
lalrpop was pretty out of date which can spread to crates bringing in lots of conflicts of old dependencies, inflating compile times,
crate sizes, etc. this updates lalrpop to the latest minor version. it added a new token "UnexpectedEOF" however I saw unexpected tokens message was about "unexpected eof" so i coped most of the implementations for diagnostics from them , assuming the implementation would be correct. I'm happy to change it though, I admittedly didn't look to deep since i seemed to find something that worked.