### PR TITLE
Treat escaped carriage returns like other impls

### DIFF
--- a/starlark-test/tests/rust-testcases/string.sky
+++ b/starlark-test/tests/rust-testcases/string.sky
@@ -17,3 +17,8 @@ assert_eq("ab[1]cd", "ab%scd" % [1])
 ''%(0)     ###   The type 'int' is not iterable
 ---
 ''%(0,)    ###   Too many arguments for format string
+---
+# Issue #280
+# Note: Some editors may auto-replace the \r literal with a \n literal on save, which would defeat the point of this test.
+assert_eq(len("a\b"), 2)
+assert_eq(len("""a\b"""), 2)

--- a/starlark/src/syntax/lexer.rs
+++ b/starlark/src/syntax/lexer.rs
@@ -737,6 +737,10 @@ impl Lexer {
                             Err(LexerError::InvalidEscapeSequence(pos, pos2 + 1))
                         }
                     }
+                    '\r' => {
+                        self.pop();
+                        Ok(None)
+                    }
                     'u' => {
                         self.pop();
                         let c = self.next_char();


### PR DESCRIPTION
Fixes #280.