### PR TITLE
intra_doc_resolution_failures -> broken_intra_doc_links

### DIFF
--- a/starlark/src/lib.rs
+++ b/starlark/src/lib.rs
@@ -71,7 +71,7 @@
 //! * [tuple](values::tuple), and
 //! * [function](values::function).
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Fix warning on tests and builds.